### PR TITLE
[psqldef] Support absent foreign key and improve `DEFERRABLE` handling

### DIFF
--- a/cmd/psqldef/tests.yml
+++ b/cmd/psqldef/tests.yml
@@ -763,3 +763,64 @@ RemoveDefaultExpression:
     );
   output: |
     ALTER TABLE "public"."users" ALTER COLUMN "key" DROP DEFAULT;
+CreateTableAddAbsentForeignKey:
+  current: |
+    CREATE TABLE users (
+      id INT PRIMARY KEY
+    );
+    CREATE TABLE posts (
+      content TEXT,
+      user_id INT
+    );
+  desired: |
+    CREATE TABLE users (
+      id INT PRIMARY KEY
+    );
+    CREATE TABLE posts (
+      content TEXT,
+      user_id INT REFERENCES users(id)
+    );
+  output: |
+    ALTER TABLE "public"."posts" ADD CONSTRAINT "posts_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users" ("id");
+CreateTableWithConstraintOptions:
+  current: |
+    CREATE TABLE images (
+      id INT PRIMARY KEY
+    );
+    CREATE TABLE image_owners (
+      id INT,
+      type VARCHAR(20) NOT NULL,
+      PRIMARY KEY (type, id)
+    );
+    CREATE TABLE image_bindings (
+      image_id INT REFERENCES images(id) ON DELETE CASCADE,
+      image_order INT NOT NULL,
+      image_owner_type VARCHAR(20) NOT NULL,
+      image_owner_id INT NOT NULL,
+      CONSTRAINT image_owner_fk FOREIGN KEY (image_owner_type, image_owner_id) REFERENCES image_owners(type, id) ON DELETE CASCADE,
+      CONSTRAINT image_order_unique UNIQUE (image_owner_type, image_owner_id, image_order)
+    );
+  desired: |
+    CREATE TABLE images (
+      id INT PRIMARY KEY
+    );
+    CREATE TABLE image_owners (
+      id INT,
+      type VARCHAR(20) NOT NULL,
+      PRIMARY KEY (type, id)
+    );
+    CREATE TABLE image_bindings (
+      image_id INT REFERENCES images(id) ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE,
+      image_order INT NOT NULL,
+      image_owner_type VARCHAR(20) NOT NULL,
+      image_owner_id INT NOT NULL,
+      CONSTRAINT image_owner_fk FOREIGN KEY (image_owner_type, image_owner_id) REFERENCES image_owners(type, id) ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE,
+      CONSTRAINT image_order_unique UNIQUE (image_owner_type, image_owner_id, image_order) DEFERRABLE INITIALLY DEFERRED
+    );
+  output: |
+    ALTER TABLE "public"."image_bindings" DROP CONSTRAINT "image_order_unique";
+    ALTER TABLE "public"."image_bindings" ADD CONSTRAINT "image_order_unique" UNIQUE ("image_owner_type", "image_owner_id", "image_order") DEFERRABLE INITIALLY DEFERRED;
+    ALTER TABLE "public"."image_bindings" DROP CONSTRAINT "image_bindings_image_id_fkey";
+    ALTER TABLE "public"."image_bindings" ADD CONSTRAINT "image_bindings_image_id_fkey" FOREIGN KEY ("image_id") REFERENCES "public"."images" ("id") ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE;
+    ALTER TABLE "public"."image_bindings" DROP CONSTRAINT "image_owner_fk";
+    ALTER TABLE "public"."image_bindings" ADD CONSTRAINT "image_owner_fk" FOREIGN KEY ("image_owner_type","image_owner_id") REFERENCES "public"."image_owners" ("type","id") ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE;

--- a/cmd/psqldef/tests.yml
+++ b/cmd/psqldef/tests.yml
@@ -194,9 +194,14 @@ PosixRegexCheckConstraint:
     ALTER TABLE "public"."test" ADD CONSTRAINT test_posix_not_regex_ci_check CHECK (posix_not_regex_ci !~* '[a-z]');
 ForeignKeyOnReservedName:
   current: |
