### PR TITLE
Allow multiple targets for target_schema config

### DIFF
--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -1409,6 +1409,24 @@ func TestPsqldefConfigIncludesTargetSchema(t *testing.T) {
 
 	apply := assertedExecute(t, "./psqldef", "-Upostgres", databaseName, "-f", "schema.sql", "--config", "config.yml")
 	assertEquals(t, apply, nothingModified)
+
+	// multiple targets
+	mustExecuteSQL(`
+        CREATE SCHEMA schema_c;
+        CREATE TABLE schema_c.users (id bigint PRIMARY KEY);
+    `)
+
+	writeFile("schema.sql", `
+        CREATE TABLE schema_a.users (id bigint PRIMARY KEY);
+        CREATE TABLE schema_b.users (id bigint PRIMARY KEY);
+    `)
+
+	writeFile("config.yml", `target_schema: |
+  schema_a
+  schema_b`)
+
+	apply = assertedExecute(t, "./psqldef", "-Upostgres", databaseName, "-f", "schema.sql", "--config", "config.yml")
+	assertEquals(t, apply, nothingModified)
 }
 
 func TestPsqldefConfigIncludesSkipTables(t *testing.T) {

--- a/database/database.go
+++ b/database/database.go
@@ -28,13 +28,13 @@ type Config struct {
 	SslCa                      string
 
 	// Only PostgreSQL
-	TargetSchema string
+	TargetSchema []string
 }
 
 type GeneratorConfig struct {
 	TargetTables []string
 	SkipTables   []string
-	TargetSchema string
+	TargetSchema []string
 	Algorithm    string
 	Lock         string
 }
@@ -121,9 +121,9 @@ func ParseGeneratorConfig(configFile string) GeneratorConfig {
 		skipTables = strings.Split(strings.Trim(config.SkipTables, "\n"), "\n")
 	}
 
-	var targetSchema string
+	var targetSchema []string
 	if config.TargetSchema != "" {
-		targetSchema = strings.Trim(config.TargetSchema, "\n")
+		targetSchema = strings.Split(strings.Trim(config.TargetSchema, "\n"), "\n")
 	}
 
 	var algorithm string

--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -97,7 +97,7 @@ func (d *PostgresDatabase) tableNames() ([]string, error) {
 		if err := rows.Scan(&schema, &name); err != nil {
 			return nil, err
 		}
-		if d.config.TargetSchema != "" && d.config.TargetSchema != schema {
+		if d.config.TargetSchema != nil && !containsString(d.config.TargetSchema, schema) {
 			continue
 		}
 		tables = append(tables, schema+"."+name)
@@ -890,4 +890,13 @@ func splitTableName(table string, defaultSchema string) (string, string) {
 		table = schemaTable[1]
 	}
 	return schema, table
+}
+
+func containsString(strs []string, str string) bool {
+	for _, s := range strs {
+		if s == str {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
`target_tables` allows specifying multiple tables separated by new lines, but `target_schema` could only specify a single schema. This change will allow specifying multiple schemas in target_schema as well.