### PR TITLE
Fix CHECK constraint idempotency for time columns with bare literals in psqldef

### DIFF
--- a/cmd/psqldef/tests_datatypes.yml
+++ b/cmd/psqldef/tests_datatypes.yml
@@ -940,12 +940,34 @@ TypedLiteralsInCheckWithCast:
     );
   up: |
     ALTER TABLE "public"."events" ADD COLUMN "event_date" date CHECK (event_date >= '2020-01-01');
-    ALTER TABLE "public"."events" ADD COLUMN "event_time" time CHECK (event_time >= '09:00:00'::time);
+    ALTER TABLE "public"."events" ADD COLUMN "event_time" time CHECK (event_time >= '09:00:00');
     ALTER TABLE "public"."events" ADD COLUMN "event_end_date" date CHECK (event_end_date <= '2030-12-31');
   down: |
     ALTER TABLE "public"."events" DROP COLUMN "event_end_date";
     ALTER TABLE "public"."events" DROP COLUMN "event_time";
     ALTER TABLE "public"."events" DROP COLUMN "event_date";
+CheckWithTimeColumnBareLiteralIsIdempotent:
+  desired: |
+    CREATE TABLE samples (
+      id bigserial PRIMARY KEY,
+      flag boolean NOT NULL DEFAULT false,
+      start_at time NOT NULL,
+      end_at time NOT NULL,
+      CHECK (start_at <> end_at),
+      CHECK (
+        NOT flag
+        OR (start_at >= '00:00:00' AND end_at <= '06:00:00' AND start_at < end_at)
+      )
+    );
+  legacy_ignore_quotes: false
+CheckWithExplicitTimeCastIsIdempotent:
+  desired: |
+    CREATE TABLE samples (
+      id bigserial PRIMARY KEY,
+      start_at time NOT NULL,
+      CHECK (start_at >= '00:00:00'::time)
+    );
+  legacy_ignore_quotes: false
 # Multi-dimensional array support
 CreateTableWithMultiDimensionalArrays:
   desired: |

--- a/schema/normalize.go
+++ b/schema/normalize.go
@@ -211,7 +211,6 @@ func normalizeCheckExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 
 			// Remove date/timestamp casts from string literals
 			// PostgreSQL simplifies '2020-01-01'::date to '2020-01-01' in CHECK constraints
-			// But keeps time casts: time '09:00:00' becomes '09:00:00'::time
 			if normalizedTypeStr == "date" || normalizedTypeStr == "timestamp" {
 				return normalizeCheckExpr(e.Expr, mode)
 			}
@@ -466,22 +465,10 @@ func normalizeCheckExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 			Qualifier: parser.TableName{Name: qualifier},
 		}
 	case *parser.TypedLiteral:
-		// PostgreSQL normalizes typed literals differently based on type:
-		// - DATE 'value' -> 'value' (removes type prefix)
-		// - TIMESTAMP 'value' -> 'value' (removes type prefix)
-		// - TIME 'value' -> 'value'::time (converts to cast expression)
-		// - TIMETZ 'value' -> 'value'::timetz (converts to cast expression)
-		typeStr := strings.ToLower(e.Type)
-
-		// For time types, convert to cast expression
-		if strings.HasPrefix(typeStr, "time") {
-			return &parser.CastExpr{
-				Expr: normalizeCheckExpr(e.Value, mode),
-				Type: &parser.ConvertType{Type: typeStr},
-			}
-		}
-
-		// For date/timestamp, remove the type prefix
+		// Strip the type prefix for all temporal literals.
+		// PostgreSQL's pg_get_constraintdef emits typed literals for time/timestamp/date
+		// when comparing to typed columns, but user SQL often writes bare literals.
+		// Dropping the type prefix on both sides makes them compare equal.
 		return normalizeCheckExpr(e.Value, mode)
 	default:
 		// For all other expression types (literals, etc.), return as-is


### PR DESCRIPTION
## Summary

`psqldef` generates unnecessary `DROP CONSTRAINT` + `ADD CONSTRAINT` statements for CHECK constraints on `time`/`timetz` columns when the literal is written without a cast (e.g. `'00:00:00'`), on every run, even when the schema is already up to date.

Example:

```sql
CREATE TABLE samples (
    start_at time NOT NULL,
    end_at   time NOT NULL,
    CHECK (start_at >= '00:00:00' AND end_at <= '06:00:00')
);
```

## Root Cause

PostgreSQL's `pg_get_constraintdef` appends `::time without time zone` to bare literals compared with `time` columns, and sqldef's generic parser renders that form as the typed literal `time '00:00:00'`:

```
c_date_check | CHECK ((c_date >= '2020-01-01'::date))
c_time_check | CHECK ((c_time >= '09:00:00'::time without time zone))
c_ts_check   | CHECK ((c_ts >= '2020-01-01 00:00:00'::timestamp without time zone))
```

User SQL almost always writes bare literals. In `schema/normalize.go`, the `TypedLiteral` branch of `normalizeCheckExpr` stripped the type prefix for `DATE` / `TIMESTAMP` but rewrote `TIME`/`TIMETZ` typed literals into `CastExpr` (keeping the `::time` cast). The comment claimed PostgreSQL preserves time casts "for precision", but `pg_get_constraintdef` treats all three temporal types the same.

As a result:

- Desired (user): `start_at >= '00:00:00'`
- Exported (DB): `start_at >= time '00:00:00'` → normalized to `'00:00:00'::time`

always compared unequal, forcing a DROP + ADD on every run.

The existing `TypedLiteralsInCheckWithCast` test passed only because both `desired` and the expected `up` DDL used the same `::time` cast form, so no bare-literal case was exercised.

## Fix

In `normalizeCheckExpr`'s `TypedLiteral` branch, strip the type prefix for all temporal typed literals uniformly — including `TIME`/`TIMETZ` — instead of rewriting them to `CastExpr`. The `CastExpr` branch is left untouched: the generic parser already discards `'value'::time` casts on string literals during parsing, so they never reach normalization, and stripping a `col::time` CastExpr would be unsafe since it drops information needed for column-expression comparisons.

## Changes

- `schema/normalize.go`: `TypedLiteral` branch now returns `normalizeCheckExpr(e.Value, mode)` for every temporal type, matching existing `DATE`/`TIMESTAMP` behavior
- `cmd/psqldef/tests_datatypes.yml`:
  - Updated `TypedLiteralsInCheckWithCast` `up` expectation to drop `::time`
  - Added `CheckWithTimeColumnBareLiteralIsIdempotent` (bare-literal form)
  - Added `CheckWithExplicitTimeCastIsIdempotent` (explicit `'value'::time` form)

## Testing

- `PSQLDEF_PARSER=generic go test ./cmd/psqldef` — all tests pass
- Verified `CheckWithTimeColumnBareLiteralIsIdempotent` fails with the fix reverted and passes with it applied