### PR TITLE
[psqldef] Recognize schema for view/materializedView

### DIFF
--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -144,6 +144,9 @@ func (d *PostgresDatabase) views() ([]string, error) {
 		if err := rows.Scan(&schema, &name, &definition); err != nil {
 			return nil, err
 		}
+		if d.config.TargetSchema != nil && !containsString(d.config.TargetSchema, schema) {
+			continue
+		}
 		definition = strings.TrimSpace(definition)
 		definition = strings.ReplaceAll(definition, "\n", "")
 		definition = suffixSemicolon.ReplaceAllString(definition, "")
@@ -178,6 +181,9 @@ func (d *PostgresDatabase) materializedViews() ([]string, error) {
 		var schema, name, definition string
 		if err := rows.Scan(&schema, &name, &definition); err != nil {
 			return nil, err
+		}
+		if d.config.TargetSchema != nil && !containsString(d.config.TargetSchema, schema) {
+			continue
 		}
 		definition = strings.TrimSpace(definition)
 		definition = strings.ReplaceAll(definition, "\n", "")


### PR DESCRIPTION
[psqldef] Recognize schema for view/materializedView.

This fixes the bug that generates wrong alter statements for those when defined in a different schema.

<details>
<summary>outdated reproduction step</summary>
Creating a test in tests.yml is hard currently because it cannot set up schema outside of sqldef DDL.
"expected nothing is modified" error happens. 
And also, tests.yml doesn't support tests using a config.
So, I attached reproduction steps.

## Reproduction

### Preparation

Create following three files and initialize database.

* init.sql
* config.yml
* schema.sql

init.sql
```
DROP DATABASE IF EXISTS sandbox;
CREATE DATABASE sandbox;
\c sandbox;
CREATE SCHEMA foo;

CREATE TABLE foo.users (
  id BIGINT PRIMARY KEY,
  name character varying(100)
);
CREATE TABLE foo.posts (
  id BIGINT PRIMARY KEY,
  name character varying(100),
  user_id BIGINT,
  is_deleted boolean
);
CREATE MATERIALIZED VIEW foo.view_user_posts AS SELECT p.id FROM (foo.posts as p JOIN foo.users as u ON ((p.user_id = u.id)));
```

config.yml
```
target_schema: |
  bar
```

schema.sql
```
CREATE SCHEMA bar;
CREATE TABLE bar.companies (
  id BIGINT PRIMARY KEY
);
```

initialize database.
```
psql -h localhost -U postgres < init.sql
```

## Expectation (After)

no alter statements about view/materializedView in different schema

```
$ go run ./cmd/psqldef --host localhost --user postgres --config config.yml sandbox < schema.sql
-- Apply --
CREATE SCHEMA bar;
CREATE TABLE bar.companies (
  id BIGINT PRIMARY KEY
);
```

## Actual (Before)

Unexpectedly, sqldef drops foo.view_user_posts.

```
$ go run ./cmd/psqldef --host localhost --user postgres --config config.yml sandbox < schema.sql
-- Apply --
CREATE SCHEMA bar;
CREATE TABLE bar.companies (
  id BIGINT PRIMARY KEY
);
DROP MATERIALIZED VIEW "foo"."view_user_posts";
```

</details>


