### PR TITLE
Add `--config-inline=<yaml-string>` flag and support multiple config specifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,3 @@
 /MacOSX.sdk.tar.xz
 /MacOSX.sdk
 y.output
-mysqldef
-psqldef

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Application Options:
       --enable-drop                 Enable destructive changes such as DROP for TABLE, SCHEMA, ROLE, USER, FUNCTION, PROCEDURE, TRIGGER, VIEW, INDEX, SEQUENCE, TYPE
       --skip-view                   Skip managing views (temporary feature, to be removed later)
       --before-apply=               Execute the given string before applying the regular DDLs
-      --config=                     YAML file to specify: target_tables, skip_tables, algorithm, lock
+      --config=                     YAML file to specify: target_tables, skip_tables, algorithm, lock, dump_concurrency (can be specified multiple times)
+      --config-inline=              YAML object to specify: target_tables, skip_tables, algorithm, lock, dump_concurrency (can be specified multiple times)
       --help                        Show this help
       --version                     Show this version
 ```
@@ -109,6 +110,26 @@ Run: 'DROP TABLE users;'
 # Tables in 'skip-tables' are ignored (can use Regexp)
 $ echo "user\n.*_bk\n.*_[0-9]{8}" > skip-tables
 $ mysqldef -uroot test --skip-file skip-tables < schema.sql
+
+# Use config file to control schema management
+$ cat > config.yml <<EOF
+target_tables: |
+  users
+  posts_\d+
+skip_tables: |
+  tmp_.*
+algorithm: INPLACE
+lock: NONE
+dump_concurrency: 8
+EOF
+$ mysqldef -uroot test --config=config.yml < schema.sql
+
+# Use inline YAML configuration
+$ mysqldef -uroot test --config-inline="skip_tables: temp_.*" < schema.sql
+
+# Multiple configs with order preservation (latter wins)
+# In this example, algorithm from config-inline overrides the one from config.yml
+$ mysqldef -uroot test --config=config.yml --config-inline="algorithm: INSTANT" < schema.sql
 ```
 
 ### psqldef
@@ -132,7 +153,8 @@ Application Options:
       --skip-view             Skip managing views/materialized views
       --skip-extension        Skip managing extensions
       --before-apply=         Execute the given string before applying the regular DDLs
-      --config=               YAML file to specify: target_tables, skip_tables, skip_views, target_schema
+      --config=               YAML file to specify: target_tables, skip_tables, skip_views, target_schema, dump_concurrency (can be specified multiple times)
+      --config-inline=        YAML object to specify: target_tables, skip_tables, skip_views, target_schema, dump_concurrency (can be specified multiple times)
       --help                  Show this help
       --version               Show this version
 ```
@@ -204,6 +226,30 @@ Skipped: 'DROP TABLE users;'
 # Run dropping existing tables and columns
 $ psqldef -U postgres test --enable-drop < schema.sql
 Run: 'DROP TABLE users;'
+
+# Use config file to filter tables and schemas
+$ cat > config.yml <<EOF
+target_tables: |
+  public\.users
+  public\.posts_\d+
+skip_tables: |
+  migrations
+  temp_.*
+skip_views: |
+  materialized_view_.*
+target_schema: |
+  public
+  app
+dump_concurrency: 4
+EOF
+$ psqldef -U postgres test --config=config.yml < schema.sql
+
+# Use inline YAML configuration
+$ psqldef -U postgres test --config-inline="target_schema: public" < schema.sql
+
+# Multiple configs with order preservation (latter wins)
+# In this example, skip_tables from the second config overrides the first
+$ psqldef -U postgres test --config=base.yml --config-inline="skip_tables: archived_.*" < schema.sql
 ```
 
 ### sqlite3def
@@ -217,9 +263,37 @@ Application Options:
       --dry-run               Don't run DDLs but just show them
       --export                Just dump the current schema to stdout
       --enable-drop           Enable destructive changes such as DROP for TABLE, SCHEMA, ROLE, USER, FUNCTION, PROCEDURE, TRIGGER, VIEW, INDEX, SEQUENCE, TYPE
