### PR TITLE
Fix ALTER DDL to not add AFTER syntax when adding to last column.

### DIFF
--- a/cmd/mysqldef/mysqldef_test.go
+++ b/cmd/mysqldef/mysqldef_test.go
@@ -217,6 +217,18 @@ func TestMysqldefAddColumnAfter(t *testing.T) {
 	)
 	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD COLUMN `name` varchar(40) NOT NULL AFTER `id`;\n")
 	assertApplyOutput(t, createTable, nothingModified)
+
+	createTable = stripHeredoc(`
+		CREATE TABLE users (
+		  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		  name varchar(40) NOT NULL,
+		  created_at datetime NOT NULL,
+		  updated_at datetime NOT NULL
+		);
+		`,
+	)
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD COLUMN `updated_at` datetime NOT NULL;\n")
+	assertApplyOutput(t, createTable, nothingModified)
 }
 
 func TestMysqldefAddColumnWithNull(t *testing.T) {

--- a/cmd/mysqldef/mysqldef_test.go
+++ b/cmd/mysqldef/mysqldef_test.go
@@ -182,7 +182,7 @@ func TestMysqldefAddColumn(t *testing.T) {
 		  created_at datetime NOT NULL
 		);`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD COLUMN `created_at` datetime NOT NULL AFTER `name`;\n")
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD COLUMN `created_at` datetime NOT NULL;\n")
 	assertApplyOutput(t, createTable, nothingModified)
 
 	createTable = stripHeredoc(`
@@ -229,6 +229,20 @@ func TestMysqldefAddColumnAfter(t *testing.T) {
 	)
 	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD COLUMN `updated_at` datetime NOT NULL;\n")
 	assertApplyOutput(t, createTable, nothingModified)
+
+	createTable = stripHeredoc(`
+		CREATE TABLE users (
+		  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		  name varchar(40) NOT NULL,
+		  created_at datetime NOT NULL,
+		  updated_at datetime NOT NULL,
+		  deleted_at datetime NOT NULL,
+		  INDEX index_1 (name)
+		);
+		`,
+	)
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD COLUMN `deleted_at` datetime NOT NULL;\nALTER TABLE `users` ADD INDEX `index_1` (`name`);\n")
+	assertApplyOutput(t, createTable, nothingModified)
 }
 
 func TestMysqldefAddColumnWithNull(t *testing.T) {
@@ -251,7 +265,7 @@ func TestMysqldefAddColumnWithNull(t *testing.T) {
 		  created_at timestamp NULL DEFAULT NULL
 		);`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD COLUMN `created_at` timestamp NULL DEFAULT null AFTER `name`;\n")
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD COLUMN `created_at` timestamp NULL DEFAULT null;\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
@@ -388,7 +402,7 @@ func TestMysqldefChangeGenerateColumnGemerayedAlwaysAs(t *testing.T) {
 	)
 	assertApplyOutput(t, createTable, applyPrefix+stripHeredoc(`
 		ALTER TABLE `+"`test_table`"+` DROP COLUMN `+"`name`"+`;
-		ALTER TABLE `+"`test_table`"+` ADD COLUMN `+"`name`"+` varchar(20) GENERATED ALWAYS AS (json_extract(data, '$.name2')) VIRTUAL AFTER `+"`data`"+`;
+		ALTER TABLE `+"`test_table`"+` ADD COLUMN `+"`name`"+` varchar(20) GENERATED ALWAYS AS (json_extract(data, '$.name2')) VIRTUAL;
 		`,
 	))
 	assertApplyOutput(t, createTable, nothingModified)
@@ -408,7 +422,7 @@ func TestMysqldefChangeGenerateColumnGemerayedAlwaysAs(t *testing.T) {
 		ALTER TABLE `+"`test_table`"+` DROP COLUMN `+"`test_expr`"+`;
 		ALTER TABLE `+"`test_table`"+` ADD COLUMN `+"`test_expr`"+` varchar(45) GENERATED ALWAYS AS (test_value / test_value) STORED AFTER `+"`test_value`"+`;
 		ALTER TABLE `+"`test_table`"+` DROP COLUMN `+"`name`"+`;
-		ALTER TABLE `+"`test_table`"+` ADD COLUMN `+"`name`"+` varchar(20) GENERATED ALWAYS AS (json_extract(data, '$.name2')) STORED AFTER `+"`data`"+`;
+		ALTER TABLE `+"`test_table`"+` ADD COLUMN `+"`name`"+` varchar(20) GENERATED ALWAYS AS (json_extract(data, '$.name2')) STORED;
 		`,
 	))
 	assertApplyOutput(t, createTable, nothingModified)
