### PR TITLE
Support ALL/ANY operation in postgres parser

### DIFF
--- a/cmd/psqldef/tests.yml
+++ b/cmd/psqldef/tests.yml
@@ -77,6 +77,23 @@ ParseTextCheckConstraint:
     );
   output: |
     ALTER TABLE "public"."test" DROP CONSTRAINT test_col_check;
+ParseAllAnyCheckConstraint:
+  current: |
+    CREATE TABLE test (
+      n1 int,
+      n2 int,
+      t1 text
+    );
+  desired: |
+    CREATE TABLE test (
+      n1 int CHECK (n1 = ANY (ARRAY[1, 2, 3])),
+      n2 int CHECK (n2 = ALL ('{1,2,3}'::int[])),
+      t1 text CHECK (t1 = SOME ('{x,y}'::text[]))
+    );
+  output: |
+    ALTER TABLE "public"."test" ADD CONSTRAINT test_n1_check CHECK (n1 = ANY (ARRAY[1, 2, 3]));
+    ALTER TABLE "public"."test" ADD CONSTRAINT test_n2_check CHECK (n2 = ALL ('{1,2,3}'::integer[]));
+    ALTER TABLE "public"."test" ADD CONSTRAINT test_t1_check CHECK (t1 = ANY ('{x,y}'::text[]));
 NullCast:
   desired: |
     CREATE TABLE public.test (

--- a/database/postgres/tests.yml
+++ b/database/postgres/tests.yml
@@ -97,6 +97,13 @@ CheckConstraint:
       quantity integer,
       CONSTRAINT chk CHECK (quantity > 0 AND price > 0)
     );
+CheckConstraintAllAny:
+  sql: |
+    CREATE TABLE test (
+      n1 int CHECK (n1 = ANY (ARRAY[1, 2, 3])),
+      n2 int CHECK (n2 = ALL ('{1, 2, 3}'::integer[])),
+      t1 text CHECK (t1 = SOME ('{x, y}'::text[]))
+    );
 CheckConstraintPosixRegex:
   compare_with_generic_parser: true
   sql: |

--- a/parser/ast.go
+++ b/parser/ast.go
@@ -1760,6 +1760,7 @@ type ComparisonExpr struct {
 	Operator    string
 	Left, Right Expr
 	Escape      Expr
+	All, Any    bool
 }
 
 // ComparisonExpr.Operator
@@ -1787,7 +1788,13 @@ const (
 
 // Format formats the node.
 func (node *ComparisonExpr) Format(buf *TrackedBuffer) {
-	buf.Myprintf("%v %s %v", node.Left, node.Operator, node.Right)
+	if node.All {
+		buf.Myprintf("%v %s ALL (%v)", node.Left, node.Operator, node.Right)
+	} else if node.Any {
+		buf.Myprintf("%v %s ANY (%v)", node.Left, node.Operator, node.Right)
+	} else {
+		buf.Myprintf("%v %s %v", node.Left, node.Operator, node.Right)
+	}
 	if node.Escape != nil {
 		buf.Myprintf(" escape %v", node.Escape)
 	}


### PR DESCRIPTION
Fixed an error in psqldef with SQL using `ALL`, `ANY`, and `SOME` as follows.

```sql
CREATE TABLE test (
  n1 int CHECK (n1 = ANY (ARRAY[1, 2, 3])),
  n2 int CHECK (n2 = ALL ('{1,2,3}'::int[])),
  t1 text CHECK (t1 = SOME ('{x,y}'::text[]))
);
```