### PR TITLE
[psqldef] Add support for dropping materialized view

### DIFF
--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -590,6 +590,9 @@ func TestPsqldefCreateMaterializedView(t *testing.T) {
 			assertApplyOutput(t, createUsers+createPosts+createMaterializedView, applyPrefix+
 				fmt.Sprintf("CREATE MATERIALIZED VIEW %s.view_user_posts AS SELECT p.id FROM (%s as p JOIN %s as u ON ((p.user_id = u.id)));\n", tc.Schema, posts, users))
 			assertApplyOutput(t, createUsers+createPosts+createMaterializedView, nothingModified)
+
+			assertApplyOutput(t, createUsers+createPosts, applyPrefix+fmt.Sprintf(`DROP MATERIALIZED VIEW "%s"."view_user_posts";`, tc.Schema)+"\n")
+			assertApplyOutput(t, createUsers+createPosts, nothingModified)
 		})
 	}
 }

--- a/cmd/psqldef/tests.yml
+++ b/cmd/psqldef/tests.yml
@@ -297,6 +297,40 @@ MaterializedView:
   desired: |
     CREATE TABLE points (id bigint);
     CREATE MATERIALIZED VIEW IF NOT EXISTS points_view AS SELECT id FROM points;
+CreateMaterializedView:
+  current: |
+    CREATE TABLE public.users (
+      id BIGINT PRIMARY KEY,
+      name character varying(100)
+    );
+    CREATE TABLE public.posts (
+      id BIGINT PRIMARY KEY,
+      name character varying(100),
+      user_id BIGINT,
+      is_deleted boolean
+    );
+  desired: |
+    CREATE TABLE public.users (
+      id BIGINT PRIMARY KEY,
+      name character varying(100)
+    );
+    CREATE TABLE public.posts (
+      id BIGINT PRIMARY KEY,
+      name character varying(100),
+      user_id BIGINT,
+      is_deleted boolean
+    );
+    CREATE MATERIALIZED VIEW public.view_user_posts AS SELECT p.id FROM (posts as p JOIN users as u ON ((p.user_id = u.id)));
+  output: | 
+    CREATE MATERIALIZED VIEW public.view_user_posts AS SELECT p.id FROM (posts as p JOIN users as u ON ((p.user_id = u.id)));
+DropMaterializedView:
+  current: |
+    CREATE TABLE "public"."points" (id bigint);
+    CREATE MATERIALIZED VIEW IF NOT EXISTS "public"."points_view" AS SELECT id FROM points; 
+  desired: |
+    CREATE TABLE "public"."points" (id bigint);
+  output: | 
+    DROP MATERIALIZED VIEW "public"."points_view";
 IntervalExpression:
   desired: |
     CREATE TABLE points (id bigint, created_at timestamp, main_type text, sub_type text, user_id bigint);

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -257,6 +257,10 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 		if containsString(convertViewNames(g.desiredViews), currentView.name) {
 			continue
 		}
+		if currentView.viewType == "MATERIALIZED VIEW" {
+			ddls = append(ddls, fmt.Sprintf("DROP MATERIALIZED VIEW %s", g.escapeTableName(currentView.name)))
+			continue
+		}
 		ddls = append(ddls, fmt.Sprintf("DROP VIEW %s", g.escapeTableName(currentView.name)))
 	}
 


### PR DESCRIPTION
## ISSUE
There was a bug that materialized view could not be dropped.

### exmple
```
$ psqldef -U postgres postgres < schema.sql --export           
CREATE TABLE "public"."users" (
    "id" serial NOT NULL,
    "name" character varying(100) NOT NULL,
    PRIMARY KEY ("id")
);

CREATE MATERIALIZED VIEW public.view_users AS SELECT id, name FROM users;
```

### input (schema.sql)
``` sql
create table users (
  id   serial       primary key,
  name varchar(100) not null
);
```
### current output
```
$ psqldef -U postgres postgres < schema.sql
-- Apply --
DROP VIEW "public"."view_users";
2024/03/26 17:52:48 pq: "view_users" is not a view
```
### expected output
```
$ psqldef -U postgres postgres < schema.sql
-- Apply --
DROP MATERIALIZED VIEW "public"."view_users";
```
## PATCH
This was because the materialized view was recognized as a normal view. Therefore, we added a if branch for materialized view and added a test code.