### PR TITLE
Exclude a temporary table

### DIFF
--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -82,6 +82,7 @@ func (d *PostgresDatabase) tableNames() ([]string, error) {
 		inner join pg_catalog.pg_namespace n on c.relnamespace = n.oid
 		where n.nspname not in ('information_schema', 'pg_catalog')
 		and c.relkind in ('r', 'p')
+		and c.relpersistence in ('p', 'u')
 		and not exists (select * from pg_catalog.pg_depend d where c.oid = d.objid and d.deptype = 'e')
 		order by relname asc;
 	`)


### PR DESCRIPTION
This PR excludes temporary tables from psqldef migration.

Having temporary tables on migration gets an ambiguous error:

```bash
2024/04/26 09:58:16 Error on DumpDDLs: sql: Scan error on column index 0, name "column_name": converting NULL to string is unsupported
```

This comes from temp tables not returning column defs.  
I think they should be excluded because we cannot say much about temporalities.

I just tried to add a test case, but couldn't find out a proper way to describe excluded DB objects. I confirmed it passes through existing tests.