### PR TITLE
psqldef: Fix syntax error occurring when using boolean comparisons in CREATE INDEX

### DIFF
--- a/cmd/psqldef/tests.yml
+++ b/cmd/psqldef/tests.yml
@@ -144,6 +144,18 @@ CreateIndexWithCoalesce:
     CREATE INDEX create_index_with_function_call ON users (name, COALESCE(user_name, 'NO_NAME'::TEXT));
   output: |
     CREATE INDEX create_index_with_function_call ON users (name, COALESCE(user_name, 'NO_NAME'::TEXT));
+CreateIndexWithBoolExpr:
+  current: |
+    CREATE TABLE users (
+      is_active BOOLEAN
+    );
+  desired: |
+    CREATE TABLE users (
+      is_active BOOLEAN
+    );
+    CREATE INDEX create_index_with_bool ON users ((CASE WHEN is_active IS TRUE THEN 1 ELSE 0 END));
+  output: |
+    CREATE INDEX create_index_with_bool ON users ((CASE WHEN is_active IS TRUE THEN 1 ELSE 0 END));
 AlterTypeAddValue:
   current: |
     CREATE TYPE eventtype AS ENUM (

--- a/database/postgres/parser.go
+++ b/database/postgres/parser.go
@@ -682,6 +682,46 @@ func (p PostgresParser) parseExpr(stmt *pgquery.Node) (parser.Expr, error) {
 			Name:  parser.NewColIdent("coalesce"),
 			Exprs: selectExprs,
 		}, nil
+	case *pgquery.Node_BooleanTest:
+		expr, err := p.parseExpr(node.BooleanTest.Arg)
+		if err != nil {
+			return nil, err
+		}
+
+		switch node.BooleanTest.Booltesttype {
+		case pgquery.BoolTestType_IS_TRUE:
+			return &parser.IsExpr{
+				Expr:     expr,
+				Operator: parser.IsTrueStr,
+			}, nil
+		case pgquery.BoolTestType_IS_NOT_TRUE:
+			return &parser.IsExpr{
+				Expr:     expr,
+				Operator: parser.IsNotTrueStr,
+			}, nil
+		case pgquery.BoolTestType_IS_FALSE:
+			return &parser.IsExpr{
+				Expr:     expr,
+				Operator: parser.IsFalseStr,
+			}, nil
+		case pgquery.BoolTestType_IS_NOT_FALSE:
+			return &parser.IsExpr{
+				Expr:     expr,
+				Operator: parser.IsNotFalseStr,
+			}, nil
+		case pgquery.BoolTestType_IS_UNKNOWN:
+			return &parser.IsExpr{
+				Expr:     expr,
+				Operator: parser.IsUnknownStr,
+			}, nil
+		case pgquery.BoolTestType_IS_NOT_UNKNOWN:
+			return &parser.IsExpr{
+				Expr:     expr,
+				Operator: parser.IsNotUnknownStr,
+			}, nil
+		default:
+			return nil, fmt.Errorf("unexpected boolean test type: %d", node.BooleanTest.Booltesttype)
+		}
 	default:
 		return nil, fmt.Errorf("unknown node in parseExpr: %#v", node)
 	}

--- a/database/postgres/tests.yml
+++ b/database/postgres/tests.yml
@@ -205,6 +205,13 @@ CreateIndexWithCoalesce:
     );
     CREATE INDEX create_index_with_function_call ON users (name, COALESCE(user_name, 'NO_NAME'::TEXT));
 
+CreateIndexWithBoolExpr:
+  sql: |
+    CREATE TABLE users (
+      is_active BOOLEAN
+    );
+    CREATE INDEX create_index_with_bool ON users ((CASE WHEN is_active IS TRUE THEN 1 ELSE 0 END));
+
 CreateSchema:
   sql: |
     CREATE SCHEMA foo;

--- a/parser/node.go
+++ b/parser/node.go
@@ -1505,12 +1505,14 @@ type IsExpr struct {
 
 // IsExpr.Operator
 const (
-	IsNullStr     = "is null"
-	IsNotNullStr  = "is not null"
-	IsTrueStr     = "is true"
-	IsNotTrueStr  = "is not true"
-	IsFalseStr    = "is false"
-	IsNotFalseStr = "is not false"
+	IsNullStr       = "is null"
+	IsNotNullStr    = "is not null"
+	IsTrueStr       = "is true"
+	IsNotTrueStr    = "is not true"
+	IsFalseStr      = "is false"
+	IsNotFalseStr   = "is not false"
+	IsUnknownStr    = "is unknown"
+	IsNotUnknownStr = "is not unknown"
 )
 
 // Format formats the node.


### PR DESCRIPTION
This pull request addresses an issue where a syntax error occurs during the CREATE INDEX operation when using boolean comparisons such as `IS TRUE` . The problem was identified in the parsing process, which did not correctly handle these types of expressions.

This update specifically addresses PostgreSQL and its handling of boolean comparisons in CREATE INDEX. It is currently unclear if similar support or issues exist in other database engines like MySQL.

## Test results
### Before

```
$ go test -v ./cmd/psqldef/ -run=TestApply/CreateIndexWithBoolExpr
=== RUN   TestApply
=== RUN   TestApply/CreateIndexWithBoolExpr
    testutils.go:105: found syntax error when parsing DDL "CREATE INDEX create_index_with_bool ON users ((CASE WHEN is_active IS TRUE THEN 1 ELSE 0 END))": syntax error at position 48
--- FAIL: TestApply (1.06s)
    --- FAIL: TestApply/CreateIndexWithBoolExpr (1.01s)
FAIL
FAIL    github.com/sqldef/sqldef/cmd/psqldef    4.185s
FAIL
```

```
go test -v ./database/postgres/ -run=TestParse/CreateIndexWithBoolExpr
=== RUN   TestParse
=== RUN   TestParse/CreateIndexWithBoolExpr
    parser_test.go:27: unknown node in parseExpr: &pg_query.Node_BooleanTest{BooleanTest:(*pg_query.BooleanTest)(0x1400c779480)}
--- FAIL: TestParse (0.48s)
    --- FAIL: TestParse/CreateIndexWithBoolExpr (0.48s)
FAIL
FAIL    github.com/sqldef/sqldef/database/postgres      0.858s
FAIL
```

### After

```
go test -v ./cmd/psqldef/ -run=TestApply/CreateIndexWithBoolExpr
=== RUN   TestApply
=== RUN   TestApply/CreateIndexWithBoolExpr
--- PASS: TestApply (1.07s)
    --- PASS: TestApply/CreateIndexWithBoolExpr (1.02s)
PASS
ok      github.com/sqldef/sqldef/cmd/psqldef    4.277s
```

```
go test -v ./database/postgres/ -run=TestParse/CreateIndexWithBoolExpr
=== RUN   TestParse
=== RUN   TestParse/CreateIndexWithBoolExpr
--- PASS: TestParse (0.49s)
    --- PASS: TestParse/CreateIndexWithBoolExpr (0.49s)
PASS
ok      github.com/sqldef/sqldef/database/postgres      0.885s
```