### PR TITLE
Update github actions job runner

### DIFF
--- a/.github/workflows/sqldef.yml
+++ b/.github/workflows/sqldef.yml
@@ -12,7 +12,7 @@ on:
       - reopened
 jobs:
   test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         target:

--- a/.github/workflows/sqldef.yml
+++ b/.github/workflows/sqldef.yml
@@ -12,7 +12,7 @@ on:
       - reopened
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         target:

--- a/compose.yml
+++ b/compose.yml
@@ -19,7 +19,7 @@ services:
     ports:
       - '5432:5432'
   mssql:
-    image: mcr.microsoft.com/mssql/server:2019-CU28-ubuntu-24.04
+    image: mcr.microsoft.com/mssql/server:2019-CU28-ubuntu-20.04
     user: root
     environment:
       ACCEPT_EULA: Y

--- a/compose.yml
+++ b/compose.yml
@@ -19,7 +19,7 @@ services:
     ports:
       - '5432:5432'
   mssql:
-    image: mcr.microsoft.com/mssql/server:2019-CU28-ubuntu-20.04
+    image: mcr.microsoft.com/mssql/server:2019-CU28-ubuntu-24.04
     user: root
     environment:
       ACCEPT_EULA: Y


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to use a newer version of the Ubuntu runner.

Because https://github.com/sqldef/sqldef/actions/runs/14631630554/job/41054848619

> This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101

Please review the changes, and let me know if you have any feedback or suggestions. Thank you!
