### PR TITLE
feat/extend enable-drop-table to enable-drop option which block all drop ddl

### DIFF
--- a/cmd/mssqldef/mssqldef.go
+++ b/cmd/mssqldef/mssqldef.go
@@ -22,17 +22,17 @@ var version string
 // TODO: Support `sqldef schema.sql -opt val...`
 func parseOptions(args []string) (database.Config, *sqldef.Options) {
 	var opts struct {
-		User            string   `short:"U" long:"user" description:"MSSQL user name" value-name:"user_name" default:"sa"`
-		Password        string   `short:"P" long:"password" description:"MSSQL user password, overridden by $MSSQL_PWD" value-name:"password"`
-		Host            string   `short:"h" long:"host" description:"Host to connect to the MSSQL server" value-name:"host_name" default:"127.0.0.1"`
-		Port            uint     `short:"p" long:"port" description:"Port used for the connection" value-name:"port_num" default:"1433"`
-		Prompt          bool     `long:"password-prompt" description:"Force MSSQL user password prompt"`
-		File            []string `long:"file" description:"Read desired SQL from the file, rather than stdin" value-name:"sql_file" default:"-"`
-		DryRun          bool     `long:"dry-run" description:"Don't run DDLs but just show them"`
-		Export          bool     `long:"export" description:"Just dump the current schema to stdout"`
-		EnableDropTable bool     `long:"enable-drop-table" description:"Enable destructive changes such as DROP (enable only table drops)"`
-		Help            bool     `long:"help" description:"Show this help"`
-		Version         bool     `long:"version" description:"Show this version"`
+		User       string   `short:"U" long:"user" description:"MSSQL user name" value-name:"user_name" default:"sa"`
+		Password   string   `short:"P" long:"password" description:"MSSQL user password, overridden by $MSSQL_PWD" value-name:"password"`
+		Host       string   `short:"h" long:"host" description:"Host to connect to the MSSQL server" value-name:"host_name" default:"127.0.0.1"`
+		Port       uint     `short:"p" long:"port" description:"Port used for the connection" value-name:"port_num" default:"1433"`
+		Prompt     bool     `long:"password-prompt" description:"Force MSSQL user password prompt"`
+		File       []string `long:"file" description:"Read desired SQL from the file, rather than stdin" value-name:"sql_file" default:"-"`
+		DryRun     bool     `long:"dry-run" description:"Don't run DDLs but just show them"`
+		Export     bool     `long:"export" description:"Just dump the current schema to stdout"`
+		EnableDrop bool     `long:"enable-drop" description:"Enable destructive changes such as DROP for TABLE, SCHEMA, ROLE, USER, FUNCTION, PROCEDURE, TRIGGER, VIEW, INDEX, SEQUENCE, TYPE"`
+		Help       bool     `long:"help" description:"Show this help"`
+		Version    bool     `long:"version" description:"Show this version"`
 	}
 
 	parser := flags.NewParser(&opts, flags.None)
@@ -63,10 +63,10 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 	}
 
 	options := sqldef.Options{
-		DesiredDDLs:     desiredDDLs,
-		DryRun:          opts.DryRun,
-		Export:          opts.Export,
-		EnableDropTable: opts.EnableDropTable,
+		DesiredDDLs: desiredDDLs,
+		DryRun:      opts.DryRun,
+		Export:      opts.Export,
+		EnableDrop:  opts.EnableDrop,
 	}
 
 	if len(args) == 0 {

--- a/cmd/mysqldef/mysqldef.go
+++ b/cmd/mysqldef/mysqldef.go
@@ -36,7 +36,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		File                  []string `long:"file" description:"Read desired SQL from the file, rather than stdin" value-name:"sql_file" default:"-"`
 		DryRun                bool     `long:"dry-run" description:"Don't run DDLs but just show them"`
 		Export                bool     `long:"export" description:"Just dump the current schema to stdout"`
-		EnableDropTable       bool     `long:"enable-drop-table" description:"Enable destructive changes such as DROP (enable only table drops)"`
+		EnableDrop            bool     `long:"enable-drop" description:"Enable destructive changes such as DROP for TABLE, SCHEMA, ROLE, USER, FUNCTION, PROCEDURE, TRIGGER, VIEW, INDEX, SEQUENCE, TYPE"`
 		SkipView              bool     `long:"skip-view" description:"Skip managing views (temporary feature, to be removed later)"`
 		BeforeApply           string   `long:"before-apply" description:"Execute the given string before applying the regular DDLs"`
 		Config                string   `long:"config" description:"YAML file to specify: target_tables, skip_tables, algorithm, lock"`
@@ -72,12 +72,12 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 	}
 
 	options := sqldef.Options{
-		DesiredDDLs:     desiredDDLs,
-		DryRun:          opts.DryRun,
-		Export:          opts.Export,
-		EnableDropTable: opts.EnableDropTable,
-		BeforeApply:     opts.BeforeApply,
-		Config:          database.ParseGeneratorConfig(opts.Config),
+		DesiredDDLs: desiredDDLs,
+		DryRun:      opts.DryRun,
+		Export:      opts.Export,
+		EnableDrop:  opts.EnableDrop,
+		BeforeApply: opts.BeforeApply,
+		Config:      database.ParseGeneratorConfig(opts.Config),
 	}
 
 	if len(args) == 0 {

--- a/cmd/psqldef/psqldef.go
+++ b/cmd/psqldef/psqldef.go
@@ -23,21 +23,21 @@ var version string
 // TODO: Support `sqldef schema.sql -opt val...`
 func parseOptions(args []string) (database.Config, *sqldef.Options) {
 	var opts struct {
-		User            string   `short:"U" long:"user" description:"PostgreSQL user name" value-name:"username" default:"postgres"`
-		Password        string   `short:"W" long:"password" description:"PostgreSQL user password, overridden by $PGPASSWORD" value-name:"password"`
-		Host            string   `short:"h" long:"host" description:"Host or socket directory to connect to the PostgreSQL server" value-name:"hostname" default:"127.0.0.1"`
-		Port            uint     `short:"p" long:"port" description:"Port used for the connection" value-name:"port" default:"5432"`
-		Prompt          bool     `long:"password-prompt" description:"Force PostgreSQL user password prompt"`
-		File            []string `short:"f" long:"file" description:"Read desired SQL from the file, rather than stdin" value-name:"filename" default:"-"`
-		DryRun          bool     `long:"dry-run" description:"Don't run DDLs but just show them"`
-		Export          bool     `long:"export" description:"Just dump the current schema to stdout"`
-		EnableDropTable bool     `long:"enable-drop-table" description:"Enable destructive changes such as DROP (enable only table drops)"`
-		SkipView        bool     `long:"skip-view" description:"Skip managing views/materialized views"`
-		SkipExtension   bool     `long:"skip-extension" description:"Skip managing extensions"`
-		BeforeApply     string   `long:"before-apply" description:"Execute the given string before applying the regular DDLs"`
-		Config          string   `long:"config" description:"YAML file to specify: target_tables, skip_tables, skip_views, target_schema"`
-		Help            bool     `long:"help" description:"Show this help"`
-		Version         bool     `long:"version" description:"Show this version"`
+		User          string   `short:"U" long:"user" description:"PostgreSQL user name" value-name:"username" default:"postgres"`
+		Password      string   `short:"W" long:"password" description:"PostgreSQL user password, overridden by $PGPASSWORD" value-name:"password"`
+		Host          string   `short:"h" long:"host" description:"Host or socket directory to connect to the PostgreSQL server" value-name:"hostname" default:"127.0.0.1"`
+		Port          uint     `short:"p" long:"port" description:"Port used for the connection" value-name:"port" default:"5432"`
+		Prompt        bool     `long:"password-prompt" description:"Force PostgreSQL user password prompt"`
+		File          []string `short:"f" long:"file" description:"Read desired SQL from the file, rather than stdin" value-name:"filename" default:"-"`
+		DryRun        bool     `long:"dry-run" description:"Don't run DDLs but just show them"`
+		Export        bool     `long:"export" description:"Just dump the current schema to stdout"`
+		EnableDrop    bool     `long:"enable-drop" description:"Enable destructive changes such as DROP for TABLE, SCHEMA, ROLE, USER, FUNCTION, PROCEDURE, TRIGGER, VIEW, INDEX, SEQUENCE, TYPE"`
+		SkipView      bool     `long:"skip-view" description:"Skip managing views/materialized views"`
+		SkipExtension bool     `long:"skip-extension" description:"Skip managing extensions"`
+		BeforeApply   string   `long:"before-apply" description:"Execute the given string before applying the regular DDLs"`
+		Config        string   `long:"config" description:"YAML file to specify: target_tables, skip_tables, skip_views, target_schema"`
+		Help          bool     `long:"help" description:"Show this help"`
+		Version       bool     `long:"version" description:"Show this version"`
 	}
 
 	parser := flags.NewParser(&opts, flags.None)
@@ -68,12 +68,12 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 	}
 
 	options := sqldef.Options{
-		DesiredDDLs:     desiredDDLs,
-		DryRun:          opts.DryRun,
-		Export:          opts.Export,
-		EnableDropTable: opts.EnableDropTable,
-		BeforeApply:     opts.BeforeApply,
-		Config:          database.ParseGeneratorConfig(opts.Config),
+		DesiredDDLs: desiredDDLs,
+		DryRun:      opts.DryRun,
+		Export:      opts.Export,
+		EnableDrop:  opts.EnableDrop,
+		BeforeApply: opts.BeforeApply,
+		Config:      database.ParseGeneratorConfig(opts.Config),
 	}
 
 	if len(args) == 0 {

--- a/cmd/sqlite3def/sqlite3def.go
+++ b/cmd/sqlite3def/sqlite3def.go
@@ -21,13 +21,13 @@ var version string
 // TODO: Support `sqldef schema.sql -opt val...`
 func parseOptions(args []string) (database.Config, *sqldef.Options) {
 	var opts struct {
-		File            []string `short:"f" long:"file" description:"Read desired SQL from the file, rather than stdin" value-name:"filename" default:"-"`
-		DryRun          bool     `long:"dry-run" description:"Don't run DDLs but just show them"`
-		Export          bool     `long:"export" description:"Just dump the current schema to stdout"`
-		EnableDropTable bool     `long:"enable-drop-table" description:"Enable destructive changes such as DROP (enable only table drops)"`
-		Config          string   `long:"config" description:"YAML file to specify: target_tables, skip_tables"`
-		Help            bool     `long:"help" description:"Show this help"`
-		Version         bool     `long:"version" description:"Show this version"`
+		File       []string `short:"f" long:"file" description:"Read desired SQL from the file, rather than stdin" value-name:"filename" default:"-"`
+		DryRun     bool     `long:"dry-run" description:"Don't run DDLs but just show them"`
+		Export     bool     `long:"export" description:"Just dump the current schema to stdout"`
+		EnableDrop bool     `long:"enable-drop" description:"Enable destructive changes such as DROP for TABLE, SCHEMA, ROLE, USER, FUNCTION, PROCEDURE, TRIGGER, VIEW, INDEX, SEQUENCE, TYPE"`
+		Config     string   `long:"config" description:"YAML file to specify: target_tables, skip_tables"`
+		Help       bool     `long:"help" description:"Show this help"`
+		Version    bool     `long:"version" description:"Show this version"`
 	}
 
 	parser := flags.NewParser(&opts, flags.None)
@@ -58,11 +58,11 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 	}
 
 	options := sqldef.Options{
-		DesiredDDLs:     desiredDDLs,
-		DryRun:          opts.DryRun,
-		Export:          opts.Export,
-		EnableDropTable: opts.EnableDropTable,
-		Config:          database.ParseGeneratorConfig(opts.Config),
+		DesiredDDLs: desiredDDLs,
+		DryRun:      opts.DryRun,
+		Export:      opts.Export,
+		EnableDrop:  opts.EnableDrop,
+		Config:      database.ParseGeneratorConfig(opts.Config),
 	}
 
 	if len(args) == 0 {

--- a/database/database.go
+++ b/database/database.go
@@ -52,7 +52,7 @@ type Database interface {
 	GetDefaultSchema() string
 }
 
-func RunDDLs(d Database, ddls []string, enableDropTable bool, beforeApply string, ddlSuffix string) error {
+func RunDDLs(d Database, ddls []string, enableDrop bool, beforeApply string, ddlSuffix string) error {
 	transaction, err := d.DB().Begin()
 	if err != nil {
 		return err
@@ -66,7 +66,30 @@ func RunDDLs(d Database, ddls []string, enableDropTable bool, beforeApply string
 		}
 	}
 	for _, ddl := range ddls {
-		if !enableDropTable && strings.Contains(ddl, "DROP TABLE") {
+		// Skip the DDL contain if enableDrop is true:
+		// 1. DROP TABLE
+		// 2. DROP SCHEMA
+		// 3. DROP ROLE / USER
+		// 4. DROP FUNCTION / PROCEDURE
+		// 5. DROP TRIGGER
+		// less dangerous DDLs
+		// 6. DROP VIEW
+		// 7. DROP INDEX
+		// 8. DROP SEQUENCE
+		// 9. DROP TYPE
+		// 10. DROP MATERIALIZED VIEW
+		if !enableDrop && (strings.Contains(ddl, "DROP TABLE") ||
+			strings.Contains(ddl, "DROP) SCHEMA") ||
+			strings.Contains(ddl, "DROP ROLE") ||
+			strings.Contains(ddl, "DROP USER") ||
+			strings.Contains(ddl, "DROP FUNCTION") ||
+			strings.Contains(ddl, "DROP PROCEDURE") ||
+			strings.Contains(ddl, "DROP TRIGGER") ||
+			strings.Contains(ddl, "DROP VIEW") ||
+			strings.Contains(ddl, "DROP MATERIALIZED VIEW") ||
+			strings.Contains(ddl, "DROP INDEX") ||
+			strings.Contains(ddl, "DROP SEQUENCE") ||
+			strings.Contains(ddl, "DROP TYPE")) {
 			fmt.Printf("-- Skipped: %s;\n", ddl)
 			continue
 		}

--- a/database/database.go
+++ b/database/database.go
@@ -79,7 +79,7 @@ func RunDDLs(d Database, ddls []string, enableDrop bool, beforeApply string, ddl
 		// 9. DROP TYPE
 		// 10. DROP MATERIALIZED VIEW
 		if !enableDrop && (strings.Contains(ddl, "DROP TABLE") ||
-			strings.Contains(ddl, "DROP) SCHEMA") ||
+			strings.Contains(ddl, "DROP SCHEMA") ||
 			strings.Contains(ddl, "DROP ROLE") ||
 			strings.Contains(ddl, "DROP USER") ||
 			strings.Contains(ddl, "DROP FUNCTION") ||

--- a/sqldef.go
+++ b/sqldef.go
@@ -12,13 +12,13 @@ import (
 )
 
 type Options struct {
-	DesiredDDLs     string
-	CurrentFile     string
-	DryRun          bool
-	Export          bool
-	EnableDropTable bool
-	BeforeApply     string
-	Config          database.GeneratorConfig
+	DesiredDDLs string
+	CurrentFile string
+	DryRun      bool
+	Export      bool
+	EnableDrop  bool
+	BeforeApply string
+	Config      database.GeneratorConfig
 }
 
 // Main function shared by all commands
@@ -69,11 +69,11 @@ func Run(generatorMode schema.GeneratorMode, db database.Database, sqlParser dat
 	}
 
 	if options.DryRun || len(options.CurrentFile) > 0 {
-		showDDLs(ddls, options.EnableDropTable, options.BeforeApply, ddlSuffix)
+		showDDLs(ddls, options.EnableDrop, options.BeforeApply, ddlSuffix)
 		return
 	}
 
-	err = database.RunDDLs(db, ddls, options.EnableDropTable, options.BeforeApply, ddlSuffix)
+	err = database.RunDDLs(db, ddls, options.EnableDrop, options.BeforeApply, ddlSuffix)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Discussion: https://github.com/sqldef/sqldef/discussions/677

To extend the `enable-drop-table` to `enable-drop` option.

Skip the DDL contain if `enableDrop` is true:
1. DROP TABLE
2. DROP SCHEMA
3. DROP ROLE / USER
4. DROP FUNCTION / PROCEDURE
5. DROP TRIGGER

Currently also include less dangerous DDLs: 
6. DROP VIEW
7. DROP INDEX
8. DROP SEQUENCE
9. DROP TYPE
10. DROP MATERIALIZED VIEW