### PR TITLE
Fix schema qualification for enum types in ALTER TABLE ADD COLUMN

### DIFF
--- a/cmd/psqldef/tests.yml
+++ b/cmd/psqldef/tests.yml
@@ -208,6 +208,28 @@ AlterTypeAddValueWithSameTypeNameInDifferentSchema:
   output: |
     ALTER TYPE schema2.lang ADD VALUE 'de';
   min_version: '12'
+AddEnumTypeColumn:
+  current: |
+    CREATE SCHEMA s;
+    CREATE TABLE s.users (
+      id UUID NOT NULL PRIMARY KEY
+    );
+  desired: |
+    CREATE TYPE s.lang AS ENUM (
+      'ja',
+      'en'
+    );
+    CREATE TABLE s.users (
+      id UUID NOT NULL PRIMARY KEY,
+      lang s.lang NOT NULL
+    );
+  output: |
+    CREATE TYPE s.lang AS ENUM (
+      'ja',
+      'en'
+    );
+    ALTER TABLE "s"."users" ADD COLUMN "lang" s.lang NOT NULL;
+
 UUIDCast:
   desired: |
     CREATE TABLE public.test_table (

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -1168,20 +1168,30 @@ func generateDataType(column Column) string {
 		suffix += "[]"
 	}
 
+	// Determine the full type name including schema qualification
+	typeName := column.typeName
+	// Only qualify type names with schema when:
+	// 1. references is not empty and not just "public."
+	// 2. the type name doesn't already contain a dot
+	// 3. it's not a built-in type (built-in types shouldn't have references set to non-empty schema)
+	if column.references != "" && column.references != "public." && !strings.Contains(typeName, ".") {
+		typeName = column.references + typeName
+	}
+
 	if column.displayWidth != nil {
-		return fmt.Sprintf("%s(%s)%s", column.typeName, string(column.displayWidth.raw), suffix)
+		return fmt.Sprintf("%s(%s)%s", typeName, string(column.displayWidth.raw), suffix)
 	} else if column.length != nil {
 		if column.scale != nil {
-			return fmt.Sprintf("%s(%s, %s)%s", column.typeName, string(column.length.raw), string(column.scale.raw), suffix)
+			return fmt.Sprintf("%s(%s, %s)%s", typeName, string(column.length.raw), string(column.scale.raw), suffix)
 		} else {
-			return fmt.Sprintf("%s(%s)%s", column.typeName, string(column.length.raw), suffix)
+			return fmt.Sprintf("%s(%s)%s", typeName, string(column.length.raw), suffix)
 		}
 	} else {
 		switch column.typeName {
 		case "enum", "set":
 			return fmt.Sprintf("%s(%s)%s", column.typeName, strings.Join(column.enumValues, ", "), suffix)
 		default:
-			return fmt.Sprintf("%s%s", column.typeName, suffix)
+			return fmt.Sprintf("%s%s", typeName, suffix)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Fix missing schema qualification for enum types when generating ALTER TABLE ADD COLUMN statements
- Ensure user-defined types from non-default schemas are properly qualified while keeping built-in types unqualified

## Test plan
- [x] Added test case `AddEnumTypeColumn` that verifies enum types are correctly schema-qualified
- [x] Verified existing tests pass to ensure no regressions with built-in types
- [x] Confirmed the generated SQL executes without PostgreSQL errors

🤖 Generated with [Claude Code](https://claude.ai/code)