### PR TITLE
psqldef: Emit Foreign Key Constraints Last to Support CREATE TABLE Style (Follow‑up to #500)

### DIFF
--- a/cmd/psqldef/tests.yml
+++ b/cmd/psqldef/tests.yml
@@ -297,6 +297,27 @@ IndexAndForeignOrder:
     );
     CREATE UNIQUE INDEX uniq_idx ON users (id);
     ALTER TABLE posts ADD CONSTRAINT "user_id_key" FOREIGN KEY ("user_id") REFERENCES users ("id");
+ForeignKeyConstraintsAreEmittedLast:
+  current: |
+    CREATE TABLE foos ( dummy_column text );
+    CREATE TABLE bars ( dummy_column text );
+  desired: |
+    CREATE TABLE foos (
+      foo_id bigint PRIMARY KEY,
+      bar_id bigint NOT NULL REFERENCES bars (bar_id)
+    );
+    CREATE TABLE bars (
+      bar_id bigint PRIMARY KEY
+    );
+  output: |
+    ALTER TABLE "public"."foos" ADD COLUMN "foo_id" bigint NOT NULL;
+    ALTER TABLE "public"."foos" ADD COLUMN "bar_id" bigint NOT NULL;
+    ALTER TABLE "public"."foos" ADD PRIMARY KEY ("foo_id");
+    ALTER TABLE "public"."bars" ADD COLUMN "bar_id" bigint NOT NULL;
+    ALTER TABLE "public"."bars" ADD PRIMARY KEY ("bar_id");
+    ALTER TABLE "public"."foos" ADD CONSTRAINT "foos_bar_id_fkey" FOREIGN KEY ("bar_id") REFERENCES "public"."bars" ("bar_id");
+    ALTER TABLE "public"."bars" DROP COLUMN "dummy_column";
+    ALTER TABLE "public"."foos" DROP COLUMN "dummy_column";
 ForeignKeyOnReservedName:
   current: |
     CREATE TABLE "public"."companies" (
@@ -1247,8 +1268,8 @@ CreateTableWithConstraintOptions:
     ALTER TABLE "public"."image_bindings" DROP CONSTRAINT "image_order_unique";
     ALTER TABLE "public"."image_bindings" ADD CONSTRAINT "image_order_unique" UNIQUE ("image_owner_type", "image_owner_id", "image_order") DEFERRABLE INITIALLY DEFERRED;
     ALTER TABLE "public"."image_bindings" DROP CONSTRAINT "image_bindings_image_id_fkey";
-    ALTER TABLE "public"."image_bindings" ADD CONSTRAINT "image_bindings_image_id_fkey" FOREIGN KEY ("image_id") REFERENCES "public"."images" ("id") ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE;
     ALTER TABLE "public"."image_bindings" DROP CONSTRAINT "image_owner_fk";
+    ALTER TABLE "public"."image_bindings" ADD CONSTRAINT "image_bindings_image_id_fkey" FOREIGN KEY ("image_id") REFERENCES "public"."images" ("id") ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE;
     ALTER TABLE "public"."image_bindings" ADD CONSTRAINT "image_owner_fk" FOREIGN KEY ("image_owner_type","image_owner_id") REFERENCES "public"."image_owners" ("type","id") ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE;
 CreateTableWithForeignKeyAndGeneratedColumn:
   min_version: '12'

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -128,7 +128,13 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 				if err != nil {
 					return nil, err
 				}
-				interDDLs = append(interDDLs, tableDDLs...)
+				for _, tableDDL := range tableDDLs {
+					if isAddConstraintForeignKey(tableDDL) {
+						foreignKeyDDLs = append(foreignKeyDDLs, tableDDL)
+					} else {
+						interDDLs = append(interDDLs, tableDDL)
+					}
+				}
 				mergeTable(currentTable, desired.table)
 			} else {
 				// Table not found, create table.
@@ -1585,6 +1591,13 @@ func (g *Generator) notNull(column Column) bool {
 	} else {
 		return *column.notNull
 	}
+}
+
+func isAddConstraintForeignKey(ddl string) bool {
+	if strings.HasPrefix(ddl, "ALTER TABLE") && strings.Contains(ddl, "ADD CONSTRAINT") && strings.Contains(ddl, "FOREIGN KEY") {
+		return true
+	}
+	return false
 }
 
 func isPrimaryKey(column Column, table Table) bool {


### PR DESCRIPTION
This PR updates the DDL generation so that **`ALTER TABLE … ADD CONSTRAINT … FOREIGN KEY` statements are emitted last**, after all other schema changes.  
It adds a new test case (`ForeignKeyConstraintsAreEmittedLast`) to confirm this behavior.

### Background & Motivation

We maintain a very large schema (thousands of lines) in Git and continuously run `psqldef` to migrate our databases.  
Our style is to **write foreign keys inline in `CREATE TABLE`**, rather than as separate `ALTER TABLE` statements.

`psqldef` already supports the style of emitting standalone `ALTER TABLE ADD CONSTRAINT FOREIGN KEY` statements, as introduced in https://github.com/sqldef/sqldef/pull/500.  
This PR is a follow-up that makes the `CREATE TABLE` style easier to use in large, split schemas.

When splitting a large schema into multiple files, it is hard to guarantee that concatenated files are ordered so that all referenced tables exist before their constraints are applied.  
Currently, foreign key `ALTER TABLE` statements are interleaved with other DDLs, which complicates zero‑from‑scratch migrations.

### What This PR Enables

With this change, `psqldef` now delays foreign key constraints until after all other DDLs have been emitted.  
This enables the following workflow:

1. Create all tables first (even with temporary dummy columns).
2. Apply the merged schema generated from arbitrarily ordered files.
3. `psqldef` will:
   * Add new columns, primary keys and indexes,
   * Drop dummy columns,
   * **Finally add foreign key constraints at the very end.**

### QA

🔴 → 🟢 

<img width="1310" height="186" alt="image" src="https://github.com/user-attachments/assets/e9ecc584-a314-47aa-a4bc-1f4b72658180" />