### PR TITLE
psqldef: Fix error for index with coalesce

### DIFF
--- a/cmd/psqldef/tests.yml
+++ b/cmd/psqldef/tests.yml
@@ -121,6 +121,20 @@ CreateIndexConcurrently:
     CREATE INDEX CONCURRENTLY username on users (name);
   output: |
     CREATE INDEX CONCURRENTLY username on users (name);
+CreateIndexWithCoalesce:
+  current: |
+    CREATE TABLE users (
+      name TEXT,
+      user_name TEXT
+    );
+  desired: |
+    CREATE TABLE users (
+      name TEXT,
+      user_name TEXT
+    );
+    CREATE INDEX create_index_with_function_call ON users (name, COALESCE(user_name, 'NO_NAME'::TEXT));
+  output: |
+    CREATE INDEX create_index_with_function_call ON users (name, COALESCE(user_name, 'NO_NAME'::TEXT));
 AlterTypeAddValue:
   current: |
     CREATE TYPE eventtype AS ENUM (
@@ -354,15 +368,15 @@ CreateMaterializedView:
       is_deleted boolean
     );
     CREATE MATERIALIZED VIEW public.view_user_posts AS SELECT p.id FROM (posts as p JOIN users as u ON ((p.user_id = u.id)));
-  output: | 
+  output: |
     CREATE MATERIALIZED VIEW public.view_user_posts AS SELECT p.id FROM (posts as p JOIN users as u ON ((p.user_id = u.id)));
 DropMaterializedView:
   current: |
     CREATE TABLE "public"."points" (id bigint);
-    CREATE MATERIALIZED VIEW IF NOT EXISTS "public"."points_view" AS SELECT id FROM points; 
+    CREATE MATERIALIZED VIEW IF NOT EXISTS "public"."points_view" AS SELECT id FROM points;
   desired: |
     CREATE TABLE "public"."points" (id bigint);
-  output: | 
+  output: |
     DROP MATERIALIZED VIEW "public"."points_view";
 IntervalExpression:
   desired: |

--- a/database/postgres/parser.go
+++ b/database/postgres/parser.go
@@ -664,6 +664,21 @@ func (p PostgresParser) parseExpr(stmt *pgquery.Node) (parser.Expr, error) {
 		default:
 			return nil, fmt.Errorf("unknown AExpr kind in parseExpr: %#v", node.AExpr)
 		}
+	case *pgquery.Node_CoalesceExpr:
+		var selectExprs parser.SelectExprs
+		for _, arg := range node.CoalesceExpr.Args {
+			expr, err := p.parseExpr(arg)
+			if err != nil {
+				return nil, err
+			}
+			selectExprs = append(selectExprs, &parser.AliasedExpr{
+				Expr: expr,
+			})
+		}
+		return &parser.FuncExpr{
+			Name:  parser.NewColIdent("coalesce"),
+			Exprs: selectExprs,
+		}, nil
 	default:
 		return nil, fmt.Errorf("unknown node in parseExpr: %#v", node)
 	}

--- a/database/postgres/tests.yml
+++ b/database/postgres/tests.yml
@@ -197,3 +197,10 @@ CreateTableWithConstraintOptions:
       CONSTRAINT image_owner_fk FOREIGN KEY (image_owner_type, image_owner_id) REFERENCES image_owners(type, id) ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE,
       CONSTRAINT image_order_unique UNIQUE (image_owner_type, image_owner_id, image_order) DEFERRABLE INITIALLY DEFERRED
     );
+CreateIndexWithCoalesce:
+  sql: |
+    CREATE TABLE users (
+      name TEXT,
+      user_name TEXT
+    );
+    CREATE INDEX create_index_with_function_call ON users (name, COALESCE(user_name, 'NO_NAME'::TEXT));


### PR DESCRIPTION
I fixed the error that was occurring in this SQL.

```sql
CREATE TABLE users (
  name TEXT,
  user_name TEXT
);

CREATE INDEX create_index_with_function_call ON users (name, COALESCE(user_name, 'NO_NAME'::TEXT));
```