+    CREATE TABLE "public"."companies" (
+      "id" character varying(100) NOT NULL,
+      PRIMARY KEY ("id")
+    );
+
     CREATE TABLE "public"."variables" (
       "id" character varying(100) NOT NULL,
-      "compaby_id" character varying(100) NOT NULL,
+      "company_id" character varying(100) NOT NULL,
       PRIMARY KEY ("id")
     );
 
@@ -207,18 +212,23 @@ ForeignKeyOnReservedName:
       PRIMARY KEY ("id")
     );
   desired: |
+    CREATE TABLE IF NOT EXISTS companies (
+      id VARCHAR(100) PRIMARY KEY
+    );
+
     CREATE TABLE IF NOT EXISTS variables (
       id VARCHAR(100) PRIMARY KEY,
-      compaby_id VARCHAR(100) NOT NULL REFERENCES companies(id)
+      company_id VARCHAR(100) NOT NULL REFERENCES companies(id)
     );
 
     CREATE TABLE IF NOT EXISTS users (
-        id VARCHAR(100) PRIMARY KEY,
-        variable_id VARCHAR(100) NOT NULL,
-        name VARCHAR(100),
-        CONSTRAINT users_variable_id_fk FOREIGN KEY (variable_id) REFERENCES variables(id)
+      id VARCHAR(100) PRIMARY KEY,
+      variable_id VARCHAR(100) NOT NULL,
+      name VARCHAR(100),
+      CONSTRAINT users_variable_id_fk FOREIGN KEY (variable_id) REFERENCES variables(id)
     );
   output: |
+    ALTER TABLE "public"."variables" ADD CONSTRAINT "variables_company_id_fkey" FOREIGN KEY ("company_id") REFERENCES "public"."companies" ("id");
     ALTER TABLE "public"."users" ADD CONSTRAINT "users_variable_id_fk" FOREIGN KEY ("variable_id") REFERENCES "public"."variables" ("id");
 NumericChangePrecisionAndScale:
   current: |

--- a/database/postgres/tests.yml
+++ b/database/postgres/tests.yml
@@ -189,3 +189,13 @@ UserDefinedType:
         tag "public"."tags",
         tags "public"."tags"[]
     )
+CreateTableWithConstraintOptions:
+  sql: |
+    CREATE TABLE image_bindings (
+      image_id INT REFERENCES images(id) ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE,
+      image_order INT NOT NULL,
+      image_owner_type VARCHAR(20) NOT NULL,
+      image_owner_id INT NOT NULL,
+      CONSTRAINT image_owner_fk FOREIGN KEY (image_owner_type, image_owner_id) REFERENCES image_owners(type, id) ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE,
+      CONSTRAINT image_order_unique UNIQUE (image_owner_type, image_owner_id, image_order) DEFERRABLE INITIALLY DEFERRED
+    );

--- a/database/postgres/tests.yml
+++ b/database/postgres/tests.yml
@@ -18,7 +18,6 @@ CreateTableWithConstraint:
       CONSTRAINT user_id_fk FOREIGN KEY (user_id) REFERENCES users(id, name)
     );
 CreateTableWithConstraintInlineColumn:
-  compare_with_generic_parser: true
   sql: |
     CREATE TABLE tbl (
       id bigint PRIMARY KEY,
@@ -180,7 +179,6 @@ AlterTableUnique:
   sql: |
     ALTER TABLE users ADD CONSTRAINT username UNIQUE (name, age);
 AlterTableAddForeignKey:
-  compare_with_generic_parser: true
   sql: |
     ALTER TABLE ONLY public.posts ADD CONSTRAINT posts_ibfk_1 FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE SET NULL ON UPDATE RESTRICT;
 UserDefinedType:

--- a/database/postgres/tests.yml
+++ b/database/postgres/tests.yml
@@ -7,7 +7,7 @@ CreateTable:
       created_date time with time zone,
       fn integer default foo.my_func()
     );
