### PR TITLE
Hokaccha/extension order

### DIFF
--- a/cmd/psqldef/tests.yml
+++ b/cmd/psqldef/tests.yml
@@ -732,6 +732,13 @@ CreateExtensionIfNotExists:
     CREATE EXTENSION IF NOT EXISTS pgcrypto;
   output: |
     CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CreateExtensionOrder:
+  desired: |
+    CREATE TABLE hoge (id UUID DEFAULT gen_random_uuid());
+    CREATE EXTENSION IF NOT EXISTS pgcrypto;
+  output: |
+    CREATE EXTENSION IF NOT EXISTS pgcrypto;
+    CREATE TABLE hoge (id UUID DEFAULT gen_random_uuid());
 CreateViewWithCastCase:
   desired: |
     create table hoge (amount text);

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -109,6 +109,7 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 	// These variables are used to control the output order of the DDL.
 	// `CREATE SCHEMA` should execute first, and DDLs that add indexes and foreign keys should execute last.
 	// Other ddls are stored in interDDLs.
+	createExtensionDDLs := []string{}
 	createSchemaDDLs := []string{}
 	interDDLs := []string{}
 	indexDDLs := []string{}
@@ -187,7 +188,7 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 			if err != nil {
 				return nil, err
 			}
-			interDDLs = append(interDDLs, extensionDDLs...)
+			createExtensionDDLs = append(createExtensionDDLs, extensionDDLs...)
 		case *Schema:
 			schemaDDLs, err := g.generateDDLsForSchema(desired)
 			if err != nil {
@@ -200,6 +201,7 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 	}
 
 	ddls := []string{}
+	ddls = append(ddls, createExtensionDDLs...)
 	ddls = append(ddls, createSchemaDDLs...)
 	ddls = append(ddls, interDDLs...)
 	ddls = append(ddls, indexDDLs...)


### PR DESCRIPTION
Similar to issue #405, the following DDL will fail if the SQL file is split.

```sql
CREATE TABLE hoge (id UUID DEFAULT gen_random_uuid());
CREATE EXTENSION IF NOT EXISTS pgcrypto;
```

This DDL results in the error `pq: function gen_random_uuid() does not exist`. This PR fixes this issue.