### PR TITLE
[mysqldef] Add Lock option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Application Options:
       --enable-drop-table           Enable destructive changes such as DROP (enable only table drops)
       --skip-view                   Skip managing views (temporary feature, to be removed later)
       --before-apply=               Execute the given string before applying the regular DDLs
-      --config=                     YAML file to specify: target_tables, skip_tables, algorithm
+      --config=                     YAML file to specify: target_tables, skip_tables, algorithm, lock
       --help                        Show this help
       --version                     Show this version
 ```

--- a/cmd/mysqldef/mysqldef.go
+++ b/cmd/mysqldef/mysqldef.go
@@ -39,7 +39,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		EnableDropTable       bool     `long:"enable-drop-table" description:"Enable destructive changes such as DROP (enable only table drops)"`
 		SkipView              bool     `long:"skip-view" description:"Skip managing views (temporary feature, to be removed later)"`
 		BeforeApply           string   `long:"before-apply" description:"Execute the given string before applying the regular DDLs"`
-		Config                string   `long:"config" description:"YAML file to specify: target_tables, skip_tables, algorithm"`
+		Config                string   `long:"config" description:"YAML file to specify: target_tables, skip_tables, algorithm, lock"`
 		Help                  bool     `long:"help" description:"Show this help"`
 		Version               bool     `long:"version" description:"Show this version"`
 	}

--- a/cmd/mysqldef/mysqldef_test.go
+++ b/cmd/mysqldef/mysqldef_test.go
@@ -1683,6 +1683,37 @@ func TestMysqldefConfigIncludesAlgorithm(t *testing.T) {
 	))
 }
 
+func TestMysqldefConfigIncludesLock(t *testing.T) {
+	resetTestDatabase()
+
+	createTable := stripHeredoc(`
+		CREATE TABLE users (
+		  id int UNSIGNED NOT NULL,
+		  name varchar(255) COLLATE utf8mb4_bin DEFAULT NULL
+		);
+		`,
+	)
+	assertApplyOutput(t, createTable, applyPrefix+createTable)
+	assertApplyOutput(t, createTable, nothingModified)
+
+	createTable = stripHeredoc(`
+		CREATE TABLE users (
+		  id int UNSIGNED NOT NULL,
+		  name varchar(255) COLLATE utf8mb4_bin DEFAULT NULL,
+		  new_column varchar(255) COLLATE utf8mb4_bin DEFAULT NULL
+		);
+		`,
+	)
+
+	writeFile("schema.sql", createTable)
+	writeFile("config.yml", "lock: none")
+
+	apply := assertedExecute(t, "./mysqldef", "-uroot", "mysqldef_test", "--config", "config.yml", "--file", "schema.sql")
+	assertEquals(t, apply, applyPrefix+stripHeredoc(`
+	ALTER TABLE `+"`users`"+` ADD COLUMN `+"`new_column` "+`varchar(255) COLLATE utf8mb4_bin DEFAULT null `+"AFTER `name`, "+`LOCK=NONE;
+`))
+}
+
 func TestMysqldefHelp(t *testing.T) {
 	_, err := testutils.Execute("./mysqldef", "--help")
 	if err != nil {

--- a/database/database.go
+++ b/database/database.go
@@ -36,6 +36,7 @@ type GeneratorConfig struct {
 	SkipTables   []string
 	TargetSchema string
 	Algorithm    string
+	Lock         string
 }
 
 // Abstraction layer for multiple kinds of databases
@@ -100,6 +101,7 @@ func ParseGeneratorConfig(configFile string) GeneratorConfig {
 		SkipTables   string `yaml:"skip_tables"`
 		TargetSchema string `yaml:"target_schema"`
 		Algorithm    string `yaml:"algorithm"`
+		Lock         string `yaml:"lock"`
 	}
 
 	dec := yaml.NewDecoder(bytes.NewReader(buf))
@@ -129,10 +131,14 @@ func ParseGeneratorConfig(configFile string) GeneratorConfig {
 		algorithm = strings.Trim(config.Algorithm, "\n")
 	}
 
+	if config.Lock != "" {
+		algorithm = strings.Trim(config.Lock, "\n")
+	}
 	return GeneratorConfig{
 		TargetTables: targetTables,
 		SkipTables:   skipTables,
 		TargetSchema: targetSchema,
 		Algorithm:    algorithm,
+		Lock:         config.Lock,
 	}
 }


### PR DESCRIPTION
Produce sql with lock option. 
Resolving https://github.com/sqldef/sqldef/issues/526 

for example, 

```
ALTER TABLE `users` ADD COLUMN `new_column` varchar(255) COLLATE utf8mb4_bin DEFAULT null AFTER `name`, LOCK=NONE;
```