-      --config=               YAML file to specify: target_tables, skip_tables
+      --config=               YAML file to specify: target_tables, skip_tables (can be specified multiple times)
+      --config-inline=        YAML object to specify: target_tables, skip_tables (can be specified multiple times)
       --help                  Show this help
       --version               Show this version
+```
+
+#### Example
+
+```sql
+# Create SQLite database and tables
+$ sqlite3 mydb.db "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT);"
+
+# Export current schema
+$ sqlite3def mydb.db --export > schema.sql
+
+# Use config file to filter tables
+$ cat > config.yml <<EOF
+target_tables: |
+  users
+  posts_\d+
+skip_tables: |
+  sqlite_.*
+  temp_.*
+EOF
+$ sqlite3def mydb.db --config=config.yml < schema.sql
+
+# Use inline YAML configuration
+$ sqlite3def mydb.db --config-inline="skip_tables: backup_.*" < schema.sql
+
+# Multiple configs with order preservation (latter wins)
+$ sqlite3def mydb.db --config=config.yml --config-inline="target_tables: users" < schema.sql
 ```
 
 ### mssqldef
@@ -238,8 +312,37 @@ Application Options:
       --dry-run               Don't run DDLs but just show them
       --export                Just dump the current schema to stdout
       --enable-drop           Enable destructive changes such as DROP for TABLE, SCHEMA, ROLE, USER, FUNCTION, PROCEDURE, TRIGGER, VIEW, INDEX, SEQUENCE, TYPE
+      --config=               YAML file to specify: target_tables, skip_tables (can be specified multiple times)
+      --config-inline=        YAML object to specify: target_tables, skip_tables (can be specified multiple times)
       --help                  Show this help
       --version               Show this version
+```
+
+#### Example
+
+```sql
+# Apply schema to MSSQL database
+$ mssqldef -U sa -P password123 mydb < schema.sql
+
+# Export current schema
+$ mssqldef -U sa -P password123 mydb --export > current.sql
+
+# Use config file to filter tables
+$ cat > config.yml <<EOF
+target_tables: |
+  dbo\.users
+  dbo\.posts_\d+
+skip_tables: |
+  sys\..*
+  temp_.*
+EOF
+$ mssqldef -U sa -P password123 mydb --config=config.yml < schema.sql
+
+# Use inline YAML configuration
+$ mssqldef -U sa -P password123 mydb --config-inline="skip_tables: backup_.*" < schema.sql
+
+# Multiple configs with order preservation (latter wins)
+$ mssqldef -U sa -P password123 mydb --config=base.yml --config-inline="target_tables: dbo\..*" < schema.sql
 ```
 
 ## Supported features

