### PR TITLE
Add separate Docker Images for each sqldef command

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,6 +18,9 @@ jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tool: [mysqldef, sqlite3def, mssqldef, psqldef]
     permissions:
       packages: write
       contents: read
@@ -43,7 +46,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
-          images: sqldef/sqldef
+          images: sqldef/${{ matrix.tool }}
           tags: |
               type=ref,event=branch
               type=semver,pattern={{version}}
@@ -54,8 +57,8 @@ jobs:
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           context: .
-          file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
+          build-args: SQLDEF_TOOL=${{ matrix.tool }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -63,6 +66,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: index.docker.io/sqldef/sqldef
+          subject-name: index.docker.io/sqldef/${{ matrix.tool }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM  golang:1.24.1-bookworm as builder
+FROM golang:1.24.1-bookworm AS builder
 
 WORKDIR /work
 COPY . .
@@ -7,7 +7,7 @@ RUN go install
 RUN uname
 RUN make && build/$(go env GOOS)-$(go env GOARCH)/sqlite3def --version
 
-FROM alpine as final
+FROM alpine AS final
 
 RUN mkdir -p /usr/local/bin
 COPY --from=builder /work/build/*/* /usr/local/bin

--- a/Makefile
+++ b/Makefile
@@ -14,16 +14,27 @@ else
   SUFFIX=
 endif
 
-.PHONY: all build clean deps goyacc package package-zip package-targz parser
+.PHONY: all build clean deps goyacc package package-zip package-targz parser build-mysqldef build-sqlite3def build-mssqldef build-psqldef
 
 all: build
 
-build:
+build: build-mysqldef build-sqlite3def build-mssqldef build-psqldef
+
+build-mysqldef:
 	mkdir -p $(BUILD_DIR)
-	cd cmd/mysqldef    && CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GOFLAGS) -o ../../$(BUILD_DIR)/mysqldef$(SUFFIX)
-	cd cmd/sqlite3def  && CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GOFLAGS) -o ../../$(BUILD_DIR)/sqlite3def$(SUFFIX)
-	cd cmd/mssqldef    && CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GOFLAGS) -o ../../$(BUILD_DIR)/mssqldef$(SUFFIX)
-	cd cmd/psqldef     && CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GOFLAGS) -o ../../$(BUILD_DIR)/psqldef$(SUFFIX)	
+	cd cmd/mysqldef && CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GOFLAGS) -o ../../$(BUILD_DIR)/mysqldef$(SUFFIX)
+
+build-sqlite3def:
+	mkdir -p $(BUILD_DIR)
+	cd cmd/sqlite3def && CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GOFLAGS) -o ../../$(BUILD_DIR)/sqlite3def$(SUFFIX)
+
+build-mssqldef:
+	mkdir -p $(BUILD_DIR)
+	cd cmd/mssqldef && CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GOFLAGS) -o ../../$(BUILD_DIR)/mssqldef$(SUFFIX)
+
+build-psqldef:
+	mkdir -p $(BUILD_DIR)
+	cd cmd/psqldef && CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GOFLAGS) -o ../../$(BUILD_DIR)/psqldef$(SUFFIX)
 
 clean:
 	rm -rf build package


### PR DESCRIPTION
This pull request introduces individual Docker images for each sqldef command instead of packaging multiple commands into a single image. By separating the images, each one remains lightweight and focused, which can simplify usage for those who only need a specific command.
Please review the changes, and let me know if you have any feedback or suggestions. Thank you!

This closes #661 

## Usage
```
# export
docker run --rm sqldef/mysqldef -u root -h hostname dbname --export > schema.sql

# import
docker run -i --rm sqldef/mysqldef -u root -h hostname dbname < schema.sql
```
