### PR TITLE
Add table rename support with `@rename from=<old_table_name>` magic comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,6 @@ CREATE TABLE accounts ( -- @rename from=old_accounts
 
 Because sqldef distinguishes table/index by its name, sqldef does NOT support:
 
-- RENAME TABLE
 - RENAME INDEX
   - DROP + ADD could be fine for index, though
 

--- a/README.md
+++ b/README.md
@@ -477,7 +477,9 @@ brew install sqldef/sqldef/mysqldef
 brew install sqldef/sqldef/psqldef
 ```
 
-## Column Renaming
+## Column and Table Renaming
+
+### Column Renaming
 
 sqldef supports renaming columns using the `-- @rename from=old_name` annotation:
 
@@ -502,6 +504,53 @@ CREATE TABLE users (
   id bigint NOT NULL,
   column_with_underscore varchar(50), -- @rename from="column-with-dash"
   normal_column text, -- @rename from="special column"
+);
+```
+
+### Table Renaming
+
+sqldef supports renaming tables using the `-- @rename from=old_name` annotation on the CREATE TABLE line:
+
+```sql
+CREATE TABLE users ( -- @rename from=user_accounts
+  id bigint NOT NULL,
+  username text,
+  age integer
+);
+```
+
+You can also use the block comment style:
+
+```sql
+CREATE TABLE users /* @rename from=user_accounts */ (
+  id bigint NOT NULL,
+  username text,
+  age integer
+);
+```
+
+This will generate appropriate rename commands for each database:
+- MySQL: `ALTER TABLE user_accounts RENAME TO users`
+- PostgreSQL: `ALTER TABLE user_accounts RENAME TO users`
+- SQL Server: `EXEC sp_rename 'user_accounts', 'users'`
+- SQLite: `ALTER TABLE user_accounts RENAME TO users`
+
+For tables with special characters or spaces, use double quotes:
+
+```sql
+CREATE TABLE user_profiles ( -- @rename from="user accounts"
+  id bigint NOT NULL,
+  name text
+);
+```
+
+You can combine table renaming with column renaming and other schema changes:
+
+```sql
+CREATE TABLE accounts ( -- @rename from=old_accounts
+  id bigint NOT NULL PRIMARY KEY,
+  username varchar(100) NOT NULL, -- @rename from=user_name
+  is_active boolean DEFAULT true
 );
 ```
 

--- a/cmd/mssqldef/tests.yml
+++ b/cmd/mssqldef/tests.yml
@@ -398,3 +398,69 @@ RenameColumnWithTypeChange:
   output: |
     EXEC sp_rename 'users.username', 'user_name', 'COLUMN';
     ALTER TABLE [users] ALTER COLUMN [user_name] text NOT NULL;
+
+RenameTable:
+  current: |
+    CREATE TABLE user_accounts (
+      id bigint NOT NULL,
+      username text,
+      age integer
+    );
+  desired: |
+    CREATE TABLE users ( -- @rename from=user_accounts
+      id bigint NOT NULL,
+      username text,
+      age integer
+    );
+  output: |
+    EXEC sp_rename 'user_accounts', 'users';
+
+RenameTableWithCommentVariant:
+  current: |
+    CREATE TABLE old_users (
+      id bigint NOT NULL,
+      name text
+    );
+  desired: |
+    CREATE TABLE new_users /* @rename from=old_users */ (
+      id bigint NOT NULL,
+      name text
+    );
+  output: |
+    EXEC sp_rename 'old_users', 'new_users';
+
+RenameTableWithQuotedName:
+  current: |
+    CREATE TABLE [user_accounts] (
+      id bigint NOT NULL,
+      name text
+    );
+  desired: |
+    CREATE TABLE [user_profiles] ( -- @rename from="user_accounts"
+      id bigint NOT NULL,
+      name text
+    );
+  output: |
+    EXEC sp_rename 'user_accounts', 'user_profiles';
+
+RenameTableAndMultipleChanges:
+  current: |
+    CREATE TABLE old_accounts (
+      id bigint NOT NULL,
+      user_name varchar(50),
+      is_active bit,
+      old_field text
+    );
+  desired: |
+    CREATE TABLE accounts ( -- @rename from=old_accounts
+      id bigint NOT NULL PRIMARY KEY,
+      username varchar(100) NOT NULL, -- @rename from=user_name
+      is_active bit DEFAULT 1
+    );
+  output: |
+    EXEC sp_rename 'old_accounts', 'accounts';
+    EXEC sp_rename 'accounts.user_name', 'username', 'COLUMN';
+    ALTER TABLE [accounts] ALTER COLUMN [username] varchar(100) NOT NULL;
+    ALTER TABLE [dbo].[accounts] ADD DEFAULT 1 FOR [is_active];
+    ALTER TABLE [dbo].[accounts] ADD PRIMARY KEY CLUSTERED ([id]);
+    ALTER TABLE [dbo].[accounts] DROP COLUMN [old_field];

--- a/cmd/mysqldef/tests_tables.yml
+++ b/cmd/mysqldef/tests_tables.yml
@@ -486,3 +486,71 @@ RenameMultipleColumns:
   output: |
     ALTER TABLE `users` CHANGE COLUMN `user name` `username` text;
     ALTER TABLE `users` CHANGE COLUMN `email@address` `email_address` varchar(100);
+
+RenameTable:
+  current: |
+    CREATE TABLE user_accounts (
+      id bigint NOT NULL,
+      username text,
+      age integer
+    );
+  desired: |
+    CREATE TABLE users ( -- @rename from=user_accounts
+      id bigint NOT NULL,
+      username text,
+      age integer
+    );
+  output: |
+    ALTER TABLE `user_accounts` RENAME TO `users`;
+
+RenameTableWithCommentVariant:
+  current: |
+    CREATE TABLE old_users (
+      id bigint NOT NULL,
+      name text
+    );
+  desired: |
+    CREATE TABLE new_users /* @rename from=old_users */ (
+      id bigint NOT NULL,
+      name text
+    );
+  output: |
+    ALTER TABLE `old_users` RENAME TO `new_users`;
+
+RenameTableWithQuotedName:
+  current: |
+    CREATE TABLE `user accounts` (
+      id bigint NOT NULL,
+      name text
+    );
+  desired: |
+    CREATE TABLE `user_profiles` ( -- @rename from="user accounts"
+      id bigint NOT NULL,
+      name text
+    );
+  output: |
+    ALTER TABLE `user accounts` RENAME TO `user_profiles`;
+
+RenameTableAndMultipleColumnChanges:
+  current: |
+    CREATE TABLE old_accounts (
+      id bigint NOT NULL,
+      user_name varchar(50),
+      is_active boolean,
+      old_field text
+    );
+  desired: |
+    CREATE TABLE accounts ( -- @rename from=old_accounts
+      id bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+      username varchar(100), -- @rename from=user_name
+      is_active boolean DEFAULT true,
+      created_at timestamp DEFAULT CURRENT_TIMESTAMP
+    );
+  output: |
+    ALTER TABLE `old_accounts` RENAME TO `accounts`;
+    ALTER TABLE `accounts` CHANGE COLUMN `user_name` `username` varchar(100);
+    ALTER TABLE `accounts` CHANGE COLUMN `is_active` `is_active` boolean DEFAULT true;
+    ALTER TABLE `accounts` ADD COLUMN `created_at` timestamp DEFAULT current_timestamp AFTER `is_active`;
+    ALTER TABLE `accounts` ADD PRIMARY KEY (`id`);
+    ALTER TABLE `accounts` CHANGE COLUMN `id` `id` bigint NOT NULL AUTO_INCREMENT;
+    ALTER TABLE `accounts` DROP COLUMN `old_field`;

--- a/cmd/mysqldef/tests_tables.yml
+++ b/cmd/mysqldef/tests_tables.yml
@@ -544,13 +544,13 @@ RenameTableAndMultipleColumnChanges:
       id bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
       username varchar(100), -- @rename from=user_name
       is_active boolean DEFAULT true,
-      created_at timestamp DEFAULT CURRENT_TIMESTAMP
+      created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
     );
   output: |
     ALTER TABLE `old_accounts` RENAME TO `accounts`;
     ALTER TABLE `accounts` CHANGE COLUMN `user_name` `username` varchar(100);
     ALTER TABLE `accounts` CHANGE COLUMN `is_active` `is_active` boolean DEFAULT true;