--- a/cmd/mysqldef/mysqldef.go
+++ b/cmd/mysqldef/mysqldef.go
@@ -23,25 +23,38 @@ var version string
 // Return parsed options and schema filename
 // TODO: Support `sqldef schema.sql -opt val...`
 func parseOptions(args []string) (database.Config, *sqldef.Options) {
+	// Track parsed configs in order
+	var configs []database.GeneratorConfig
+
 	var opts struct {
-		User                  string   `short:"u" long:"user" description:"MySQL user name" value-name:"user_name" default:"root"`
-		Password              string   `short:"p" long:"password" description:"MySQL user password, overridden by $MYSQL_PWD" value-name:"password"`
-		Host                  string   `short:"h" long:"host" description:"Host to connect to the MySQL server" value-name:"host_name" default:"127.0.0.1"`
-		Port                  uint     `short:"P" long:"port" description:"Port used for the connection" value-name:"port_num" default:"3306"`
-		Socket                string   `short:"S" long:"socket" description:"The socket file to use for connection" value-name:"socket"`
-		SslMode               string   `long:"ssl-mode" description:"SSL connection mode(PREFERRED,REQUIRED,DISABLED)." value-name:"ssl_mode" default:"PREFERRED"`
-		SslCa                 string   `long:"ssl-ca" description:"File that contains list of trusted SSL Certificate Authorities" value-name:"ssl_ca"`
-		Prompt                bool     `long:"password-prompt" description:"Force MySQL user password prompt"`
-		EnableCleartextPlugin bool     `long:"enable-cleartext-plugin" description:"Enable/disable the clear text authentication plugin"`
+		User                  string `short:"u" long:"user" description:"MySQL user name" value-name:"user_name" default:"root"`
+		Password              string `short:"p" long:"password" description:"MySQL user password, overridden by $MYSQL_PWD" value-name:"password"`
+		Host                  string `short:"h" long:"host" description:"Host to connect to the MySQL server" value-name:"host_name" default:"127.0.0.1"`
+		Port                  uint   `short:"P" long:"port" description:"Port used for the connection" value-name:"port_num" default:"3306"`
+		Socket                string `short:"S" long:"socket" description:"The socket file to use for connection" value-name:"socket"`
+		SslMode               string `long:"ssl-mode" description:"SSL connection mode(PREFERRED,REQUIRED,DISABLED)." value-name:"ssl_mode" default:"PREFERRED"`
+		SslCa                 string `long:"ssl-ca" description:"File that contains list of trusted SSL Certificate Authorities" value-name:"ssl_ca"`
+		Prompt                bool   `long:"password-prompt" description:"Force MySQL user password prompt"`
+		EnableCleartextPlugin bool   `long:"enable-cleartext-plugin" description:"Enable/disable the clear text authentication plugin"`
 		File                  []string `long:"file" description:"Read desired SQL from the file, rather than stdin" value-name:"sql_file" default:"-"`
 		DryRun                bool     `long:"dry-run" description:"Don't run DDLs but just show them"`
 		Export                bool     `long:"export" description:"Just dump the current schema to stdout"`
 		EnableDrop            bool     `long:"enable-drop" description:"Enable destructive changes such as DROP for TABLE, SCHEMA, ROLE, USER, FUNCTION, PROCEDURE, TRIGGER, VIEW, INDEX, SEQUENCE, TYPE"`
 		SkipView              bool     `long:"skip-view" description:"Skip managing views (temporary feature, to be removed later)"`
 		BeforeApply           string   `long:"before-apply" description:"Execute the given string before applying the regular DDLs"`
-		Config                string   `long:"config" description:"YAML file to specify: target_tables, skip_tables, algorithm, lock"`
 		Help                  bool     `long:"help" description:"Show this help"`
 		Version               bool     `long:"version" description:"Show this version"`
+
+		// Custom handlers for config flags to preserve order
+		Config       func(string) `long:"config" description:"YAML file to specify: target_tables, skip_tables, algorithm, lock (can be specified multiple times)"`
+		ConfigInline func(string) `long:"config-inline" description:"YAML object to specify: target_tables, skip_tables, algorithm, lock (can be specified multiple times)"`
+	}
+
+	opts.Config = func(path string) {
+		configs = append(configs, database.ParseGeneratorConfig(path))
+	}
+	opts.ConfigInline = func(yaml string) {
+		configs = append(configs, database.ParseGeneratorConfigString(yaml))
 	}
 
 	parser := flags.NewParser(&opts, flags.None)
@@ -71,13 +84,16 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		}
 	}
 
+	// merge --config and --config-inline in order
+	config := database.MergeGeneratorConfigs(configs)
+
 	options := sqldef.Options{
 		DesiredDDLs: desiredDDLs,
 		DryRun:      opts.DryRun,
 		Export:      opts.Export,
 		EnableDrop:  opts.EnableDrop,
 		BeforeApply: opts.BeforeApply,
-		Config:      database.ParseGeneratorConfig(opts.Config),
+		Config:      config,
 	}
 
 	if len(args) == 0 {
@@ -125,7 +141,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		password = string(pass)
 	}
 
