### PR TITLE
Add `/v2` suffix to module name for Go Modules v2 compatibility

### DIFF
--- a/cmd/mssqldef/mssqldef.go
+++ b/cmd/mssqldef/mssqldef.go
@@ -8,11 +8,11 @@ import (
 	"syscall"
 
 	"github.com/jessevdk/go-flags"
-	"github.com/sqldef/sqldef"
-	"github.com/sqldef/sqldef/database"
-	"github.com/sqldef/sqldef/database/file"
-	"github.com/sqldef/sqldef/database/mssql"
-	"github.com/sqldef/sqldef/schema"
+	"github.com/sqldef/sqldef/v2"
+	"github.com/sqldef/sqldef/v2/database"
+	"github.com/sqldef/sqldef/v2/database/file"
+	"github.com/sqldef/sqldef/v2/database/mssql"
+	"github.com/sqldef/sqldef/v2/schema"
 	"golang.org/x/term"
 )
 

--- a/cmd/mssqldef/mssqldef_test.go
+++ b/cmd/mssqldef/mssqldef_test.go
@@ -13,10 +13,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sqldef/sqldef/cmd/testutils"
-	"github.com/sqldef/sqldef/database"
-	"github.com/sqldef/sqldef/database/mssql"
-	"github.com/sqldef/sqldef/schema"
+	"github.com/sqldef/sqldef/v2/cmd/testutils"
+	"github.com/sqldef/sqldef/v2/database"
+	"github.com/sqldef/sqldef/v2/database/mssql"
+	"github.com/sqldef/sqldef/v2/schema"
 )
 
 const (

--- a/cmd/mysqldef/mysqldef.go
+++ b/cmd/mysqldef/mysqldef.go
@@ -7,14 +7,14 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/sqldef/sqldef/database/file"
-	"github.com/sqldef/sqldef/parser"
+	"github.com/sqldef/sqldef/v2/database/file"
+	"github.com/sqldef/sqldef/v2/parser"
 
 	"github.com/jessevdk/go-flags"
-	"github.com/sqldef/sqldef"
-	"github.com/sqldef/sqldef/database"
-	"github.com/sqldef/sqldef/database/mysql"
-	"github.com/sqldef/sqldef/schema"
+	"github.com/sqldef/sqldef/v2"
+	"github.com/sqldef/sqldef/v2/database"
+	"github.com/sqldef/sqldef/v2/database/mysql"
+	"github.com/sqldef/sqldef/v2/schema"
 	"golang.org/x/term"
 )
 

--- a/cmd/mysqldef/mysqldef_test.go
+++ b/cmd/mysqldef/mysqldef_test.go
@@ -12,11 +12,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sqldef/sqldef/cmd/testutils"
-	"github.com/sqldef/sqldef/database"
-	"github.com/sqldef/sqldef/database/mysql"
-	"github.com/sqldef/sqldef/parser"
-	"github.com/sqldef/sqldef/schema"
+	"github.com/sqldef/sqldef/v2/cmd/testutils"
+	"github.com/sqldef/sqldef/v2/database"
+	"github.com/sqldef/sqldef/v2/database/mysql"
+	"github.com/sqldef/sqldef/v2/parser"
+	"github.com/sqldef/sqldef/v2/schema"
 )
 
 const (

--- a/cmd/psqldef/psqldef.go
+++ b/cmd/psqldef/psqldef.go
@@ -7,13 +7,13 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/sqldef/sqldef/database/file"
+	"github.com/sqldef/sqldef/v2/database/file"
 
 	"github.com/jessevdk/go-flags"
-	"github.com/sqldef/sqldef"
-	"github.com/sqldef/sqldef/database"
-	"github.com/sqldef/sqldef/database/postgres"
-	"github.com/sqldef/sqldef/schema"
+	"github.com/sqldef/sqldef/v2"
+	"github.com/sqldef/sqldef/v2/database"
+	"github.com/sqldef/sqldef/v2/database/postgres"
+	"github.com/sqldef/sqldef/v2/schema"
 	"golang.org/x/term"
 )
 

--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -13,10 +13,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sqldef/sqldef/cmd/testutils"
-	"github.com/sqldef/sqldef/database"
-	"github.com/sqldef/sqldef/database/postgres"
-	"github.com/sqldef/sqldef/schema"
+	"github.com/sqldef/sqldef/v2/cmd/testutils"
+	"github.com/sqldef/sqldef/v2/database"
+	"github.com/sqldef/sqldef/v2/database/postgres"
+	"github.com/sqldef/sqldef/v2/schema"
 )
 
 const (

--- a/cmd/sqlite3def/sqlite3def.go
+++ b/cmd/sqlite3def/sqlite3def.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 
 	"github.com/jessevdk/go-flags"
-	"github.com/sqldef/sqldef"
-	"github.com/sqldef/sqldef/database"
-	"github.com/sqldef/sqldef/database/file"
-	"github.com/sqldef/sqldef/database/sqlite3"
-	"github.com/sqldef/sqldef/parser"
-	"github.com/sqldef/sqldef/schema"
+	"github.com/sqldef/sqldef/v2"
+	"github.com/sqldef/sqldef/v2/database"
+	"github.com/sqldef/sqldef/v2/database/file"
+	"github.com/sqldef/sqldef/v2/database/sqlite3"
+	"github.com/sqldef/sqldef/v2/parser"
+	"github.com/sqldef/sqldef/v2/schema"
 )
 
 var version string

