### PR TITLE
 [psqldef] Escape ' in strings

### DIFF
--- a/cmd/psqldef/tests.yml
+++ b/cmd/psqldef/tests.yml
@@ -51,6 +51,15 @@ CreateTableWithDefault:
       joined_at timestamp with time zone NOT NULL DEFAULT '0001-01-01 00:00:00'::timestamp without time zone,
       created_at timestamp with time zone DEFAULT now()
     );
+CreateTableWithDefaultContainingQuote:
+  current: |
+    CREATE TABLE test ();
+  desired: |
+    CREATE TABLE test (
+      thing text default 'it''s free real estate'
+    );
+  output: |
+    ALTER TABLE "public"."test" ADD COLUMN "thing" text DEFAULT 'it''s free real estate';
 CreateTableChangeDefaultBoolean:
   current: |
     CREATE TABLE test (
@@ -524,6 +533,20 @@ CommentOnNonStandardDefaultSchema:
     COMMENT ON TABLE foo.users is 'users table updated';
     COMMENT ON COLUMN foo.users.id is 'users id';
   user: psqldef_user
+CommentContainingQuote:
+  current: |
+    CREATE TABLE public.test (
+      email text
+    );
+  desired: |
+    CREATE TABLE public.test (
+      email text
+    );
+    COMMENT ON TABLE public.test is 'World''s best table';
+    COMMENT ON COLUMN public.test.email is 'The user''s contact email address.';
+  output: |
+    COMMENT ON TABLE public.test is 'World''s best table';
+    COMMENT ON COLUMN public.test.email is 'The user''s contact email address.';
 CreateViewCast:
   current: |
     CREATE TABLE "public"."hoge" (

--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -11,6 +11,7 @@ import (
 
 	_ "github.com/lib/pq"
 	"github.com/sqldef/sqldef/database"
+	schemaLib "github.com/sqldef/sqldef/schema"
 )
 
 const indent = "    "
@@ -819,7 +820,7 @@ func (d *PostgresDatabase) getComments(table string) ([]string, error) {
 		if err := tableRows.Scan(&comment); err != nil {
 			return nil, err
 		}
-		ddls = append(ddls, fmt.Sprintf("COMMENT ON TABLE \"%s\".\"%s\" IS '%s';", schema, table, comment))
+		ddls = append(ddls, fmt.Sprintf("COMMENT ON TABLE \"%s\".\"%s\" IS %s;", schema, table, schemaLib.StringConstant(comment)))
 	}
 
 	// Column comments
@@ -847,7 +848,7 @@ func (d *PostgresDatabase) getComments(table string) ([]string, error) {
 		if err := columnRows.Scan(&columnName, &comment); err != nil {
 			return nil, err
 		}
-		ddls = append(ddls, fmt.Sprintf("COMMENT ON COLUMN \"%s\".\"%s\".\"%s\" IS '%s';", schema, table, columnName, comment))
+		ddls = append(ddls, fmt.Sprintf("COMMENT ON COLUMN \"%s\".\"%s\".\"%s\" IS %s;", schema, table, columnName, schemaLib.StringConstant(comment)))
 	}
 
 	return ddls, nil

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -1168,6 +1168,7 @@ func (g *Generator) generateColumnDefinition(column Column, enableUnique bool) (
 	}
 
 	if column.comment != nil {
+		// TODO: Should this use StringConstant?
 		definition += fmt.Sprintf("COMMENT '%s' ", string(column.comment.raw))
 	}
 
@@ -2162,7 +2163,7 @@ func (g *Generator) generateDefaultDefinition(defaultDefinition DefaultDefinitio
 		defaultVal := defaultDefinition.value
 		switch defaultVal.valueType {
 		case ValueTypeStr:
-			return fmt.Sprintf("DEFAULT '%s'", defaultVal.strVal), nil
+			return fmt.Sprintf("DEFAULT %s", StringConstant(defaultVal.strVal)), nil
 		case ValueTypeBool:
 			return fmt.Sprintf("DEFAULT %s", defaultVal.strVal), nil
 		case ValueTypeInt:
@@ -2284,4 +2285,9 @@ func isValidLock(lock string) bool {
 	default:
 		return false
 	}
+}
+
+// Escape a string and add quotes to form a legal SQL string constant.
+func StringConstant(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }

--- a/schema/generator_test.go
+++ b/schema/generator_test.go
@@ -1,0 +1,19 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringConstantSimple(t *testing.T) {
+	assert.Equal(t, StringConstant(""), "''")
+	assert.Equal(t, StringConstant("hello world"), "'hello world'")
+}
+
+func TestStringConstantContainingSingleQuote(t *testing.T) {
+	assert.Equal(t, StringConstant("it's the bee's knees"), "'it''s the bee''s knees'")
+	assert.Equal(t, StringConstant("'"), "''''")
+	assert.Equal(t, StringConstant("''"), "''''''")
+	assert.Equal(t, StringConstant("'example'"), "'''example'''")
+}

--- a/schema/parser.go
+++ b/schema/parser.go
@@ -183,7 +183,7 @@ func parseDDL(mode GeneratorMode, ddl string, stmt parser.Statement, defaultSche
 			}, nil
 		} else {
 			return nil, fmt.Errorf(
-				"unsupported type of DDL action '%s': %s",
+				"unsupported type of DDL action '%d': %s",
 				stmt.Action, ddl,
 			)
 		}


### PR DESCRIPTION
psqldef errors out when a comment contains an apostrophe ('). Similarly, psqldef generates invalid SQL when adding a column with a default value containing an apostrophe. Fix these by escaping apostrophes in SQL string constants.

Unrelatedly, fix incorrect format in some error handling code (schema/parser.go).