### PR TITLE
Update MSSQL Docker image to resolve GitHub Actions crash

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -19,7 +19,8 @@ services:
     ports:
       - '5432:5432'
   mssql:
-    image: mcr.microsoft.com/mssql/server:2017-latest
+    image: mcr.microsoft.com/mssql/server:2019-CU28-ubuntu-20.04
+    user: root
     environment:
       ACCEPT_EULA: Y
       SA_PASSWORD: Passw0rd


### PR DESCRIPTION
## Problem Statement

As described in [this comment](https://github.com/sqldef/sqldef/pull/560#issuecomment-2370248854), we are currently experiencing issues with MSSQL tests failing on GitHub Actions. The problem appears to be related to the MSSQL Docker image crashing on the ubuntu-latest (20.04) environment used by GitHub Actions.

## Proposed Solution

To address this issue, we propose updating the MSSQL Docker image in our `compose.yml` file to:

- `mcr.microsoft.com/mssql/server:2019-CU28-ubuntu-20.04`

Additionally, we need to set `user: root` for the MSSQL service in the `compose.yml` file. This is necessary for versions 2019 and later to prevent volume mount failures.

These changes aim to resolve the MSSQL test failures on GitHub Actions.
