### PR TITLE
[psqldef] Fix type cast errors

### DIFF
--- a/cmd/psqldef/tests.yml
+++ b/cmd/psqldef/tests.yml
@@ -43,6 +43,7 @@ CreateTableWithDefault:
       default_current_timestamp timestamp default CURRENT_TIMESTAMP,
       default_current_date date default CURRENT_DATE,
       default_current_time time default CURRENT_TIME,
+      default_date_text text DEFAULT CURRENT_TIMESTAMP::date::text,
       default_now timestamp default now(),
       default_array_int int[] default '{}'::int[],
       default_array_constructor int[] DEFAULT ARRAY[]::int[],

--- a/cmd/psqldef/tests.yml
+++ b/cmd/psqldef/tests.yml
@@ -241,7 +241,8 @@ CheckConstraint:
       t2 text,
       t3 text,
       t4 varchar(10),
-      d date
+      d1 date,
+      d2 date
     );
   desired: |
     CREATE TABLE test (
@@ -252,7 +253,8 @@ CheckConstraint:
       t2 text CHECK (t2 not like 'x'),
       t3 text CHECK (t3 <> ''::text),
       t4 varchar(10) CHECK (t4::text ~ '[0-9]'),
-      d date CHECK (d >= '2022-01-01'::date)
+      d1 date CHECK (d1 >= '2022-01-01'::date),
+      d2 date CHECK (d2 >= date '2022-01-01')
     );
   output: |
     ALTER TABLE "public"."test" ADD CONSTRAINT test_n1_check CHECK (n1 = 0 or not n1 > 10 and n1 is not null);
@@ -262,7 +264,8 @@ CheckConstraint:
     ALTER TABLE "public"."test" ADD CONSTRAINT test_t2_check CHECK (t2 !~~ 'x');
     ALTER TABLE "public"."test" ADD CONSTRAINT test_t3_check CHECK (t3 <> '');
     ALTER TABLE "public"."test" ADD CONSTRAINT test_t4_check CHECK (t4::text ~ '[0-9]');
-    ALTER TABLE "public"."test" ADD CONSTRAINT test_d_check CHECK (d >= '2022-01-01');
+    ALTER TABLE "public"."test" ADD CONSTRAINT test_d1_check CHECK (d1 >= '2022-01-01');
+    ALTER TABLE "public"."test" ADD CONSTRAINT test_d2_check CHECK (d2 >= '2022-01-01');
 
 CompositeForeignKeyConstraint:
   current: |

--- a/cmd/psqldef/tests.yml
+++ b/cmd/psqldef/tests.yml
@@ -47,6 +47,7 @@ CreateTableWithDefault:
       default_now timestamp default now(),
       default_array_int int[] default '{}'::int[],
       default_array_constructor int[] DEFAULT ARRAY[]::int[],
+      default_array_element_typecast text[] DEFAULT ARRAY[current_date::text]::text[],
       joined_at timestamp with time zone NOT NULL DEFAULT '0001-01-01 00:00:00'::timestamp without time zone,
       created_at timestamp with time zone DEFAULT now()
     );

--- a/database/postgres/parser.go
+++ b/database/postgres/parser.go
@@ -669,6 +669,8 @@ func (p PostgresParser) parseArrayElement(node parser.Expr) (parser.ArrayElement
 		return node, nil
 	case *parser.CollateExpr:
 		return p.parseArrayElement(node.Expr)
+	case *parser.CastExpr:
+		return node, nil
 	default:
 		return nil, fmt.Errorf("unknown expr in parseArrayElement: %#v", node)
 	}

