### PR TITLE
[psqldef] Fix target schema condition

### DIFF
--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -272,7 +272,7 @@ func (d *PostgresDatabase) types() ([]string, error) {
 		if err := rows.Scan(&typeSchema, &typeName, &labels); err != nil {
 			return nil, err
 		}
-		if containsString(d.config.TargetSchema, typeSchema) {
+		if d.config.TargetSchema != nil && !containsString(d.config.TargetSchema, typeSchema) {
 			continue
 		}
 		enumLabels := []string{}


### PR DESCRIPTION
The change in https://github.com/sqldef/sqldef/pull/532 introduced an update to alter type that considers the schema, but the process of determining the target schema was incorrect, so I fixed it.

## prepare

```yml
target_schema: |
  foo
  bar
```

```sql
create schema foo;
create schema bar;

CREATE TYPE foo.lang AS ENUM (
  'ja',
  'en'
);

CREATE TYPE bar.lang AS ENUM (
  'ja',
  'en'
);
```

```
$ go run ./cmd/psqldef --host localhost --user postgres --config sqldef.yml sandbox --dry-run < schema.sql
create schema foo;
create schema bar;
CREATE TYPE foo.lang AS ENUM (
  'ja',
  'en'
);
CREATE TYPE bar.lang AS ENUM (
  'ja',
  'en'
);
```

## before

```
$ go run ./cmd/psqldef --host localhost --user postgres --config sqldef.yml sandbox --dry-run < schema.sql
-- Apply --
CREATE TYPE foo.lang AS ENUM (
  'ja',
  'en'
);
2024/08/05 16:41:31 pq: type "lang" already exists
exit status 1
```

## after

```
$ go run ./cmd/psqldef --host localhost --user postgres --config sqldef.yml sandbox --dry-run < schema.sql
-- Nothing is modified --
```

Add type:

```sql
...

CREATE TYPE bar.lang AS ENUM (
  'ja',
  'en',
  'de'
);
```

```
-- Apply --
ALTER TYPE bar.lang ADD VALUE 'de';
```