@@ -441,7 +455,7 @@ func TestMysqldefChangeGenerateColumnGemerayedAlwaysAs(t *testing.T) {
 		ALTER TABLE `+"`test_table`"+` DROP COLUMN `+"`test_expr`"+`;
 		ALTER TABLE `+"`test_table`"+` ADD COLUMN `+"`test_expr`"+` varchar(45) GENERATED ALWAYS AS (test_value / test_value) STORED NOT NULL AFTER `+"`test_value`"+`;
 		ALTER TABLE `+"`test_table`"+` DROP COLUMN `+"`name`"+`;
-		ALTER TABLE `+"`test_table`"+` ADD COLUMN `+"`name`"+` varchar(20) GENERATED ALWAYS AS (json_extract(data, '$.name2')) STORED NOT NULL AFTER `+"`data`"+`;
+		ALTER TABLE `+"`test_table`"+` ADD COLUMN `+"`name`"+` varchar(20) GENERATED ALWAYS AS (json_extract(data, '$.name2')) STORED NOT NULL;
 		`,
 	))
 	assertApplyOutput(t, createTable, nothingModified)
@@ -855,7 +869,7 @@ func TestMysqldefCreateTableWithUniqueColumn(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE `users` ADD COLUMN `name` varchar(40) UNIQUE AFTER `id`;\n",
+		"ALTER TABLE `users` ADD COLUMN `name` varchar(40) UNIQUE;\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 
@@ -1097,7 +1111,7 @@ func TestMysqldefDefaultNull(t *testing.T) {
 		);
 		`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD COLUMN `name` varchar(40) DEFAULT null AFTER `id`;\n")
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD COLUMN `name` varchar(40) DEFAULT null;\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
@@ -1147,7 +1161,7 @@ func TestMysqldefCreateTableAddColumnWithCharsetAndNotNull(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE `users` ADD COLUMN `name` varchar(20) CHARACTER SET ascii COLLATE ascii_bin NOT NULL AFTER `id`;\n",
+		"ALTER TABLE `users` ADD COLUMN `name` varchar(20) CHARACTER SET ascii COLLATE ascii_bin NOT NULL;\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 }
@@ -1218,7 +1232,7 @@ func TestMysqldefCurrentTimestampWithPrecision(t *testing.T) {
 		);
 		`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD COLUMN `updated_at` datetime(6) DEFAULT current_timestamp(6) ON UPDATE current_timestamp(6) AFTER `created_at`;\n")
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD COLUMN `updated_at` datetime(6) DEFAULT current_timestamp(6) ON UPDATE current_timestamp(6);\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
@@ -1241,7 +1255,7 @@ func TestMysqldefEnumValues(t *testing.T) {
 		);
 		`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD COLUMN `authorities` enum('normal', 'admin') NOT NULL DEFAULT 'normal' AFTER `id`;\n")
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD COLUMN `authorities` enum('normal', 'admin') NOT NULL DEFAULT 'normal';\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 

--- a/cmd/mysqldef/tests.yml
+++ b/cmd/mysqldef/tests.yml
@@ -178,7 +178,7 @@ CreateTableWithSpatialTypesAndSpatialKey:
       SPATIAL KEY index_users_location (location)
     );
   output: |
-    ALTER TABLE `users` ADD COLUMN `location` point NOT NULL AFTER `id`;
+    ALTER TABLE `users` ADD COLUMN `location` point NOT NULL;
     ALTER TABLE `users` ADD SPATIAL KEY `index_users_location` (`location`);
 CreateTableWithSpatialTypesSRIDSpecified:
   current: |
@@ -191,7 +191,7 @@ CreateTableWithSpatialTypesSRIDSpecified:
       location point NOT NULL /*!80003 SRID 4326 */
     );
   output: |