-    ALTER TABLE `accounts` ADD COLUMN `created_at` timestamp DEFAULT current_timestamp AFTER `is_active`;
+    ALTER TABLE `accounts` ADD COLUMN `created_at` timestamp NOT NULL DEFAULT current_timestamp AFTER `is_active`;
     ALTER TABLE `accounts` ADD PRIMARY KEY (`id`);
     ALTER TABLE `accounts` CHANGE COLUMN `id` `id` bigint NOT NULL AUTO_INCREMENT;
     ALTER TABLE `accounts` DROP COLUMN `old_field`;

--- a/cmd/psqldef/tests.yml
+++ b/cmd/psqldef/tests.yml
@@ -1647,3 +1647,72 @@ RenameMultipleColumns:
   output: |
     ALTER TABLE "public"."users" RENAME COLUMN "user name" TO "username";
     ALTER TABLE "public"."users" RENAME COLUMN "email@address" TO "email_address";
+
+RenameTable:
+  current: |
+    CREATE TABLE user_accounts (
+      id bigint NOT NULL,
+      username text,
+      age integer
+    );
+  desired: |
+    CREATE TABLE users ( -- @rename from=user_accounts
+      id bigint NOT NULL,
+      username text,
+      age integer
+    );
+  output: |
+    ALTER TABLE "public"."user_accounts" RENAME TO "users";
+
+RenameTableWithCommentVariant:
+  current: |
+    CREATE TABLE old_users (
+      id bigint NOT NULL,
+      name text
+    );
+  desired: |
+    CREATE TABLE new_users /* @rename from=old_users */ (
+      id bigint NOT NULL,
+      name text
+    );
+  output: |
+    ALTER TABLE "public"."old_users" RENAME TO "new_users";
+
+RenameTableWithQuotedName:
+  current: |
+    CREATE TABLE "user accounts" (
+      id bigint NOT NULL,
+      name text
+    );
+  desired: |
+    CREATE TABLE "user_profiles" ( -- @rename from="user accounts"
+      id bigint NOT NULL,
+      name text
+    );
+  output: |
+    ALTER TABLE "public"."user accounts" RENAME TO "user_profiles";
+
+RenameTableAndMultipleChanges:
+  current: |
+    CREATE TABLE old_accounts (
+      id bigint NOT NULL,
+      user_name varchar(50),
+      is_active boolean,
+      old_field text
+    );
+  desired: |
+    CREATE TABLE accounts ( -- @rename from=old_accounts
+      id bigint NOT NULL PRIMARY KEY,
+      username varchar(100) NOT NULL, -- @rename from=user_name
+      is_active boolean DEFAULT true,
+      created_at timestamp DEFAULT CURRENT_TIMESTAMP
+    );
+  output: |
+    ALTER TABLE "public"."old_accounts" RENAME TO "accounts";
+    ALTER TABLE "public"."accounts" RENAME COLUMN "user_name" TO "username";
+    ALTER TABLE "public"."accounts" ALTER COLUMN "username" TYPE varchar(100);
+    ALTER TABLE "public"."accounts" ALTER COLUMN "username" SET NOT NULL;
+    ALTER TABLE "public"."accounts" ALTER COLUMN "is_active" SET DEFAULT true;
+    ALTER TABLE "public"."accounts" ADD COLUMN "created_at" timestamp DEFAULT current_timestamp;
+    ALTER TABLE "public"."accounts" ADD PRIMARY KEY ("id");
+    ALTER TABLE "public"."accounts" DROP COLUMN "old_field";

