### PR TITLE
mssqldef: Fix TLS Handshake Error of MSSQL Server.

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -19,7 +19,7 @@ services:
     ports:
       - '5432:5432'
   mssql:
-    image: mcr.microsoft.com/mssql/server:2019-CU28-ubuntu-20.04
+    image: mcr.microsoft.com/mssql/server:2019-CU32-ubuntu-20.04
     user: root
     environment:
       ACCEPT_EULA: Y


### PR DESCRIPTION
refs. https://github.com/microsoft/mssql-docker/issues/895#issuecomment-2737646391
```
$ make test-mssqldef
go test -v ./cmd/mssqldef
=== RUN   TestApply
=== RUN   TestApply/TestMssqldefMultipleIndex
2025/07/05 12:40:40 TLS Handshake failed: tls: failed to parse certificate from server: x509: negative serial number
FAIL    github.com/sqldef/sqldef/v2/cmd/mssqldef        3.979s
FAIL
make: *** [Makefile:84: test-mssqldef] Error 1
```

