### PR TITLE
Enable push event for master branch in tagpr workflow

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -1,7 +1,7 @@
 name: tagpr
 on:
-  # push:
-  #   branches: [master]
+  push:
+    branches: [master]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Reverts https://github.com/sqldef/sqldef/pull/746

Now `tagpr` is correctly set up and its PRs trigger other GitHub Actions, such as: https://github.com/sqldef/sqldef/pull/748