--- a/cmd/sqlite3def/sqlite3def_test.go
+++ b/cmd/sqlite3def/sqlite3def_test.go
@@ -12,11 +12,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sqldef/sqldef/cmd/testutils"
-	"github.com/sqldef/sqldef/database"
-	"github.com/sqldef/sqldef/database/sqlite3"
-	"github.com/sqldef/sqldef/parser"
-	"github.com/sqldef/sqldef/schema"
+	"github.com/sqldef/sqldef/v2/cmd/testutils"
+	"github.com/sqldef/sqldef/v2/database"
+	"github.com/sqldef/sqldef/v2/database/sqlite3"
+	"github.com/sqldef/sqldef/v2/parser"
+	"github.com/sqldef/sqldef/v2/schema"
 )
 
 const (

--- a/cmd/testutils/testutils.go
+++ b/cmd/testutils/testutils.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sqldef/sqldef/database"
-	"github.com/sqldef/sqldef/schema"
+	"github.com/sqldef/sqldef/v2/database"
+	"github.com/sqldef/sqldef/v2/schema"
 	"gopkg.in/yaml.v3"
 )
 

--- a/database/file/database.go
+++ b/database/file/database.go
@@ -2,7 +2,8 @@ package file
 
 import (
 	"database/sql"
-	"github.com/sqldef/sqldef"
+
+	"github.com/sqldef/sqldef/v2"
 )
 
 // Pseudo database for comparison between files

--- a/database/mssql/database.go
+++ b/database/mssql/database.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	_ "github.com/microsoft/go-mssqldb"
-	"github.com/sqldef/sqldef/database"
+	"github.com/sqldef/sqldef/v2/database"
 )
 
 const indent = "    "

--- a/database/mssql/parser.go
+++ b/database/mssql/parser.go
@@ -4,8 +4,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/sqldef/sqldef/database"
-	"github.com/sqldef/sqldef/parser"
+	"github.com/sqldef/sqldef/v2/database"
+	"github.com/sqldef/sqldef/v2/parser"
 )
 
 type MssqlParser struct {

--- a/database/mysql/database.go
+++ b/database/mysql/database.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	driver "github.com/go-sql-driver/mysql"
-	"github.com/sqldef/sqldef/database"
+	"github.com/sqldef/sqldef/v2/database"
 )
 
 type MysqlDatabase struct {

--- a/database/parser.go
+++ b/database/parser.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/sqldef/sqldef/parser"
+	"github.com/sqldef/sqldef/v2/parser"
 )
 
 // A tuple of an original DDL and a Statement

--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 
 	_ "github.com/lib/pq"
-	"github.com/sqldef/sqldef/database"
-	schemaLib "github.com/sqldef/sqldef/schema"
+	"github.com/sqldef/sqldef/v2/database"
+	schemaLib "github.com/sqldef/sqldef/v2/schema"
 )
 
 const indent = "    "

--- a/database/postgres/parser.go
+++ b/database/postgres/parser.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	pgquery "github.com/pganalyze/pg_query_go/v6"
-	"github.com/sqldef/sqldef/database"
-	"github.com/sqldef/sqldef/parser"
+	"github.com/sqldef/sqldef/v2/database"
+	"github.com/sqldef/sqldef/v2/parser"
 	go_pgquery "github.com/wasilibs/go-pgquery"
 )
 

--- a/database/postgres/parser_test.go
+++ b/database/postgres/parser_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/sqldef/sqldef/database"
-	"github.com/sqldef/sqldef/parser"
+	"github.com/sqldef/sqldef/v2/database"
+	"github.com/sqldef/sqldef/v2/parser"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 )

--- a/database/sqlite3/database.go
+++ b/database/sqlite3/database.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"strings"
 
-	"github.com/sqldef/sqldef/database"
+	"github.com/sqldef/sqldef/v2/database"
 	_ "modernc.org/sqlite"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sqldef/sqldef
+module github.com/sqldef/sqldef/v2
 
 go 1.22.0
 

--- a/schema/ast.go
+++ b/schema/ast.go
@@ -1,6 +1,6 @@
 package schema
 
-import "github.com/sqldef/sqldef/parser"
+import "github.com/sqldef/sqldef/v2/parser"
 
 type DDL interface {
 	Statement() string

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/sqldef/sqldef/database"
+	"github.com/sqldef/sqldef/v2/database"
 )
 
 type GeneratorMode int

--- a/schema/parser.go
+++ b/schema/parser.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/sqldef/sqldef/database"
-	"github.com/sqldef/sqldef/parser"
+	"github.com/sqldef/sqldef/v2/database"
+	"github.com/sqldef/sqldef/v2/parser"
 )
 
 // Parse `ddls`, which is expected to `;`-concatenated DDLs

--- a/sqldef.go
+++ b/sqldef.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/sqldef/sqldef/database"
-	"github.com/sqldef/sqldef/schema"
+	"github.com/sqldef/sqldef/v2/database"
+	"github.com/sqldef/sqldef/v2/schema"
 )
 
 type Options struct {


### PR DESCRIPTION
This PR updates the module name to include the `/v2` suffix, following Go Modules versioning conventions for major version 2.

- Changed the `go.mod` module path to `github.com/sqldef/sqldef/v2`
- Updated all import paths to use `/v2`
- No functional changes; this is to ensure correct versioning and import behavior for v2 and above

Please update your import paths accordingly when upgrading to v2.