### PR TITLE
opt/Optimize column lookup with map to improve DDL diff performance

### DIFF
--- a/schema/ast.go
+++ b/schema/ast.go
@@ -50,7 +50,7 @@ type AddPolicy struct {
 
 type Table struct {
 	name        string
-	columns     []Column
+	columns     map[string]*Column
 	indexes     []Index
 	checks      []CheckDefinition
 	foreignKeys []ForeignKey


### PR DESCRIPTION
### Summary

This PR optimizes performance by replacing column lookups in []Column with a map[string]*Column, reducing the time complexity of column access from O(n) to O(1).

### Changes

- Replace []Column with map[string]*Column in the Table struct.
- Adjust column ordering logic (e.g., for MySQL's AFTER) by storing columns in a separate slice for ordered iteration.
- Simplify findColumnByName to use direct map access.
- Clean up legacy functions like convertColumnsToColumnNames.
