### PR TITLE
fix permissions

### DIFF
--- a/.github/workflows/sqldef.yml
+++ b/.github/workflows/sqldef.yml
@@ -223,7 +223,7 @@ jobs:
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: sqldef
           repositories: sqldef-preview-action
-          permission-administration: write
+          permission-contents: write
 
       - name: Trigger sqldef-preview-action update
         run: |


### PR DESCRIPTION
https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event

> The fine-grained token must have the following permission set:
>
>    "Contents" repository permissions (write)