### PR TITLE
feat: determine migration scope by desired DDLs at 1st step

### DIFF
--- a/cmd/mysqldef/tests_enable_drop.yml
+++ b/cmd/mysqldef/tests_enable_drop.yml
@@ -7,8 +7,7 @@ DropTableSkipped:
   current: |
     CREATE TABLE users (id bigint NOT NULL);
   desired: ""
-  up: |
-    -- Skipped: DROP TABLE `users`;
+  up: ""
   down: ""
 
 DropViewSkipped:
@@ -18,8 +17,7 @@ DropViewSkipped:
     CREATE VIEW users_view AS SELECT id, name FROM users;
   desired: |
     CREATE TABLE users (id bigint NOT NULL, name varchar(100));
-  up: |
-    -- Skipped: DROP VIEW `users_view`;
+  up: ""
   down: ""
 
 DropColumnSkipped:

--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -1544,6 +1544,7 @@ func TestPsqldefDomainWithTargetSchema(t *testing.T) {
 		}
 		db.SetGeneratorConfig(config)
 
+		db.SetMigrationScope(schema.FullScope())
 		exported, err := db.ExportDDLs()
 		if err != nil {
 			t.Fatal(err)
@@ -1574,6 +1575,7 @@ func TestPsqldefDomainWithTargetSchema(t *testing.T) {
 		}
 		db.SetGeneratorConfig(config)
 
+		db.SetMigrationScope(schema.FullScope())
 		exported, err := db.ExportDDLs()
 		if err != nil {
 			t.Fatal(err)
@@ -1604,6 +1606,7 @@ func TestPsqldefDomainWithTargetSchema(t *testing.T) {
 		}
 		db.SetGeneratorConfig(config)
 
+		db.SetMigrationScope(schema.FullScope())
 		exported, err := db.ExportDDLs()
 		if err != nil {
 			t.Fatal(err)

--- a/cmd/psqldef/tests_enable_drop.yml
+++ b/cmd/psqldef/tests_enable_drop.yml
@@ -7,8 +7,7 @@ DropDomainSkipped:
   current: |
     CREATE DOMAIN email AS TEXT;
   desired: ""
-  up: |
-    -- Skipped: DROP DOMAIN "public"."email";
+  up: ""
   down: ""
 
 DropExtensionSkipped:
@@ -17,8 +16,7 @@ DropExtensionSkipped:
   current: |
     CREATE EXTENSION IF NOT EXISTS btree_gist;
   desired: ""
-  up: |
-    -- Skipped: DROP EXTENSION "btree_gist";
+  up: ""
   down: ""
 
 DropPolicySkipped:
@@ -42,8 +40,7 @@ DropTriggerSkipped:
   desired: |
     CREATE TABLE users (id serial PRIMARY KEY);
     CREATE FUNCTION log_func() RETURNS TRIGGER AS $$ BEGIN RETURN NEW; END; $$ LANGUAGE plpgsql;
-  up: |
-    -- Skipped: DROP TRIGGER log_insert ON public.users;
+  up: ""
   down: ""
 
 DropFunctionSkipped:
@@ -52,8 +49,7 @@ DropFunctionSkipped:
   current: |
     CREATE FUNCTION add_one(x integer) RETURNS integer AS $$ BEGIN RETURN x + 1; END; $$ LANGUAGE plpgsql;
   desired: ""
-  up: |
-    -- Skipped: DROP FUNCTION public.add_one;
+  up: ""
   down: ""
 
 DropTableSkipped:
@@ -61,8 +57,7 @@ DropTableSkipped:
   current: |
     CREATE TABLE users (id bigint NOT NULL);
   desired: ""
-  up: |
-    -- Skipped: DROP TABLE "public"."users";
+  up: ""
   down: ""
 
 DropColumnSkipped:
@@ -104,8 +99,7 @@ DropViewSkipped:
     CREATE VIEW users_view AS SELECT id, name FROM users;
   desired: |
     CREATE TABLE users (id bigint NOT NULL, name text);
-  up: |
-    -- Skipped: DROP VIEW "public"."users_view";
+  up: ""
   down: ""
 
 DropMaterializedViewSkipped:
@@ -115,8 +109,7 @@ DropMaterializedViewSkipped:
     CREATE MATERIALIZED VIEW users_mat AS SELECT id, name FROM users;
   desired: |
     CREATE TABLE users (id bigint NOT NULL, name text);
-  up: |
-    -- Skipped: DROP MATERIALIZED VIEW "public"."users_mat";
+  up: ""
   down: ""
 
 DropTypeSkipped:
@@ -124,8 +117,7 @@ DropTypeSkipped:
   current: |
     CREATE TYPE status AS ENUM ('active', 'inactive');
   desired: ""
-  up: |
-    -- Skipped: DROP TYPE "public"."status";
+  up: ""
   down: ""
 
 RevokePrivilegeSkipped:

--- a/cmd/sqlite3def/tests_enable_drop.yml
+++ b/cmd/sqlite3def/tests_enable_drop.yml
@@ -7,8 +7,7 @@ DropTableSkipped:
   current: |
     CREATE TABLE users (id integer NOT NULL);
   desired: ""
-  up: |
-    -- Skipped: DROP TABLE "users";
+  up: ""
   down: ""
 
 DropViewSkipped:
@@ -18,8 +17,7 @@ DropViewSkipped:
     CREATE VIEW users_view AS SELECT id, name FROM users;
   desired: |
     CREATE TABLE users (id integer NOT NULL, name text);
-  up: |
-    -- Skipped: DROP VIEW "users_view";
+  up: ""
   down: ""
 
 DropTriggerSkipped:
@@ -31,8 +29,7 @@ DropTriggerSkipped:
   desired: |
     CREATE TABLE users (id integer NOT NULL, name text);
     CREATE TABLE audit (msg text);
-  up: |
-    -- Skipped: DROP TRIGGER "users_delete";
+  up: ""
   down: ""
 
 DropColumnSkipped:

--- a/database/database.go
+++ b/database/database.go
@@ -67,6 +67,18 @@ type GeneratorConfig struct {
 	MysqlLowerCaseTableNames int
 }
 
+type MigrationScope struct {
+	Domain    bool
+	Extension bool
+	Function  bool
+	Partition bool
+	Schema    bool
+	Table     bool
+	Trigger   bool
+	Type      bool
+	View      bool
+}
+
 type TransactionQueries struct {
 	Begin    string
 	Commit   string
@@ -180,6 +192,8 @@ type Database interface {
 	GetGeneratorConfig() GeneratorConfig
 	GetTransactionQueries() TransactionQueries
 	GetConfig() Config
+	SetMigrationScope(scope MigrationScope)
+	GetMigrationScope() MigrationScope
 }
 
 func isDryRun(d Database) bool {

--- a/database/dry_run.go
+++ b/database/dry_run.go
@@ -66,6 +66,14 @@ func (d *DryRunDatabase) GetConfig() Config {
 	return d.wrapped.GetConfig()
 }
 
+func (d *DryRunDatabase) SetMigrationScope(scope MigrationScope) {
+	d.wrapped.SetMigrationScope(scope)
+}
+
+func (d *DryRunDatabase) GetMigrationScope() MigrationScope {
+	return d.wrapped.GetMigrationScope()
+}
+
 type dryRunDriver struct {
 	txQueries TransactionQueries
 }

--- a/database/file/database.go
+++ b/database/file/database.go
@@ -11,6 +11,7 @@ import (
 type FileDatabase struct {
 	file            string
 	generatorConfig database.GeneratorConfig
+	migrationScope  database.MigrationScope
 }
 
 func NewDatabase(file string) *FileDatabase {
@@ -53,4 +54,12 @@ func (d *FileDatabase) GetTransactionQueries() database.TransactionQueries {
 
 func (d *FileDatabase) GetConfig() database.Config {
 	return database.Config{}
+}
+
+func (d *FileDatabase) SetMigrationScope(scope database.MigrationScope) {
+	d.migrationScope = scope
+}
+
+func (d *FileDatabase) GetMigrationScope() database.MigrationScope {
+	return d.migrationScope
 }

--- a/database/mssql/database.go
+++ b/database/mssql/database.go
@@ -29,6 +29,7 @@ type MssqlDatabase struct {
 	defaultSchema   *string
 	info            databaseInfo
 	generatorConfig database.GeneratorConfig
+	migrationScope  database.MigrationScope
 }
 
 func NewDatabase(config database.Config) (database.Database, error) {
@@ -890,4 +891,12 @@ func (d *MssqlDatabase) GetTransactionQueries() database.TransactionQueries {
 
 func (d *MssqlDatabase) GetConfig() database.Config {
 	return d.config
+}
+
+func (d *MssqlDatabase) SetMigrationScope(scope database.MigrationScope) {
+	d.migrationScope = scope
+}
+
+func (d *MssqlDatabase) GetMigrationScope() database.MigrationScope {
+	return d.migrationScope
 }

--- a/database/postgres/database_test.go
+++ b/database/postgres/database_test.go
@@ -12,6 +12,7 @@ import (
 
 	_ "github.com/lib/pq"
 	"github.com/sqldef/sqldef/v3/database"
+	"github.com/sqldef/sqldef/v3/schema"
 	"github.com/sqldef/sqldef/v3/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -138,6 +139,7 @@ func TestExtensionOIDCollisionByInjectedDependency(t *testing.T) {
 	db.SetGeneratorConfig(database.GeneratorConfig{
 		LegacyIgnoreQuotes: true,
 	})
+	db.SetMigrationScope(schema.FullScope())
 	exported, err := db.ExportDDLs()
 	require.NoError(t, err)
 
@@ -201,6 +203,7 @@ func TestExtensionOIDCollisionForViews(t *testing.T) {
 	db.SetGeneratorConfig(database.GeneratorConfig{
 		LegacyIgnoreQuotes: true,
 	})
+	db.SetMigrationScope(schema.FullScope())
 	exported, err := db.ExportDDLs()
 	require.NoError(t, err)
 
@@ -262,6 +265,7 @@ func TestExtensionOIDCollisionForFunctions(t *testing.T) {
 	db.SetGeneratorConfig(database.GeneratorConfig{
 		LegacyIgnoreQuotes: true,
 	})
+	db.SetMigrationScope(schema.FullScope())
 	exported, err := db.ExportDDLs()
 	require.NoError(t, err)
 

--- a/schema/ast.go
+++ b/schema/ast.go
@@ -613,3 +613,47 @@ func (t *Table) PrimaryKey() *Index {
 func (keyOption ColumnKeyOption) isUnique() bool {
 	return keyOption == ColumnKeyUnique || keyOption == ColumnKeyUniqueKey
 }
+
+func DesiredScope(ddls []DDL, export bool, drop bool) database.MigrationScope {
+	if export || drop {
+		return FullScope()
+	}
+	scope := database.MigrationScope{}
+	for _, ddl := range ddls {
+		switch ddl.(type) {
+		case *CreatePartitionOf:
+			scope.Partition = true
+		case *CreateTable:
+			scope.Table = true
+		case *Domain:
+			scope.Domain = true
+		case *Extension:
+			scope.Extension = true
+		case *Function:
+			scope.Function = true
+		case *Schema:
+			scope.Schema = true
+		case *Trigger:
+			scope.Trigger = true
+		case *Type:
+			scope.Type = true
+		case *View:
+			scope.View = true
+		}
+	}
+	return scope
+}
+
+func FullScope() database.MigrationScope {
+	return database.MigrationScope{
+		Domain:    true,
+		Extension: true,
+		Function:  true,
+		Partition: true,
+		Schema:    true,
+		Table:     true,
+		Trigger:   true,
+		Type:      true,
+		View:      true,
+	}
+}


### PR DESCRIPTION
Hi there, I just implemented MigrationScope functionality based on input schema.
With this PR, you can keep objects untouched by category which you don't define any DDL.

## Summary

With this change, sqldef first checks the desired DDLs to determine which types of objects are being defined. It then configures the database driver to only fetch the schema information relevant to those objects.

* While sqldef is expanding its support objects, users can limit their exposure against unstable feature at will.
  * Actually this is my main motivation. I'm facing fatal error on `Function` since v3.7.3.
  * As I mentioned in #1060, `psql` can be utilized for emergency.
* Can provide basis for clean config structure.
  * @gfx started #1072 work. I understand our situation is really complex. This PR can separate several exclusion scenario from conigs.
* You may organize each object definitions into separated files and apply partially.
  * Of course, partial migration of one object type is still risky.


## Status

* I implemented full functionality against psqldef, mysqldef and sqlite3def.
  * `make build-*def` works
  * `go test` results all green.
* I partially implemented against mssqldef because I don't have SQLServer facilities.
  * `MigrationScope` is implemented, but not utilized in `ExportDDLs()` yet.  So, mssqldef should behave as same as before.
    * Simple implementation based on the others' `ExportDDLs()` should work.
  * `make build-mssqldef` works
* Several `DROP` test cases are modified to expect no diffs. Previously they expected `-- Skipped: ...` outputs.
  * It is the core intension of this PR.
  * Resulting behavior is the same as before.
* `EnableDrop` and `Export` option keeps previous behavior.
  * It is provided by `FullScope()`.

In favor of clarity, this PR leaves further works like:

* Desired DDLs are parsed multiple times at this time.
* Several options like `--skip-view`, `--skip-extension` may be removed.