-    ALTER TABLE `users` ADD COLUMN `location` point NOT NULL /*!80003 SRID 4326 */ AFTER `id`;
+    ALTER TABLE `users` ADD COLUMN `location` point NOT NULL /*!80003 SRID 4326 */;
 CreateTableGeneratedAlwaysAs80:
   desired: |
     CREATE TABLE `test_table` (
@@ -218,7 +218,7 @@ CreateTableGeneratedAlwaysAsChangeExpr80:
     );
   output: |
     ALTER TABLE `test_table` DROP COLUMN `test_expr`;
-    ALTER TABLE `test_table` ADD COLUMN `test_expr` varchar(45) GENERATED ALWAYS AS ((test_value / test_value) * 2) VIRTUAL AFTER `test_value`;
+    ALTER TABLE `test_table` ADD COLUMN `test_expr` varchar(45) GENERATED ALWAYS AS ((test_value / test_value) * 2) VIRTUAL;
   min_version: '8.0'
 CreateTableGeneratedAlwaysAsAbbreviation80:
   desired: |
@@ -246,7 +246,7 @@ CreateTableGeneratedAlwaysAsAbbreviationChangeExpr80:
     );
   output: |
     ALTER TABLE `test_table` DROP COLUMN `test_expr`;
-    ALTER TABLE `test_table` ADD COLUMN `test_expr` varchar(45) GENERATED ALWAYS AS ((test_value / test_value) * 2) STORED NOT NULL AFTER `test_value`;
+    ALTER TABLE `test_table` ADD COLUMN `test_expr` varchar(45) GENERATED ALWAYS AS ((test_value / test_value) * 2) STORED NOT NULL;
   min_version: '8.0'
 ConstraintCheck:
   desired: |
@@ -364,7 +364,7 @@ AlterTableAddSetTypeColumn:
       dayOfWeek SET('Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun') NOT NULL
     );
   output: |
-    ALTER TABLE `alarm` ADD COLUMN `dayOfWeek` set('Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun') NOT NULL AFTER `id`;
+    ALTER TABLE `alarm` ADD COLUMN `dayOfWeek` set('Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun') NOT NULL;
 UUIDToBin:
   desired: |
     CREATE TABLE users (
@@ -530,7 +530,7 @@ AddColumnWithDefaultExpression:
       friend_ids JSON DEFAULT(JSON_ARRAY())  
     );
   output: |
