### PR TITLE
Fix foreign key recreation when dropping referencing tables

### DIFF
--- a/cmd/mssqldef/tests_fk_deps.yml
+++ b/cmd/mssqldef/tests_fk_deps.yml
@@ -274,3 +274,32 @@ ForeignKeyDependenciesMultipleDrops:
         foreign key (supplier_id, item_id) references items(supplier_id, item_id)
     );
   desired: "" # all drops
+
+# Test case: Primary key column rename with foreign key from table that will be dropped
+# When changing a primary key column and a referencing table will be dropped,
+# we should not try to recreate the foreign key constraint
+ForeignKeyWithPrimaryKeyChangeAndDrop:
+  current: |
+    CREATE TABLE users (
+      id int,
+      CONSTRAINT PK_users PRIMARY KEY (id)
+    );
+    CREATE TABLE taggings (
+      user_id int NOT NULL,
+      tag nvarchar(max) NOT NULL,
+      CONSTRAINT taggings_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id)
+    );
+  desired: |
+    CREATE TABLE users (
+      user_id int,
+      name nvarchar(max),
+      CONSTRAINT PK_users PRIMARY KEY (user_id)
+    );
+  output: |
+    ALTER TABLE [dbo].[users] ADD [user_id] int NOT NULL;
+    ALTER TABLE [dbo].[users] ADD [name] nvarchar(max);
+    ALTER TABLE [dbo].[taggings] DROP CONSTRAINT [taggings_user_id_fkey];
+    ALTER TABLE [dbo].[users] DROP CONSTRAINT [PK_users];
+    ALTER TABLE [dbo].[users] ADD CONSTRAINT [PK_users] PRIMARY KEY NONCLUSTERED ([user_id]);
+    DROP TABLE [dbo].[taggings];
+    ALTER TABLE [dbo].[users] DROP COLUMN [id];

--- a/cmd/mysqldef/tests_fk_deps.yml
+++ b/cmd/mysqldef/tests_fk_deps.yml
@@ -243,3 +243,31 @@ ForeignKeyDependenciesMultipleDrops:
         foreign key (supplier_id, item_id) references items(supplier_id, item_id)
     );
   desired: "" # all drops
+
+# Test case: Primary key column rename with foreign key from table that will be dropped
+# When changing a primary key column and a referencing table will be dropped,
+# we should not try to recreate the foreign key constraint
+ForeignKeyWithPrimaryKeyChangeAndDrop:
+  current: |
+    CREATE TABLE users (
+      id integer PRIMARY KEY
+    );
+    CREATE TABLE taggings (
+      user_id integer NOT NULL,
+      tag text NOT NULL,
+      CONSTRAINT taggings_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id)
+    );
+  desired: |
+    CREATE TABLE users (
+      user_id integer PRIMARY KEY,
+      name text
+    );
+  output: |
+    ALTER TABLE `users` ADD COLUMN `user_id` integer NOT NULL FIRST;
+    ALTER TABLE `users` ADD COLUMN `name` text AFTER `user_id`;
+    ALTER TABLE `taggings` DROP FOREIGN KEY `taggings_user_id_fkey`;
+    ALTER TABLE `taggings` DROP INDEX `taggings_user_id_fkey`;
+    ALTER TABLE `users` DROP PRIMARY KEY;
+    ALTER TABLE `users` ADD PRIMARY KEY (`user_id`);
+    DROP TABLE `taggings`;
+    ALTER TABLE `users` DROP COLUMN `id`;

--- a/cmd/psqldef/tests_fk_deps.yml
+++ b/cmd/psqldef/tests_fk_deps.yml
@@ -268,3 +268,30 @@ ForeignKeyDependenciesMultipleDrops:
         foreign key (supplier_id, item_id) references items(supplier_id, item_id)
     );
   desired: "" # all drops
+
+# Test case: Primary key column rename with foreign key from table that will be dropped
+# When changing a primary key column and a referencing table will be dropped,
+# we should not try to recreate the foreign key constraint
+ForeignKeyWithPrimaryKeyChangeAndDrop:
+  current: |
+    CREATE TABLE users (
+      id integer PRIMARY KEY
+    );
+    CREATE TABLE taggings (
+      user_id integer NOT NULL,
+      tag text NOT NULL,
+      CONSTRAINT taggings_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id)
+    );
+  desired: |
+    CREATE TABLE users (
+      user_id integer PRIMARY KEY,
+      name text
+    );
+  output: |
+    ALTER TABLE "public"."users" ADD COLUMN "user_id" integer NOT NULL;
+    ALTER TABLE "public"."users" ADD COLUMN "name" text;
+    ALTER TABLE "public"."taggings" DROP CONSTRAINT "taggings_user_id_fkey";
+    ALTER TABLE "public"."users" DROP CONSTRAINT "users_pkey";
+    ALTER TABLE "public"."users" ADD PRIMARY KEY ("user_id");
+    DROP TABLE "public"."taggings";
+    ALTER TABLE "public"."users" DROP COLUMN "id";


### PR DESCRIPTION
Fixes an issue where changing a primary key column would fail when there are foreign keys from tables that will be dropped.