### PR TITLE
Support constraint in create table for postgres parser

### DIFF
--- a/database/postgres/tests.yml
+++ b/database/postgres/tests.yml
@@ -4,7 +4,26 @@ CreateTable:
     CREATE TABLE bigdata (
       id bigint,
       created_at timestamp with time zone,
-      created_date time with time zone
+      created_date time with time zone,
+      fn integer default foo.my_func()
+    );
+CreateTableWithConstrant:
+  sql: |
+    CREATE TABLE tbl (
+      id bigint,
+      user_id bigint,
+      email text,
+      PRIMARY KEY (id),
+      CONSTRAINT uniq_email UNIQUE (email),
+      CONSTRAINT user_id_fk FOREIGN KEY (user_id) REFERENCES users(id, name)
+    );
+CreateTableWithConstrantInlineColumn:
+  compare_with_generic_parser: true
+  sql: |
+    CREATE TABLE tbl (
+      id bigint PRIMARY KEY,
+      user_id bigint REFERENCES users(id, name),
+      email text UNIQUE
     );
 CreateTableWithDefault:
   compare_with_generic_parser: true


### PR DESCRIPTION
The error occurred because the generic parser doesn't support the unique constraint in create table, causing an issue with the following SQL:

```sql
CREATE TABLE foo (
    id int,
    CONSTRAINT uniq_id UNIQUE (id)
);
```

```
$ psqldef -h localhost -U postgres sandbox < schema.sql
found syntax error when parsing DDL "CREATE TABLE foo (
    id int,
    CONSTRAINT uniq_id UNIQUE (id)
)": syntax error at position 61 near 'unique'
```

To resolve this problem, I implemented the parsing of constraints in the Postgres parser.