### PR TITLE
[psqldef] Fix create schema conditions

### DIFF
--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -196,12 +196,12 @@ func (d *PostgresDatabase) materializedViews() ([]string, error) {
 }
 
 func (d *PostgresDatabase) schemas() ([]string, error) {
-	rows, err := d.db.Query(fmt.Sprintf(`
+	rows, err := d.db.Query(`
 		SELECT schema_name
 		FROM information_schema.schemata
 		WHERE schema_name NOT LIKE 'pg_%%'
-		AND schema_name not in ('information_schema', '%s');
-	`, d.GetDefaultSchema()))
+		AND schema_name not in ('information_schema', 'public');
+	`)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
follow up to https://github.com/sqldef/sqldef/pull/541

## Problem

```sql
create table foo.bar (id int);
create schema foo;
```

```
$ psql -h localhost -U postgres sandbox -c 'CREATE USER foo';
CREATE ROLE

$ psql -h localhost -U postgres sandbox -c 'GRANT ALL ON DATABASE sandbox TO foo';
GRANT

$ psqldef -h localhost -U foo sandbox < schema.sql
-- Apply --
create schema foo;
create table foo.bar (id int);

$ psqldef -h localhost -U foo sandbox < schema.sql
-- Apply --
create schema foo;
2024/07/13 22:31:30 pq: schema "foo" already exists
```

The reason is that for a `foo` user, the current schema becomes `foo`.

```
# foo user
$ psql -h localhost -U foo sandbox -c 'select current_schema';
 current_schema
----------------
 foo
(1 row)

# other user
$ psql -h localhost -U postgres sandbox -c 'select current_schema';
 current_schema
----------------
 public
(1 row)
```

This is due to the postgres specification that takes the current schema to be the same as the user name.

```
$ psql -h localhost -U foo sandbox -c 'show search_path';
   search_path
-----------------
 "$user", public
(1 row)
```

## Solution

Do not include dynamic current schema in `currentDDLs`, include `public` schema instead. `public` schema can also be excluded, but it will also be included in the `--export` result. If this causes problems, please raise an issue.