### PR TITLE
Error by working with postgres and partitions. Cannot work with indexes or constrains on partitions.

### DIFF
--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -231,6 +231,7 @@ func (d *PostgresDatabase) partitionChildTables() ([]string, error) {
 		INNER JOIN pg_catalog.pg_class pc ON i.inhparent = pc.oid
 		INNER JOIN pg_catalog.pg_namespace pn ON pc.relnamespace = pn.oid
 		WHERE c.relispartition = true
+		AND c.relpartbound IS NOT NULL
 		AND n.nspname NOT IN ('information_schema', 'pg_catalog', 'sys')
 		AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_depend d WHERE c.oid = d.objid AND d.classid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'pg_class') AND d.deptype = 'e')
 		ORDER BY n.nspname ASC, c.relname ASC;


### PR DESCRIPTION
Hi,

I noticed that if the partition have a constrain or index, the following error is thrown:


`2026/04/26 17:20:58 Error on ExportDDLs: sql: Scan error on column index 4, name "partition_bound": converting NULL to string is unsupported`

I fixed it by filtering the others out. I used relpartbound IS NOT NULL. If you preferer something more specific, It could be filtered by relkind ( https://www.postgresql.org/docs/current/catalog-pg-class.html ). But more tests are necessary to check all the types of objects.

I tested the change on Postgres 16 and 18 and its working fine. 