--- a/database/postgres/parser.go
+++ b/database/postgres/parser.go
@@ -528,48 +528,22 @@ func (p PostgresParser) parseExpr(stmt *pgquery.Node) (parser.Expr, error) {
 		if err != nil {
 			return nil, err
 		}
-		if columnType.Type == "integer" ||
-			columnType.Type == "bigint" ||
-			columnType.Type == "smallint" ||
-			columnType.Type == "numeric" ||
-			columnType.Type == "real" ||
-			columnType.Type == "double precision" ||
-			columnType.Array {
-			switch node.TypeCast.Arg.Node.(type) {
-			case *pgquery.Node_AConst:
-				typeName := columnType.Type
-				if columnType.Array {
-					typeName += "[]"
-				}
-				return &parser.CastExpr{
-					Type: &parser.ConvertType{
-						Type:    typeName,
-						Length:  columnType.Length,
-						Scale:   columnType.Scale,
-						Charset: columnType.Charset,
-					},
-					Expr: expr,
-				}, nil
-			default:
-				return &parser.CollateExpr{
-					Expr: expr,
-				}, nil
-			}
+		if shouldDeleteTypeCast(node.TypeCast.Arg, columnType) {
+			return expr, nil
 		} else {
-			switch node.TypeCast.Arg.Node.(type) {
-			case *pgquery.Node_AConst:
-				return expr, nil
-			default:
-				return &parser.CastExpr{
-					Type: &parser.ConvertType{
-						Type:    columnType.Type,
-						Length:  columnType.Length,
-						Scale:   columnType.Scale,
-						Charset: columnType.Charset,
-					},
-					Expr: expr,
-				}, nil
+			typeName := columnType.Type
+			if columnType.Array {
+				typeName += "[]"
 			}
+			return &parser.CastExpr{
+				Type: &parser.ConvertType{
+					Type:    typeName,
+					Length:  columnType.Length,
+					Scale:   columnType.Scale,
+					Charset: columnType.Charset,
+				},
+				Expr: expr,
+			}, nil
 		}
 	case *pgquery.Node_SqlvalueFunction:
 		switch node.SqlvalueFunction.Op {
@@ -911,14 +885,7 @@ func (p PostgresParser) parseDefaultValue(rawExpr *pgquery.Node) (*parser.Defaul
 					Value: castExpr,
 				},
 			}, nil
-		case *parser.ArrayConstructor:
-			return &parser.DefaultDefinition{
-				ValueOrExpression: parser.DefaultValueOrExpression{
-					Expr: castExpr,
-				},
-			}, nil
-		case *parser.CastExpr:
-			// nested typecast: e.g. '1'::character varying::text
+		case *parser.CastExpr, *parser.ArrayConstructor:
 			return &parser.DefaultDefinition{
 				ValueOrExpression: parser.DefaultValueOrExpression{
 					Expr: castExpr,
@@ -1077,4 +1044,48 @@ func (p PostgresParser) parseCheckConstraint(constraint *pgquery.Constraint) (*p
 		ConstraintName: parser.NewColIdent(constraint.Conname),
 		NoInherit:      parser.BoolVal(constraint.IsNoInherit),
 	}, nil
+}
+
+// This is a workaround to handle cases where PostgreSQL automatically adds or removes type casting.
+//
+// Example:
+//
+// ```
+// $ cat schema.sql
+// CREATE TABLE test (
+// t text CHECK (t ~ '[0-9]'),
+// i integer CHECK (i = ANY (ARRAY[1,2,3]::integer[]))
+// );
+//
+// $ psql sandbox < schema.sql
+// $ psqldef sandbox --export
+// CREATE TABLE "public"."test" (
+// "t" text CONSTRAINT test_t_check CHECK (t ~ '[0-9]'::text),
+// "i" integer CONSTRAINT test_i_check CHECK (i = ANY (ARRAY[1, 2, 3]))
+// );
+// ```
+//
+// Looking at the export result, PostgreSQL automatically adds `::text` type casting to '[0-9]',
+// and removes `::integer[]` from `ARRAY[1,2,3]`. In such cases, if you don't remove the type casting,
+// the generator will fail to calculate the diff.
+//
+// Ideally, the generator should be smart enough to handle the calculation of diff while keeping the type casting.
+// However, as a workaround, it is handled by the parser.
+//
+// Since this function's support is not complete, updates will be necessary in the future.
+func shouldDeleteTypeCast(sourceNode *pgquery.Node, targetType parser.ColumnType) bool {
+	switch sourceNode.Node.(type) {
+	case *pgquery.Node_AConst:
+		if targetType.Array {
+			// Do not delete type cast from '{1,2,3}'::integer[]
+			return false
+		}
+		// Delete type cast from '[0-9]'::text
+		return true
+	case *pgquery.Node_AArrayExpr, *pgquery.Node_TypeCast:
+		// Delete type cast from ARRAY[1,2,3]::integer[]
+		return true
+	default:
+		return false
+	}
 }

--- a/database/postgres/parser.go
+++ b/database/postgres/parser.go
@@ -902,21 +902,28 @@ func (p PostgresParser) parseDefaultValue(rawExpr *pgquery.Node) (*parser.Defaul
 			},
 		}, nil
 	case *parser.CastExpr:
-		switch expr := expr.Expr.(type) {
+		switch castExpr := expr.Expr.(type) {
 		case *parser.SQLVal:
 			return &parser.DefaultDefinition{
 				ValueOrExpression: parser.DefaultValueOrExpression{
-					Value: expr,
+					Value: castExpr,
 				},
 			}, nil
 		case *parser.ArrayConstructor:
 			return &parser.DefaultDefinition{
 				ValueOrExpression: parser.DefaultValueOrExpression{
-					Expr: expr,
+					Expr: castExpr,
+				},
+			}, nil
+		case *parser.CastExpr:
+			// nested typecast: e.g. '1'::character varying::text
+			return &parser.DefaultDefinition{
+				ValueOrExpression: parser.DefaultValueOrExpression{
+					Expr: castExpr,
 				},
 			}, nil
 		default:
-			return nil, fmt.Errorf("unhandled default CastExpr node: %#v", expr)
+			return nil, fmt.Errorf("unhandled default CastExpr node: %#v", castExpr)
 		}
 	case *parser.CollateExpr:
 		switch expr := expr.Expr.(type) {

--- a/database/postgres/tests.yml
+++ b/database/postgres/tests.yml
@@ -1,20 +1,3 @@
-TestCasting:
-  compare_with_generic_parser: true
-  sql: |
-    create view hoge_view as
-    select
-      b::bool,
-      b2::boolean,
-      s::smallint,
-      i::integer,
-      bi::bigint,
-      r::real,
-      d::double precision,
-      n::numeric,
-      t::text,
-      dt::date,
-      uu::uuid
-    from hoge;
 CreateTable:
   compare_with_generic_parser: true
   sql: |
@@ -121,10 +104,21 @@ CreateView:
     create view hoge_view as
     select amount from hoge;
 CreateViewWithCast:
-  compare_with_generic_parser: true
   sql: |
     create view hoge_view as
-    select amount::numeric(10,2) from hoge;
+    select
+      b::bool,
+      b2::boolean,
+      s::smallint,
+      i::integer,
+      bi::bigint,
+      r::real,
+      d::double precision,
+      n::numeric(10,2),
+      t::text,
+      dt::date,
+      uu::uuid
+    from hoge;
 CreateViewWithFullColumn:
   sql: |
     CREATE VIEW public.hoge_view

--- a/database/postgres/tests.yml
+++ b/database/postgres/tests.yml
@@ -69,6 +69,7 @@ CreateTableWithDefaultWithoutCompare:
       default_text text default '',
       default_now timestamp default now(),
       default_text_with_cast text default ''::text,
+      default_date_text text DEFAULT CURRENT_TIMESTAMP::date::text,
       default_array_constructor int[] DEFAULT ARRAY[],
       default_array_constructor_with_cast int[] DEFAULT ARRAY[]::int[]
     );

--- a/database/postgres/tests.yml
+++ b/database/postgres/tests.yml
@@ -71,7 +71,8 @@ CreateTableWithDefaultWithoutCompare:
       default_text_with_cast text default ''::text,
       default_date_text text DEFAULT CURRENT_TIMESTAMP::date::text,
       default_array_constructor int[] DEFAULT ARRAY[],
-      default_array_constructor_with_cast int[] DEFAULT ARRAY[]::int[]
+      default_array_constructor_with_cast int[] DEFAULT ARRAY[]::int[],
+      default_array_element_typecast text[] DEFAULT ARRAY[current_date::text]::text[]
     );
 CreateTableWithSchema:
   compare_with_generic_parser: true

--- a/parser/ast.go
+++ b/parser/ast.go
@@ -2908,4 +2908,5 @@ type ArrayElement interface {
 	SQLNode
 }
 
-func (*SQLVal) iArrayElement() {}
+func (*SQLVal) iArrayElement()   {}
+func (*CastExpr) iArrayElement() {}


### PR DESCRIPTION
Fixed type cast errors in the following cases:

```sql
create table test (
  t text DEFAULT CURRENT_TIMESTAMP::date::text,
  a text[] DEFAULT ARRAY[CURRENT_DATE::text]::text[],
)
```