-CreateTableWithConstrant:
+CreateTableWithConstraint:
   sql: |
     CREATE TABLE tbl (
       id bigint,
@@ -17,7 +17,7 @@ CreateTableWithConstrant:
       CONSTRAINT uniq_email UNIQUE (email),
       CONSTRAINT user_id_fk FOREIGN KEY (user_id) REFERENCES users(id, name)
     );
-CreateTableWithConstrantInlineColumn:
+CreateTableWithConstraintInlineColumn:
   compare_with_generic_parser: true
   sql: |
     CREATE TABLE tbl (

--- a/parser/node.go
+++ b/parser/node.go
@@ -734,10 +734,11 @@ func (ct *ColumnType) Format(buf *nodeBuffer) {
 
 // IndexDefinition describes an index in a CREATE TABLE statement
 type IndexDefinition struct {
-	Info      *IndexInfo
-	Columns   []IndexColumn
-	Options   []*IndexOption
-	Partition *IndexPartition
+	Info              *IndexInfo
+	Columns           []IndexColumn
+	Options           []*IndexOption
+	Partition         *IndexPartition
+	ConstraintOptions *ConstraintOptions
 }
 
 // Format formats the node.
@@ -858,6 +859,7 @@ type ForeignKeyDefinition struct {
 	OnDelete          ColIdent
 	OnUpdate          ColIdent
 	NotForReplication bool
+	ConstraintOptions *ConstraintOptions
 }
 
 type Policy struct {

--- a/schema/ast.go
+++ b/schema/ast.go
@@ -132,6 +132,7 @@ type ForeignKey struct {
 	onDelete          string
 	onUpdate          string
 	notForReplication bool
+	constraintOptions *ConstraintOptions
 }
 
 type Policy struct {

--- a/schema/parser.go
+++ b/schema/parser.go
@@ -84,6 +84,13 @@ func parseDDL(mode GeneratorMode, ddl string, stmt parser.Statement, defaultSche
 			for _, referenceColumn := range stmt.ForeignKey.ReferenceColumns {
 				referenceColumns = append(referenceColumns, referenceColumn.String())
 			}
+			var constraintOptions *ConstraintOptions
+			if stmt.ForeignKey.ConstraintOptions != nil {
+				constraintOptions = &ConstraintOptions{
+					deferrable:        stmt.ForeignKey.ConstraintOptions.Deferrable,
+					initiallyDeferred: stmt.ForeignKey.ConstraintOptions.InitiallyDeferred,
+				}
+			}
 
 			return &AddForeignKey{
 				statement: ddl,
@@ -97,6 +104,7 @@ func parseDDL(mode GeneratorMode, ddl string, stmt parser.Statement, defaultSche
 					onDelete:          stmt.ForeignKey.OnDelete.String(),
 					onUpdate:          stmt.ForeignKey.OnUpdate.String(),
 					notForReplication: stmt.ForeignKey.NotForReplication,
+					constraintOptions: constraintOptions,
 				},
 			}, nil
 		} else if stmt.Action == parser.CreatePolicy {
@@ -254,6 +262,14 @@ func parseTable(mode GeneratorMode, stmt *parser.DDL, defaultSchema string) (Tab
 			name = indexColumns[0].column
 		}
 
+		var constraintOptions *ConstraintOptions
+		if indexDef.ConstraintOptions != nil {
+			constraintOptions = &ConstraintOptions{
+				deferrable:        indexDef.ConstraintOptions.Deferrable,
+				initiallyDeferred: indexDef.ConstraintOptions.InitiallyDeferred,
+			}
+		}
+
 		index := Index{
 			name:      name,
 			indexType: indexDef.Info.Type,
@@ -263,6 +279,12 @@ func parseTable(mode GeneratorMode, stmt *parser.DDL, defaultSchema string) (Tab
 			clustered: bool(indexDef.Info.Clustered),
 			options:   indexOptions,
 			partition: indexPartition,
+
+			// FIXME: existence of constraintOptions doesn't mean it's a
+			// constraint but other parts of the code doesn't mark it as a
+			// constraint so we have to leave it as is for now.
+			constraint:        constraintOptions != nil,
+			constraintOptions: constraintOptions,
 		}
 		indexes = append(indexes, index)
 	}
@@ -288,6 +310,14 @@ func parseTable(mode GeneratorMode, stmt *parser.DDL, defaultSchema string) (Tab
 			referenceColumns = append(referenceColumns, referenceColumn.String())
 		}
 
+		var constraintOptions *ConstraintOptions
+		if foreignKeyDef.ConstraintOptions != nil {
+			constraintOptions = &ConstraintOptions{
+				deferrable:        foreignKeyDef.ConstraintOptions.Deferrable,
+				initiallyDeferred: foreignKeyDef.ConstraintOptions.InitiallyDeferred,
+			}
+		}
+
 		foreignKey := ForeignKey{
 			constraintName:    foreignKeyDef.ConstraintName.String(),
 			indexName:         foreignKeyDef.IndexName.String(),
@@ -297,6 +327,7 @@ func parseTable(mode GeneratorMode, stmt *parser.DDL, defaultSchema string) (Tab
 			onDelete:          foreignKeyDef.OnDelete.String(),
 			onUpdate:          foreignKeyDef.OnUpdate.String(),
 			notForReplication: foreignKeyDef.NotForReplication,
+			constraintOptions: constraintOptions,
 		}
 		foreignKeys = append(foreignKeys, foreignKey)
 	}


### PR DESCRIPTION
This PR contains two improvements:

1. Enable to handle adding an absent foreign key
2. Enhance `DEFERRABLE` support

# 1. Enable to handle adding an absent foreign key

```diff
  CREATE TABLE users (
    id INT PRIMARY KEY
  );
  CREATE TABLE posts (
    content TEXT,
-   user_id INT
+   user_id INT REFERENCES users(id)
  );
```

**Before** (v1.7.0)

*No diff*

**After**

```sql
ALTER TABLE "public"."posts" ADD CONSTRAINT "posts_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users" ("id");
```

# 2. Enhance `DEFERRABLE` support

```diff
  CREATE TABLE images (
    id INT PRIMARY KEY
  );
  CREATE TABLE image_owners (
    id INT,
    type VARCHAR(20) NOT NULL,
    PRIMARY KEY (type, id)
  );
  CREATE TABLE image_bindings (
-   image_id INT REFERENCES images(id) ON DELETE CASCADE,
+   image_id INT REFERENCES images(id) ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE,
    image_order INT NOT NULL,
    image_owner_type VARCHAR(20) NOT NULL,
    image_owner_id INT NOT NULL,
-   CONSTRAINT image_owner_fk FOREIGN KEY (image_owner_type, image_owner_id) REFERENCES image_owners(type, id) ON DELETE CASCADE,
-   CONSTRAINT image_order_unique UNIQUE (image_owner_type, image_owner_id, image_order)
+   CONSTRAINT image_owner_fk FOREIGN KEY (image_owner_type, image_owner_id) REFERENCES image_owners(type, id) ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE,
+   CONSTRAINT image_order_unique UNIQUE (image_owner_type, image_owner_id, image_order) DEFERRABLE INITIALLY DEFERRED
  );
```

**Before** (v1.7.0)

*Syntax error*

**After**

```sql
ALTER TABLE "public"."image_bindings" DROP CONSTRAINT "image_order_unique";
ALTER TABLE "public"."image_bindings" ADD CONSTRAINT "image_order_unique" UNIQUE ("image_owner_type", "image_owner_id", "image_order") DEFERRABLE INITIALLY DEFERRED;
ALTER TABLE "public"."image_bindings" DROP CONSTRAINT "image_bindings_image_id_fkey";
ALTER TABLE "public"."image_bindings" ADD CONSTRAINT "image_bindings_image_id_fkey" FOREIGN KEY ("image_id") REFERENCES "public"."images" ("id") ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE;
ALTER TABLE "public"."image_bindings" DROP CONSTRAINT "image_owner_fk";
ALTER TABLE "public"."image_bindings" ADD CONSTRAINT "image_owner_fk" FOREIGN KEY ("image_owner_type","image_owner_id") REFERENCES "public"."image_owners" ("type","id") ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE;
```