### PR TITLE
psqldef: Emit CREATE VIEW after ALTER TABLE

### DIFF
--- a/cmd/psqldef/tests.yml
+++ b/cmd/psqldef/tests.yml
@@ -318,6 +318,37 @@ ForeignKeyConstraintsAreEmittedLast:
     ALTER TABLE "public"."foos" ADD CONSTRAINT "foos_bar_id_fkey" FOREIGN KEY ("bar_id") REFERENCES "public"."bars" ("bar_id");
     ALTER TABLE "public"."bars" DROP COLUMN "dummy_column";
     ALTER TABLE "public"."foos" DROP COLUMN "dummy_column";
+ViewDDLsAreEmittedLastWithoutChangingDefinition:
+  current: |
+    CREATE TABLE foos (
+      id bigint PRIMARY KEY
+    );
+  desired: |
+    CREATE VIEW foos_view AS SELECT id, secret FROM foos WHERE secret = false;
+    CREATE TABLE foos (
+      id bigint PRIMARY KEY,
+      secret boolean NOT NULL DEFAULT false
+    );
+  output: |
+    ALTER TABLE "public"."foos" ADD COLUMN "secret" boolean NOT NULL DEFAULT false;
+    CREATE VIEW foos_view AS SELECT id, secret FROM foos WHERE secret = false;
+ViewDDLsAreEmittedLastWithChangingDefinition:
+  current: |
+    CREATE TABLE foos (
+      id bigint PRIMARY KEY
+    );
+    CREATE VIEW foos_view AS SELECT 1 AS dummy;
+  desired: |
+    CREATE VIEW foos_view AS
+      SELECT id, secret FROM foos WHERE secret = false;
+    CREATE TABLE foos (
+      id bigint PRIMARY KEY,
+      secret boolean NOT NULL DEFAULT false
+    );
+  output: |
+    ALTER TABLE "public"."foos" ADD COLUMN "secret" boolean NOT NULL DEFAULT false;
+    DROP VIEW "public"."foos_view";
+    CREATE VIEW "public"."foos_view" AS select id, secret from foos where secret = false;
 ForeignKeyOnReservedName:
   current: |
     CREATE TABLE "public"."companies" (

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -117,6 +117,7 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 	indexDDLs := []string{}
 	foreignKeyDDLs := []string{}
 	exclusionDDLs := []string{}
+	viewDDLs := []string{}
 
 	// Incrementally examine desiredDDLs
 	for _, ddl := range desiredDDLs {
@@ -175,11 +176,11 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 			}
 			interDDLs = append(interDDLs, policyDDLs...)
 		case *View:
-			viewDDLs, err := g.generateDDLsForCreateView(desired.name, desired)
+			ddls, err := g.generateDDLsForCreateView(desired.name, desired)
 			if err != nil {
 				return nil, err
 			}
-			interDDLs = append(interDDLs, viewDDLs...)
+			viewDDLs = append(viewDDLs, ddls...)
 		case *Trigger:
 			triggerDDLs, err := g.generateDDLsForCreateTrigger(desired.name, desired)
 			if err != nil {
@@ -219,6 +220,7 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 	ddls = append(ddls, createExtensionDDLs...)
 	ddls = append(ddls, createSchemaDDLs...)
 	ddls = append(ddls, interDDLs...)
+	ddls = append(ddls, viewDDLs...)
 	ddls = append(ddls, indexDDLs...)
 	ddls = append(ddls, foreignKeyDDLs...)
 	ddls = append(ddls, exclusionDDLs...)
@@ -1916,13 +1918,13 @@ func areSameCheckDefinition(checkA *CheckDefinition, checkB *CheckDefinition) bo
 func normalizeCheckDefinitionForComparison(def string) string {
 	// Remove ::text type casts from string literals
 	result := regexp.MustCompile(`'([^']*)'::text`).ReplaceAllString(def, "'$1'")
-	
+
 	// Remove ::character varying type casts
 	result = regexp.MustCompile(`'([^']*)'::character varying(\([^)]*\))?`).ReplaceAllString(result, "'$1'")
-	
+
 	// Remove extra parentheses that PostgreSQL sometimes adds
 	result = regexp.MustCompile(`\(\((.*)\)\)`).ReplaceAllString(result, "($1)")
-	
+
 	return result
 }
 


### PR DESCRIPTION
Follow-up to #500 and #705.

By this change, we no longer need to consider the place of CREATE VIEW DDLs, as they are now emitted after CREATE TABLE DDLs in the DDL generation order, similar to how foreign key constraints were resolved by #500 and #705.

This ensures that all table modifications (like adding columns) are completed before views that depend on those tables are created or modified, preventing dependency issues during schema migrations.

## QA

🔴 → 🟢 

<img width="430" height="91" alt="image" src="https://github.com/user-attachments/assets/89509056-0ab1-4234-9184-2a530410ac4c" />