--- a/cmd/sqlite3def/tests.yml
+++ b/cmd/sqlite3def/tests.yml
@@ -173,3 +173,70 @@ RenameColumnWithTypeChange:
     ALTER TABLE `users` ADD COLUMN `user_name` text NOT NULL;
     UPDATE `users` SET `user_name` = `username`;
     ALTER TABLE `users` DROP COLUMN `username`;
+
+RenameTable:
+  current: |
+    CREATE TABLE user_accounts (
+      id bigint NOT NULL,
+      username text,
+      age integer
+    );
+  desired: |
+    CREATE TABLE users ( -- @rename from=user_accounts
+      id bigint NOT NULL,
+      username text,
+      age integer
+    );
+  output: |
+    ALTER TABLE `user_accounts` RENAME TO `users`;
+
+RenameTableWithCommentVariant:
+  current: |
+    CREATE TABLE old_users (
+      id bigint NOT NULL,
+      name text
+    );
+  desired: |
+    CREATE TABLE new_users /* @rename from=old_users */ (
+      id bigint NOT NULL,
+      name text
+    );
+  output: |
+    ALTER TABLE `old_users` RENAME TO `new_users`;
+
+RenameTableWithQuotedName:
+  current: |
+    CREATE TABLE "user accounts" (
+      id bigint NOT NULL,
+      name text
+    );
+  desired: |
+    CREATE TABLE "user_profiles" ( -- @rename from="user accounts"
+      id bigint NOT NULL,
+      name text
+    );
+  output: |
+    ALTER TABLE `user accounts` RENAME TO `user_profiles`;
+
+RenameTableAndMultipleColumnChanges:
+  current: |
+    CREATE TABLE old_accounts (
+      id bigint NOT NULL,
+      user_name varchar(50),
+      is_active integer,
+      old_field text
+    );
+  desired: |
+    CREATE TABLE accounts ( -- @rename from=old_accounts
+      id bigint NOT NULL,
+      username varchar(100) NOT NULL, -- @rename from=user_name
+      is_active integer DEFAULT 1,
+      created_at timestamp DEFAULT CURRENT_TIMESTAMP
+    );
+  output: |
+    ALTER TABLE `old_accounts` RENAME TO `accounts`;
+    ALTER TABLE `accounts` ADD COLUMN `username` varchar(100) NOT NULL;
+    UPDATE `accounts` SET `username` = `user_name`;
+    ALTER TABLE `accounts` DROP COLUMN `user_name`;
+    ALTER TABLE `accounts` ADD COLUMN `created_at` timestamp DEFAULT current_timestamp;
+    ALTER TABLE `accounts` DROP COLUMN `old_field`;

