### PR TITLE
Add "--skip-function" option to psqldef

### DIFF
--- a/cmd-psqldef.md
+++ b/cmd-psqldef.md
@@ -23,6 +23,7 @@ Application Options:
       --skip-view             Skip managing views/materialized views
       --skip-extension        Skip managing extensions
       --skip-partition        Skip managing partitioned tables
+      --skip-function         Skip managing functions
       --before-apply=SQL      Execute the given string before applying the regular DDLs
       --config=PATH           YAML configuration file (can be specified multiple times)
       --config-inline=YAML    YAML configuration as inline string (can be specified multiple times)

--- a/cmd/psqldef/psqldef.go
+++ b/cmd/psqldef/psqldef.go
@@ -39,6 +39,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		SkipView      bool     `long:"skip-view" description:"Skip managing views/materialized views"`
 		SkipExtension bool     `long:"skip-extension" description:"Skip managing extensions"`
 		SkipPartition bool     `long:"skip-partition" description:"Skip managing partitioned tables"`
+		SkipFunction  bool     `long:"skip-function" description:"Skip managing functions"`
 		BeforeApply   string   `long:"before-apply" description:"Execute the given string before applying the regular DDLs" value-name:"SQL"`
 
 		// Custom handlers for config flags to preserve order
@@ -142,6 +143,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		SkipView:              opts.SkipView,
 		SkipExtension:         opts.SkipExtension,
 		SkipPartition:         opts.SkipPartition,
+		SkipFunction:          opts.SkipFunction,
 		TargetSchema:          options.Config.TargetSchema,
 		DumpConcurrency:       options.Config.DumpConcurrency,
 		DisableDdlTransaction: options.Config.DisableDdlTransaction,

--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -813,6 +813,23 @@ func TestPsqldefSkipExtension(t *testing.T) {
 	assert.Equal(t, nothingModified, output)
 }
 
+func TestPsqldefSkipFunction(t *testing.T) {
+	resetTestDatabase()
+
+	createFunction := `CREATE OR REPLACE FUNCTION quote(sql varchar) RETURNS varchar AS $$
+  BEGIN
+    RETURN '"' || sql || '"';
+  END;
+  $$ LANGUAGE plpgsql;`
+
+	mustPgExec(testDatabaseName, createFunction)
+
+	tu.WriteFile("schema.sql", "")
+
+	output := tu.MustExecute(t, "./psqldef", psqldefArgs(testDatabaseName, "--skip-function", "-f", "schema.sql")...)
+	assert.Equal(t, nothingModified, output)
+}
+
 func TestPsqldefSkipPartition(t *testing.T) {
 	resetTestDatabase()
 

--- a/database/database.go
+++ b/database/database.go
@@ -23,6 +23,9 @@ type Config struct {
 	SkipExtension bool
 	SkipPartition bool
 
+	// Only PostgreSQL
+	SkipFunction bool
+
 	// Only MySQL
 	MySQLEnableCleartextPlugin bool
 

--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -577,6 +577,10 @@ func (d *PostgresDatabase) domains() ([]string, error) {
 
 // functions fetches user-defined functions from the database
 func (d *PostgresDatabase) functions() ([]string, error) {
+	if d.config.SkipFunction {
+		return []string{}, nil
+	}
+
 	// Query to get user-defined functions (excluding system functions and extension functions)
 	// We use pg_get_functiondef to get the complete function definition
 	// pg_get_function_identity_arguments gives us the function signature for comments

--- a/database/postgres/database_test.go
+++ b/database/postgres/database_test.go
@@ -273,6 +273,24 @@ func TestExtensionOIDCollisionForFunctions(t *testing.T) {
 		funcOID, pgTypeClassID)
 }
 
+func TestSkipFunction(t *testing.T) {
+	db := setupTestDatabase(t)
+	db.config.SkipFunction = true
+	defer db.Close()
+
+	// Create a function
+	_, err := db.DB().Exec(`CREATE OR REPLACE FUNCTION quote(sql varchar) RETURNS varchar AS $$
+    BEGIN
+      RETURN '"' || sql || '"';
+    END;
+    $$ LANGUAGE plpgsql;`)
+	require.NoError(t, err)
+
+	exported, err := db.ExportDDLs()
+	require.NoError(t, err)
+	assert.Empty(t, exported)
+}
+
 // Helper functions
 
 func setupTestDatabase(t *testing.T) *PostgresDatabase {


### PR DESCRIPTION
Add the `--skip-function` option to psqldef.

---

The problem I'm having is that exporting the following functions fails:

```sql
CREATE OR REPLACE FUNCTION quote(sql varchar) RETURNS varchar AS $$
BEGIN
  RETURN '"' || sql || '"';
END;
$$ LANGUAGE plpgsql;
```

```
$ psqldef --export -h localhost  -U postgres postgres
2026/02/06 18:32:34 WARN Generic parser failed on full SQL, using pgquery fallback error="found syntax error when parsing DDL \"CREATE OR REPLACE FUNCTION public.quote(sql character varying)\n RETURNS character varying\n LANGUAGE plpgsql\nAS $function$\n        BEGIN\n                RETURN '\"' || sql || '\"';\n        END;\n$function$\": syntax error at line 1, column 45 near 'sql'\n  CREATE OR REPLACE FUNCTION public.quote(sql character varying)\n                                              ^"
```

This is because the identifier `sql` is parsed as an **SQL** token.

When modifying the parser, I think it's necessary to allow the use of non-reserved keywords as arguments. (**UNUSED**, **CURSOR**, etc..)

However, since the impact of the changes is unclear, this Pull Request adds an option to skip the function.

---

This option is not a good interface.

1. Does not ignore the DesiredDDL function.
2. Cannot specify function names to skip.

I made it behave similarly to `--skip-extension`.

---

If there are any issues, I will fix them.

If it does not comply with the design policy, please reject it.

---

(I ignored `psqldef.go` coverage because I wasn't sure if I should test it.)