### PR TITLE
[WIP][psqldef] postgresql table constraints exclusion

### DIFF
--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -279,14 +279,18 @@ func (d *PostgresDatabase) dumpTableDDL(table string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	exclusionConstraints, err := d.getTableExclusionConstraints(table)
+	if err != nil {
+		return "", err
+	}
 	comments, err := d.getComments(table)
 	if err != nil {
 		return "", err
 	}
-	return buildDumpTableDDL(table, cols, pkeyCols, indexDefs, foreignDefs, policyDefs, comments, checkConstraints, uniqueConstraints, d.GetDefaultSchema()), nil
+	return buildDumpTableDDL(table, cols, pkeyCols, indexDefs, foreignDefs, policyDefs, comments, checkConstraints, uniqueConstraints, exclusionConstraints, d.GetDefaultSchema()), nil
 }
 
-func buildDumpTableDDL(table string, columns []column, pkeyCols, indexDefs, foreignDefs, policyDefs, comments []string, checkConstraints, uniqueConstraints map[string]string, defaultSchema string) string {
+func buildDumpTableDDL(table string, columns []column, pkeyCols, indexDefs, foreignDefs, policyDefs, comments []string, checkConstraints, uniqueConstraints, exclusionConstraints map[string]string, defaultSchema string) string {
 	var queryBuilder strings.Builder
 	schema, table := splitTableName(table, defaultSchema)
 	fmt.Fprintf(&queryBuilder, "CREATE TABLE %s.%s (", escapeSQLName(schema), escapeSQLName(table))
@@ -571,6 +575,11 @@ func (d *PostgresDatabase) getUniqueConstraints(tableName string) (map[string]st
 		)
 	}
 
+	return result, nil
+}
+
+func (d *PostgresDatabase) getTableExclusionConstraints(tableName string) (map[string]string, error) {
+	result := map[string]string{}
 	return result, nil
 }
 

--- a/database/postgres/tests.yml
+++ b/database/postgres/tests.yml
@@ -211,6 +211,6 @@ ExcludeConstraint:
       event_start tstzrange NOT NULL,
       event_end tstzrange NOT NULL,
       EXCLUDE (name WITH =),
-      EXCLUDE (lower(name) WITH =),
+      EXCLUDE (lower(name) WITH =) where (name <> ''),
       EXCLUDE USING GIST (event_start WITH &&, event_end WITH &&)
     );

--- a/database/postgres/tests.yml
+++ b/database/postgres/tests.yml
@@ -204,3 +204,13 @@ CreateIndexWithCoalesce:
       user_name TEXT
     );
     CREATE INDEX create_index_with_function_call ON users (name, COALESCE(user_name, 'NO_NAME'::TEXT));
+ExcludeConstraint:
+  sql: |
+    CREATE TABLE exclude_example (
+      name varchar(255),
+      event_start tstzrange NOT NULL,
+      event_end tstzrange NOT NULL,
+      EXCLUDE (name WITH =),
+      EXCLUDE (lower(name) WITH =),
+      EXCLUDE USING GIST (event_start WITH &&, event_end WITH &&)
+    );

--- a/parser/node.go
+++ b/parser/node.go
@@ -512,6 +512,7 @@ type TableSpec struct {
 	Indexes     []*IndexDefinition
 	ForeignKeys []*ForeignKeyDefinition
 	Checks      []*CheckDefinition
+	Exclusions  []*ExclusionDefinition // for Postgres
 	Options     map[string]string
 }
 
@@ -660,6 +661,17 @@ type CheckDefinition struct {
 	ConstraintName    ColIdent
 	NotForReplication bool
 	NoInherit         BoolVal
+}
+
+type ExclusionPair struct {
+	Column   ColIdent
+	Operator string
+}
+
+type ExclusionDefinition struct {
+	AccessMethod string
+	Exclusions   []ExclusionPair
+	Where        *Where
 }
 
 // Format returns a canonical string representation of the type and all relevant options


### PR DESCRIPTION
__Not completed yet__

Postgresql has exclude constraint.

```sql
CREATE TABLE exclude_example (
  name varchar(255),
  event_start tstzrange NOT NULL,
  event_end tstzrange NOT NULL,
  EXCLUDE (name WITH =),
  EXCLUDE (lower(name) WITH =) where (name <> ''),
  EXCLUDE USING GIST (event_start WITH &&, event_end WITH &&)
);
```

This is a table constraint:
```
EXCLUDE [ USING index_method ] ( exclude_element WITH operator [, ... ] ) index_parameters [ WHERE ( predicate ) ]
```

https://www.postgresql.org/docs/15/ddl-constraints.html#DDL-CONSTRAINTS-EXCLUSION
https://www.postgresql.org/docs/15/sql-createtable.html#SQL-CREATETABLE-EXCLUDE

fixes #473