--- a/schema/ast.go
+++ b/schema/ast.go
@@ -57,6 +57,7 @@ type Table struct {
 	exclusions  []Exclusion
 	policies    []Policy
 	options     map[string]string
+	renameFrom  string // Previous table name if renamed via @rename annotation
 }
 
 type Column struct {

--- a/schema/parser.go
+++ b/schema/parser.go
@@ -206,7 +206,7 @@ func parseTable(mode GeneratorMode, stmt *parser.DDL, defaultSchema string, rawD
 	var foreignKeys []ForeignKey
 	var exclusions []Exclusion
 
-	inlineComments := extractInlineComments(rawDDL)
+	columnComments := extractColumnComments(rawDDL, mode)
 
 	for i, parsedCol := range stmt.TableSpec.Columns {
 		column := Column{
@@ -235,8 +235,8 @@ func parseTable(mode GeneratorMode, stmt *parser.DDL, defaultSchema string, rawD
 			generated:     parseGenerated(parsedCol.Type.Generated),
 		}
 
-		// Parse @rename annotation from inline comment if present
-		if comment, ok := inlineComments[parsedCol.Name.String()]; ok {
+		// Parse @rename annotation for each column
+		if comment, ok := columnComments[parsedCol.Name.String()]; ok {
 			column.renameFrom = extractRenameFrom(comment)
 		}
 
@@ -375,6 +375,12 @@ func parseTable(mode GeneratorMode, stmt *parser.DDL, defaultSchema string, rawD
 		exclusions = append(exclusions, exclusion)
 	}
 
+	tableComment := extractTableComment(rawDDL, mode)
+	tableRenameFrom := ""
+	if tableComment != "" {
+		tableRenameFrom = extractRenameFrom(tableComment)
+	}
+
 	return Table{
 		name:        normalizedTableName(mode, stmt.NewName, defaultSchema),
 		columns:     columns,
@@ -383,6 +389,7 @@ func parseTable(mode GeneratorMode, stmt *parser.DDL, defaultSchema string, rawD
 		foreignKeys: foreignKeys,
 		exclusions:  exclusions,
 		options:     stmt.TableSpec.Options,
+		renameFrom:  tableRenameFrom,
 	}, nil
 }
 
@@ -822,9 +829,69 @@ func extractRenameFrom(comment string) string {
 	return ""
 }
 
-// extractInlineComments extracts inline comments (-- comments) from a CREATE TABLE statement
+// generatorModeToParserMode converts GeneratorMode to ParserMode
+func generatorModeToParserMode(mode GeneratorMode) parser.ParserMode {
+	switch mode {
+	case GeneratorModeMysql:
+		return parser.ParserModeMysql
+	case GeneratorModePostgres:
+		return parser.ParserModePostgres
+	case GeneratorModeSQLite3:
+		return parser.ParserModeSQLite3
+	case GeneratorModeMssql:
+		return parser.ParserModeMssql
+	default:
+		return parser.ParserModeMysql
+	}
+}
+
+func extractTableComment(rawDDL string, mode GeneratorMode) string {
+	tokenizer := parser.NewTokenizer(rawDDL, generatorModeToParserMode(mode))
+	tokenizer.AllowComments = true
+
+	var foundCreate, foundTable bool
+	var firstComment string // Store the first comment after CREATE TABLE
+
+	for {
+		tok, val := tokenizer.Scan()
+		if tok == 0 {
+			break // EOF
+		}
+
+		// Look for CREATE keyword
+		if tok == parser.CREATE {
+			foundCreate = true
+			continue
+		}
+
+		// Look for TABLE keyword after CREATE
+		if foundCreate && tok == parser.TABLE {
+			foundTable = true
+			foundCreate = false
+			continue
+		}
+
+		// After CREATE TABLE, capture the first comment we encounter
+		// This could be before or after the opening parenthesis
+		if foundTable && tok == parser.COMMENT && firstComment == "" {
+			comment := string(val)
+			comment = strings.TrimSpace(comment)
+			firstComment = comment
+			// Continue scanning to handle all cases
+		}
+
+		// Reset if we found CREATE but next token is not TABLE
+		if foundCreate && tok != parser.TABLE {
+			foundCreate = false
+		}
+	}
+
+	return firstComment
+}
+
+// extractColumnComments extracts inline comments (-- comments) from a CREATE TABLE statement
 // and maps them to column names
-func extractInlineComments(rawDDL string) map[string]string {
+func extractColumnComments(rawDDL string, mode GeneratorMode) map[string]string {
 	comments := make(map[string]string)
 
 	// Split DDL into lines


### PR DESCRIPTION
With the similar syntax as https://github.com/sqldef/sqldef/pull/727

For example,

```sql
CREATE TABLE users ( -- @rename from=user_accounts
  id bigint NOT NULL,
  username text,
  age integer
);
```

will create:

```sql
ALTER TABLE `user_accounts` RENAME TO `users`;
```

See for README.md and the tests for details.