### PR TITLE
[psqldef] Fix error when specifying a schema for user-defined type

### DIFF
--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -753,10 +753,10 @@ func TestPsqldefCreateType(t *testing.T) {
 	resetTestDatabase()
 
 	createTable := stripHeredoc(`
-		CREATE TYPE country AS ENUM ('us', 'jp');
+		CREATE TYPE "public"."country" AS ENUM ('us', 'jp');
 		CREATE TABLE users (
 		  id SERIAL PRIMARY KEY,
-		  country country NOT NULL DEFAULT 'jp'::country
+		  country "public"."country" NOT NULL DEFAULT 'jp'::country
 		);
 		`,
 	)

--- a/database/postgres/parser.go
+++ b/database/postgres/parser.go
@@ -996,7 +996,8 @@ func (p PostgresParser) parseTypeName(node *pgquery.TypeName) (parser.ColumnType
 				return columnType, fmt.Errorf("unhandled type in parseTypeName: %s", typeNames[1])
 			}
 		} else {
-			return columnType, fmt.Errorf("unknown schema in parseTypeName: %#v", typeNames)
+			columnType.References = typeNames[0] + "."
+			columnType.Type = typeNames[1]
 		}
 	} else {
 		return columnType, fmt.Errorf("unexpected length in parseTypeName: %d", len(typeNames))

--- a/database/postgres/tests.yml
+++ b/database/postgres/tests.yml
@@ -187,3 +187,9 @@ AlterTableAddForeignKey:
   compare_with_generic_parser: true
   sql: |
     ALTER TABLE ONLY public.posts ADD CONSTRAINT posts_ibfk_1 FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE SET NULL ON UPDATE RESTRICT;
+UserDefinedType:
+  sql: |
+    CREATE TABLE "public"."test" (
+        tag "public"."tags",
+        tags "public"."tags"[]
+    )


### PR DESCRIPTION
Fixed the following error:

```sql
CREATE TYPE tags AS ENUM ('foo');
CREATE TABLE test (
    tag public.tags
);
```

```
$ psqldef -h localhost -U postgres sandbox < schema.sql
found syntax error when parsing DDL "CREATE TABLE test (
    tag public.tags
)": syntax error at position 36
```