### PR TITLE
allow update statements without from clause inside triggers

### DIFF
--- a/cmd/mysqldef/tests_views_triggers.yml
+++ b/cmd/mysqldef/tests_views_triggers.yml
@@ -292,3 +292,25 @@ TriggerIf:
     set NEW.sort_order = (select COALESCE(MAX(sort_order) + 1, 1) from test_trigger where set_id = NEW.set_id);
     end if;
     end;
+TriggerUpdate:
+  desired: |
+    CREATE TABLE t1 (
+      id int(11) NOT NULL AUTO_INCREMENT,
+      t2_id int(11),
+      PRIMARY KEY (id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+    CREATE TABLE t2 (
+      id int(11) NOT NULL AUTO_INCREMENT,
+      PRIMARY KEY (id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+    CREATE TRIGGER `t2_BEFORE_DELETE` before delete ON `t2` FOR EACH ROW update t1 set t2_id = null where t1.t2_id = OLD.id;
+TriggerSelect:
+  desired: |
+    CREATE TABLE users (
+      id int unsigned NOT NULL AUTO_INCREMENT,
+      name varchar(255) NOT NULL,
+      deleted_at timestamp NULL DEFAULT NULL,
+      logical_uniqueness tinyint(1) DEFAULT '1',
+      PRIMARY KEY (id)
+    );
+    CREATE TRIGGER `set_logical_uniqueness_on_users` before update ON `users` FOR EACH ROW set NEW.logical_uniqueness = (select 1 from dual);

--- a/parser/node.go
+++ b/parser/node.go
@@ -174,9 +174,16 @@ func (node *Select) setLimit(limit *Limit) {
 
 // Format formats the node.
 func (node *Select) Format(buf *nodeBuffer) {
-	buf.Printf("select %v%s%s%s%v from %v%v%v%v%v%v%s",
+	buf.Printf("select %v%s%s%s%v",
 		node.Comments, node.Cache, node.Distinct, node.Hints, node.SelectExprs,
-		node.From, node.Where,
+	)
+	if node.From.isEmpty() {
+		buf.Printf(" from dual")
+	} else {
+		buf.Printf(" from %v", node.From)
+	}
+	buf.Printf("%v%v%v%v%v%s",
+		node.Where,
 		node.GroupBy, node.Having, node.OrderBy,
 		node.Limit, node.Lock)
 }
@@ -349,7 +356,7 @@ type Update struct {
 // Format formats the node.
 func (node *Update) Format(buf *nodeBuffer) {
 	buf.Printf("update %v%v set %v", node.Comments, node.TableExprs, node.Exprs)
-	if node.From != nil {
+	if !node.From.isEmpty() {
 		buf.Printf(" from %v", node.From)
 	}
 	buf.Printf("%v%v%v", node.Where, node.OrderBy, node.Limit)
@@ -1195,6 +1202,10 @@ func (node TableExprs) Format(buf *nodeBuffer) {
 		buf.Printf("%s%v", prefix, n)
 		prefix = ", "
 	}
+}
+
+func (node TableExprs) isEmpty() bool {
+	return len(node) == 0
 }
 
 // TableExpr represents a table expression.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -6345,7 +6345,7 @@ yydefault:
 		yyDollar = yyS[yypt-0 : yypt+1]
 //line parser/parser.y:2964
 		{
-			yyVAL.tableExprs = TableExprs{&AliasedTableExpr{Expr: TableName{Name: NewTableIdent("dual")}}}
+			yyVAL.tableExprs = TableExprs{}
 		}
 	case 478:
 		yyDollar = yyS[yypt-2 : yypt+1]

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -2962,7 +2962,7 @@ over_expression:
 
 from_opt:
   {
-    $$ = TableExprs{&AliasedTableExpr{Expr:TableName{Name: NewTableIdent("dual")}}}
+    $$ = TableExprs{}
   }
 | FROM table_references
   {


### PR DESCRIPTION

### Description
This fixes https://github.com/sqldef/sqldef/discussions/780

When parsing triggers containing UPDATE statements without FROM clauses, the parser was incorrectly adding `FROM dual` to the UPDATE statement, which is not valid MySQL syntax and would cause execution errors.

### Changes
- Modified the parser to handle empty FROM clauses properly by:
  - Changing `from_opt` rule to return empty `TableExprs{}` instead of automatically adding `dual` table
  - Updated `Update.Format()` to only include FROM clause when `TableExprs` is not empty using new `isEmpty()` method
  - Updated `Select.Format()` to add `FROM dual` only when FROM clause is actually empty (preserving existing SELECT behavior)
