### PR TITLE
[psqldef] Fix missing columns and comments in partition tables

### DIFF
--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -441,7 +441,7 @@ func (d *PostgresDatabase) getColumns(table string) ([]column, error) {
 	    LEFT JOIN pg_attrdef d ON d.adrelid = c.oid AND d.adnum = f.attnum
 	    LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
 	    LEFT JOIN information_schema.columns s ON s.column_name = f.attname AND s.table_name = c.relname AND s.table_schema = n.nspname
-	    WHERE c.relkind = 'r'::char
+	    WHERE c.relkind in ('r', 'p')
 	    AND n.nspname = $1
 	    AND c.relname = $2
 	    AND f.attnum > 0
@@ -813,7 +813,7 @@ func (d *PostgresDatabase) getComments(table string) ([]string, error) {
 		SELECT obj_description(c.oid)
 		FROM pg_class c
 		JOIN pg_namespace n ON n.oid = c.relnamespace
-		WHERE c.relkind = 'r'
+		WHERE c.relkind in ('r', 'p')
 		AND obj_description(c.oid) IS NOT NULL
 		AND n.nspname = $1
 		AND c.relname = $2


### PR DESCRIPTION
This fixes #594

Partition table support looks still not perfect, but I just confirmed psqldef can migrate my testing table schema created with 'PARTITION BY' clause.
I think this patch improves feasibility a little bit.

Thanks a lot for your hard work !