-    ALTER TABLE `users` ADD COLUMN `friend_ids` json DEFAULT(JSON_ARRAY()) AFTER `id`;
+    ALTER TABLE `users` ADD COLUMN `friend_ids` json DEFAULT(JSON_ARRAY());
   min_version: '8.0'
 AddDefaultExpression:
   current: |

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -336,8 +336,13 @@ func (g *Generator) generateDDLsForCreateTable(currentTable Table, desired Creat
 			}
 
 			if g.mode == GeneratorModeMysql {
-				after := " FIRST"
-				if i > 0 {
+				var after string
+				switch {
+				case i == 0:
+					after = " FIRST"
+				case i > 0 && i < len(desired.table.columns)-1:
+					// To add columns other than the first and last, write AFTER.
+					// But, Do not write AFTER when adding to the last column.
 					after = " AFTER " + g.escapeSQLName(desired.table.columns[i-1].name)
 				}
 				ddl += after
@@ -351,7 +356,6 @@ func (g *Generator) generateDDLsForCreateTable(currentTable Table, desired Creat
 				currentPos := currentColumn.position
 				desiredPos := desiredColumn.position
 				changeOrder := currentPos > desiredPos && currentPos-desiredPos > len(currentTable.columns)-len(desired.table.columns)
-
 				// Change column type and orders, *except* AUTO_INCREMENT and UNIQUE KEY.
 				if !g.haveSameColumnDefinition(*currentColumn, desiredColumn) || !g.areSameDefaultValue(currentColumn.defaultDef, desiredColumn.defaultDef) || !g.areSameGenerated(currentColumn.generated, desiredColumn.generated) || changeOrder {
 					definition, err := g.generateColumnDefinition(desiredColumn, false)
@@ -362,8 +366,13 @@ func (g *Generator) generateDDLsForCreateTable(currentTable Table, desired Creat
 					if desiredColumn.generated != nil {
 						ddl1 := fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s", g.escapeTableName(desired.table.name), g.escapeSQLName(currentColumn.name))
 						ddl2 := fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s", g.escapeTableName(desired.table.name), definition)
-						after := " FIRST"
-						if i > 0 {
+						var after string
+						switch {
+						case i == 0:
+							after = " FIRST"
+						case i > 0 && i < len(desired.table.columns)-1:
+							// To add columns other than the first and last, write AFTER.
+							// But, Do not write AFTER when adding to the last column.
 							after = " AFTER " + g.escapeSQLName(desired.table.columns[i-1].name)
 						}
 						ddl2 += after
@@ -371,8 +380,13 @@ func (g *Generator) generateDDLsForCreateTable(currentTable Table, desired Creat
 					} else {
 						ddl := fmt.Sprintf("ALTER TABLE %s CHANGE COLUMN %s %s", g.escapeTableName(desired.table.name), g.escapeSQLName(currentColumn.name), definition)
 						if changeOrder {
-							after := " FIRST"
-							if i > 0 {
+							var after string
+							switch {
+							case i == 0:
+								after = " FIRST"
+							case i > 0 && i < len(desired.table.columns)-1:
+								// To add columns other than the first and last, write AFTER.
+								// But, Do not write AFTER when adding to the last column.
 								after = " AFTER " + g.escapeSQLName(desired.table.columns[i-1].name)
 							}
 							ddl += after


### PR DESCRIPTION
# Background
In the current sqldef, the AFTER syntax is always specified when adding a column other than the first.

```diff
CREATE TABLE users (
    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
    name varchar(40) NOT NULL,
    created_at datetime NOT NULL,
+   updated_at datetime NOT NULL
);
```

```sql
ALTER TABLE `users` ADD COLUMN `updated_at` datetime NOT NULL AFTER `created_at`;
```

However, since the RDB behaves differently when FIRST/AFTER is specified or not specified, it may be desirable to execute without specifying AFTER.
Specifically, in MySQL, when adding a column in ALTER TABLE, the INSTANT Algorithm can be used when adding to the last column, but if BEFORE/AFTER is used, the INPLACE Algorithm is used (MySQL 8.0.29 or later ).

https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl-operations.html
> The INSTANT algorithm can add a column at any position in the table. Before MySQL 8.0.29, the INSTANT algorithm could only add a column as the last column of the table.

There are cases where the INSTANT algorithm should be used instead of the INPLACE algorithm due to the specific bugs listed below.
https://docs.aws.amazon.com/AmazonRDS/latest/AuroraMySQLReleaseNotes/AuroraMySQL.Updates.3050.html
> Fixed an issue where the reader instance is unable to open a table, with ERROR 1146. This issue occurs when executing certain types of online Data Definition Language (DDL) while the INPLACE algorithm is being used on the writer instance.

# Solution

Fix to issue DDL without AFTER when adding to the last COLUMN of a table.

```diff
CREATE TABLE users (
    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
    name varchar(40) NOT NULL,
    created_at datetime NOT NULL,
+   updated_at datetime NOT NULL
);
```

```sql
ALTER TABLE `users` ADD COLUMN `updated_at` datetime NOT NULL;
```
