### PR TITLE
update CI targets: removed pg10, 11; added pg16, pg17

### DIFF
--- a/.github/workflows/sqldef.yml
+++ b/.github/workflows/sqldef.yml
@@ -24,10 +24,6 @@ jobs:
           - target: mysqldef
             mysql_version: '8.0'
           - target: psqldef
-            postgres_version: 10
-          - target: psqldef
-            postgres_version: 11
-          - target: psqldef
             postgres_version: 12
           - target: psqldef
             postgres_version: 13
@@ -35,6 +31,10 @@ jobs:
             postgres_version: 14
           - target: psqldef
             postgres_version: 15
+          - target: psqldef
+            postgres_version: 16
+          - target: psqldef
+            postgres_version: 17
       fail-fast: false
     steps:
       - uses: actions/setup-go@v5

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -977,8 +977,16 @@ func (g *Generator) normalizeViewDefinition(definition string) string {
 	if g.mode == GeneratorModePostgres {
 		definition = strings.ReplaceAll(definition, "array[", "")
 		definition = strings.ReplaceAll(definition, "]", "")
-		definition = strings.ReplaceAll(definition, "collate", "")
-		definition = strings.ReplaceAll(definition, "  ", "")
+
+		// Normalize table prefixes in column references (e.g., "users.name" -> "name")
+		// This handles cases like "(users.name collate ...)" -> "(name collate ...)"
+		// Match patterns like "table.column" but preserve the column name
+		tableColumnPattern := regexp.MustCompile(`\b(\w+)\.(\w+)\b`)
+		definition = tableColumnPattern.ReplaceAllString(definition, "$2")
+
+		// Normalize multiple spaces to single space
+		definition = regexp.MustCompile(`\s+`).ReplaceAllString(definition, " ")
+		definition = strings.TrimSpace(definition)
 	}
 	return definition
 }

--- a/schema/generator_test.go
+++ b/schema/generator_test.go
@@ -17,3 +17,77 @@ func TestStringConstantContainingSingleQuote(t *testing.T) {
 	assert.Equal(t, StringConstant("''"), "''''''")
 	assert.Equal(t, StringConstant("'example'"), "'''example'''")
 }
+
+func TestNormalizeViewDefinition(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     GeneratorMode
+		input    string
+		expected string
+	}{
+		// PostgreSQL specific tests
+		{
+			name:     "PostgreSQL: normalize table prefix with COLLATE",
+			mode:     GeneratorModePostgres,
+			input:    `select users.id, (users.name COLLATE "ja-JP-x-icu") as name from users`,
+			expected: `select id, (name collate "ja-jp-x-icu") as name from users`,
+		},
+		{
+			name:     "PostgreSQL: normalize multiple table prefixes",
+			mode:     GeneratorModePostgres,
+			input:    `select users.id, users.name, users.email from users`,
+			expected: `select id, name, email from users`,
+		},
+		{
+			name:     "PostgreSQL: normalize with lowercase collate",
+			mode:     GeneratorModePostgres,
+			input:    `select users.id, (users.name collate "ja-JP-x-icu") as name from users`,
+			expected: `select id, (name collate "ja-jp-x-icu") as name from users`,
+		},
+		{
+			name:     "PostgreSQL: normalize spaces",
+			mode:     GeneratorModePostgres,
+			input:    `select   users.id,    (users.name   COLLATE   "ja-JP-x-icu")   as   name   from   users`,
+			expected: `select id, (name collate "ja-jp-x-icu") as name from users`,
+		},
+		{
+			name:     "PostgreSQL: normalize with joins",
+			mode:     GeneratorModePostgres,
+			input:    `select u.id, (u.name COLLATE "en_US") as name from users u join orders o on u.id = o.user_id`,
+			expected: `select id, (name collate "en_us") as name from users u join orders o on id = user_id`,
+		},
+		{
+			name:     "PostgreSQL: preserve column names without prefixes",
+			mode:     GeneratorModePostgres,
+			input:    `select id, (name COLLATE "ja-JP-x-icu") as name from users`,
+			expected: `select id, (name collate "ja-jp-x-icu") as name from users`,
+		},
+		{
+			name:     "PostgreSQL: normalize array syntax",
+			mode:     GeneratorModePostgres,
+			input:    `select array[1, 2, 3] as nums`,
+			expected: `select 1, 2, 3 as nums`,
+		},
+		// Non-PostgreSQL modes should not normalize
+		{
+			name:     "MySQL: no normalization",
+			mode:     GeneratorModeMysql,
+			input:    `SELECT users.id, users.name FROM users`,
+			expected: `select users.id, users.name from users`,
+		},
+		{
+			name:     "SQLite3: no normalization",
+			mode:     GeneratorModeSQLite3,
+			input:    `SELECT users.id, users.name FROM users`,
+			expected: `select users.id, users.name from users`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &Generator{mode: tt.mode}
+			actual := g.normalizeViewDefinition(tt.input)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
Added newer versions of Pg, dropping obsolete Pg versions.

FYI Pg 13 to 17 are actively maintained versions, according to https://www.postgresql.org/support/versioning/

---

From Pg16, the way to normalize View definitions have been changed, which caused a test `CollateOnColumn` to fail. [a4b7607](https://github.com/sqldef/sqldef/pull/729/commits/a4b7607a983779880e1b57961f2068c63295e130) fixes the issue.

---

If the PR is okay, could you please update CI rules to drop pg 10 and 11 from required, and add pg 16 and 17 to required?