### PR TITLE
ci: run packaging jobs only for tags

### DIFF
--- a/.github/workflows/sqldef.yml
+++ b/.github/workflows/sqldef.yml
@@ -113,6 +113,7 @@ jobs:
           - { GOOS: linux,   GOARCH: arm64, EXT: tar.gz }
           - { GOOS: linux,   GOARCH: arm,   EXT: tar.gz }
           - { GOOS: windows, GOARCH: amd64, EXT: zip }
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/setup-go@v5
         with:
@@ -137,6 +138,7 @@ jobs:
           - { GOOS: darwin, GOARCH: amd64, EXT: zip }
           - { GOOS: darwin, GOARCH: arm64, EXT: zip }
       fail-fast: false
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
They are only necessary for tags.