### PR TITLE
psqldef: Support multiple schema for comment

### DIFF
--- a/cmd/psqldef/tests.yml
+++ b/cmd/psqldef/tests.yml
@@ -346,13 +346,13 @@ Comment:
         PRIMARY KEY ("id")
     );
 
-    COMMENT ON TABLE hoge is 'hoge table';
-    COMMENT ON COLUMN hoge.id is 'hoge id';
-    COMMENT ON COLUMN hoge.foo is 'foo comment';
+    COMMENT ON TABLE public.hoge is 'hoge table';
+    COMMENT ON COLUMN public.hoge.id is 'hoge id';
+    COMMENT ON COLUMN public.hoge.foo is 'foo comment';
   output: |
-    COMMENT ON TABLE hoge is 'hoge table';
-    COMMENT ON COLUMN hoge.id is 'hoge id';
-    COMMENT ON COLUMN hoge.foo is 'foo comment';
+    COMMENT ON TABLE public.hoge is 'hoge table';
+    COMMENT ON COLUMN public.hoge.id is 'hoge id';
+    COMMENT ON COLUMN public.hoge.foo is 'foo comment';
 MultipleComments:
   current: |
     CREATE TABLE "public"."hoge" (
@@ -364,7 +364,7 @@ MultipleComments:
       PRIMARY KEY ("id")
     );
 
-    COMMENT ON COLUMN hoge.id is 'hoge id';
+    COMMENT ON COLUMN public.hoge.id is 'hoge id';
   desired: |
     CREATE TABLE "public"."hoge" (
       "id" bigserial NOT NULL,
@@ -375,10 +375,10 @@ MultipleComments:
       PRIMARY KEY ("id")
     );
 
-    COMMENT ON COLUMN hoge.id is 'hoge id';
-    COMMENT ON COLUMN bar.id is 'bar id';
+    COMMENT ON COLUMN public.hoge.id is 'hoge id';
+    COMMENT ON COLUMN public.bar.id is 'bar id';
   output: |
-    COMMENT ON COLUMN bar.id is 'bar id';
+    COMMENT ON COLUMN public.bar.id is 'bar id';
 UpdateComment:
   current: |
     CREATE TABLE "public"."hoge" (
@@ -390,10 +390,10 @@ UpdateComment:
       PRIMARY KEY ("id")
     );
 
-    COMMENT ON TABLE hoge is 'hoge table';
-    COMMENT ON COLUMN hoge.id is 'hoge id';
-    COMMENT ON TABLE bar is 'bar table';
-    COMMENT ON COLUMN bar.id is 'bar id';
+    COMMENT ON TABLE public.hoge is 'hoge table';
+    COMMENT ON COLUMN public.hoge.id is 'hoge id';
+    COMMENT ON TABLE public.bar is 'bar table';
+    COMMENT ON COLUMN public.bar.id is 'bar id';
   desired: |
     CREATE TABLE "public"."hoge" (
       "id" bigserial NOT NULL,
@@ -404,13 +404,28 @@ UpdateComment:
       PRIMARY KEY ("id")
     );
 
-    COMMENT ON TABLE hoge is 'hoge table updated';
-    COMMENT ON COLUMN hoge.id is 'hoge id updated';
-    COMMENT ON TABLE bar is 'bar table';
-    COMMENT ON COLUMN bar.id is 'bar id';
+    COMMENT ON TABLE public.hoge is 'hoge table updated';
+    COMMENT ON COLUMN public.hoge.id is 'hoge id updated';
+    COMMENT ON TABLE public.bar is 'bar table';
+    COMMENT ON COLUMN public.bar.id is 'bar id';
   output: |
-    COMMENT ON TABLE hoge is 'hoge table updated';
-    COMMENT ON COLUMN hoge.id is 'hoge id updated';
+    COMMENT ON TABLE public.hoge is 'hoge table updated';
+    COMMENT ON COLUMN public.hoge.id is 'hoge id updated';
+CommentOnNonStandardDefaultSchema:
+  current: |
+    CREATE TABLE foo.users (
+      id bigint
+    );
+  desired: |
+    CREATE TABLE foo.users (
+      id bigint
+    );
+    COMMENT ON TABLE foo.users is 'users table updated';
+    COMMENT ON COLUMN foo.users.id is 'users id';
+  output: |
+    COMMENT ON TABLE foo.users is 'users table updated';
+    COMMENT ON COLUMN foo.users.id is 'users id';
+  user: psqldef_user
 CreateViewCast:
   current: |
     CREATE TABLE "public"."hoge" (


### PR DESCRIPTION
We didn't support comments outside of the public schema in psqldef, so we've made adjustments to accommodate them.