### PR TITLE
[mysqldef] Fix ALGORITHM option being overwritten by LOCK in config

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -136,15 +136,16 @@ func ParseGeneratorConfig(configFile string) GeneratorConfig {
 		algorithm = strings.Trim(config.Algorithm, "\n")
 	}
 
+	var lock string
 	if config.Lock != "" {
-		algorithm = strings.Trim(config.Lock, "\n")
+		lock = strings.Trim(config.Lock, "\n")
 	}
 	return GeneratorConfig{
 		TargetTables:    targetTables,
 		SkipTables:      skipTables,
 		TargetSchema:    targetSchema,
 		Algorithm:       algorithm,
-		Lock:            config.Lock,
+		Lock:            lock,
 		DumpConcurrency: config.DumpConcurrency,
 	}
 }


### PR DESCRIPTION
The previous implementation had a bug where specifying both ALGORITHM and LOCK in the configuration would result in only LOCK being applied. This PR fixes the issue to ensure both options are correctly used when specified.


```yaml
# config.yml
algorithm: inplace
lock: none
```

Before
```sql
ALTER TABLE `users` CHANGE COLUMN `name` `name` varchar(1000) DEFAULT NULL, LOCK=NONE;
```

After
```sql
ALTER TABLE `users` CHANGE COLUMN `name` `name` varchar(1000) DEFAULT NULL, ALGORITHM=INPLACE, LOCK=NONE;
```