-	config := database.Config{
+	dbConfig := database.Config{
 		DbName:                     databaseName,
 		User:                       opts.User,
 		Password:                   password,
@@ -138,7 +154,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		SslCa:                      opts.SslCa,
 		DumpConcurrency:            options.Config.DumpConcurrency,
 	}
-	return config, &options
+	return dbConfig, &options
 }
 
 func main() {

--- a/cmd/mysqldef/mysqldef_test.go
+++ b/cmd/mysqldef/mysqldef_test.go
@@ -297,6 +297,21 @@ func TestMysqldefConfigIncludesSkipTables(t *testing.T) {
 	assertEquals(t, apply, nothingModified)
 }
 
+func TestMysqldefConfigInlineSkipTables(t *testing.T) {
+	resetTestDatabase()
+
+	usersTable := "CREATE TABLE users (id bigint);"
+	users1Table := "CREATE TABLE users_1 (id bigint);"
+	users10Table := "CREATE TABLE users_10 (id bigint);"
+	args := append(getMySQLArgs("mysqldef_test"), "-e", usersTable+users1Table+users10Table)
+	testutils.MustExecute("mysql", args...)
+
+	writeFile("schema.sql", usersTable+users1Table)
+
+	apply := assertedExecuteMySQLDef(t, "mysqldef_test", "--config-inline", "skip_tables: users_10", "--file", "schema.sql")
+	assertEquals(t, apply, nothingModified)
+}
+
 func TestMysqldefConfigIncludesAlgorithm(t *testing.T) {
 	resetTestDatabase()
 

--- a/cmd/sqlite3def/config3.yml
+++ b/cmd/sqlite3def/config3.yml
@@ -1,0 +1,1 @@
+skip_tables: comments

--- a/database/database.go
+++ b/database/database.go
@@ -116,6 +116,21 @@ func TransactionSupported(ddl string) bool {
 	return !strings.Contains(strings.ToLower(ddl), "concurrently")
 }
 
+func MergeGeneratorConfigs(configs []GeneratorConfig) GeneratorConfig {
+	var result GeneratorConfig
+	for _, config := range configs {
+		result = MergeGeneratorConfig(result, config)
+	}
+	return result
+}
+
+func ParseGeneratorConfigString(yamlString string) GeneratorConfig {
+	if yamlString == "" {
+		return GeneratorConfig{}
+	}
+	return parseGeneratorConfigFromBytes([]byte(yamlString))
+}
+
 func ParseGeneratorConfig(configFile string) GeneratorConfig {
 	if configFile == "" {
 		return GeneratorConfig{}
@@ -125,7 +140,40 @@ func ParseGeneratorConfig(configFile string) GeneratorConfig {
 	if err != nil {
 		log.Fatal(err)
 	}
+	return parseGeneratorConfigFromBytes(buf)
+}
 
+// MergeGeneratorConfig merges two configs, with the second one taking precedence
+func MergeGeneratorConfig(base, override GeneratorConfig) GeneratorConfig {
+	result := base
+
+	// Override fields if they are set in the override config
+	if override.TargetTables != nil {
+		result.TargetTables = override.TargetTables
+	}
+	if override.SkipTables != nil {
+		result.SkipTables = override.SkipTables
+	}
+	if override.SkipViews != nil {
+		result.SkipViews = override.SkipViews
+	}
+	if override.TargetSchema != nil {
+		result.TargetSchema = override.TargetSchema
+	}
+	if override.Algorithm != "" {
+		result.Algorithm = override.Algorithm
+	}
+	if override.Lock != "" {
+		result.Lock = override.Lock
+	}
+	if override.DumpConcurrency != 0 {
+		result.DumpConcurrency = override.DumpConcurrency
+	}
+
+	return result
+}
+
+func parseGeneratorConfigFromBytes(buf []byte) GeneratorConfig {
 	var config struct {
 		TargetTables    string `yaml:"target_tables"`
 		SkipTables      string `yaml:"skip_tables"`
@@ -138,7 +186,7 @@ func ParseGeneratorConfig(configFile string) GeneratorConfig {
 
 	dec := yaml.NewDecoder(bytes.NewReader(buf))
 	dec.KnownFields(true)
-	err = dec.Decode(&config)
+	err := dec.Decode(&config)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Discussed in https://github.com/sqldef/sqldef/discussions/716#discussioncomment-14157726

---

This PR adds the `--config-inline` flag to all sqldef tools (mysqldef, psqldef, sqlite3def, mssqldef) to allow specifying YAML configuration directly on the command line without requiring a file.

### Key features:
- Both `--config` and `--config-inline` can be specified multiple times
- Configs are processed in command-line order with "latter wins" semantics
- Allows flexible configuration management by mixing file-based and inline configs

### Example usage:
```bash
# Override specific settings from a base config
mysqldef --config=base.yml --config-inline="algorithm: INSTANT" database < schema.sql

# Multiple inline configs
psqldef --config-inline="target_schema: public" --config-inline="skip_tables: temp_.*" database < schema.sql
```