### PR TITLE
feat(MySQL): add --bulk-alter to fuse ALTER TABLE actions per table 

### DIFF
--- a/cmd-mysqldef.md
+++ b/cmd-mysqldef.md
@@ -26,6 +26,7 @@ Application Options:
       --export                      Just dump the current schema to stdout
       --enable-drop                 Enable destructive changes such as DROP for TABLE, SCHEMA, ROLE, USER, FUNCTION, PROCEDURE, TRIGGER, VIEW, INDEX, SEQUENCE, TYPE
       --skip-view                   Skip managing views (temporary feature, to be removed later)
+      --bulk-alter                  Bundle multiple ALTER TABLE actions on the same table into a single statement
       --before-apply=SQL            Execute the given string before applying the regular DDLs
       --config=PATH                 YAML configuration file (can be specified multiple times)
       --config-inline=YAML          YAML configuration as inline string (can be specified multiple times)
@@ -430,6 +431,7 @@ $ mysqldef -uroot dbname --apply \
 | `algorithm` | string | Algorithm to use for ALTER TABLE operations (e.g., INPLACE, INSTANT, COPY). Controls how MySQL performs the schema change. |
 | `lock` | string | Lock level to use for ALTER TABLE operations (e.g., NONE, SHARED, EXCLUSIVE). Controls concurrent access during schema changes. |
 | `dump_concurrency` | integer | Number of parallel connections to use when exporting the schema. Improves performance for large schemas. Default is 1. |
+| `bulk_alter` | boolean | When true, the column and constraint changes on the same table (adds, drops, type changes, and cleanup drops of columns, checks, indexes, and foreign keys) are bundled into a single `ALTER TABLE t a1, a2, ...` statement (acquires one DDL lock per migration per table instead of one per action). Index and foreign-key creation, and table renames, remain separate statements. Equivalent to `--bulk-alter`. Default is false. **TiDB caveat:** TiDB validates the entire `ALTER TABLE` against the pre-execution schema, so a bundled `ADD COLUMN ... AFTER <col-added-in-the-same-statement>` is rejected (see [TiDB ALTER TABLE docs](https://docs.pingcap.com/tidb/stable/sql-statement-alter-table/)). Avoid `bulk_alter` on TiDB if your schema causes column adds with `AFTER` to reference newly-added columns. |
 | `legacy_ignore_quotes` | boolean | Controls identifier quoting behavior. When `true` (default), all identifiers are quoted in output. When `false`, identifiers preserve their original quoting from the source SQL. Default is `true` but will change to `false` in the next major version. |
 
 ## MariaDB Compatibility

--- a/cmd/mysqldef/mysqldef.go
+++ b/cmd/mysqldef/mysqldef.go
@@ -43,6 +43,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		Export                bool     `long:"export" description:"Just dump the current schema to stdout"`
 		EnableDrop            bool     `long:"enable-drop" description:"Enable destructive changes such as DROP for TABLE, SCHEMA, ROLE, USER, FUNCTION, PROCEDURE, TRIGGER, VIEW, INDEX, SEQUENCE, TYPE"`
 		SkipView              bool     `long:"skip-view" description:"Skip managing views (temporary feature, to be removed later)"`
+		BulkAlter             bool     `long:"bulk-alter" description:"Bundle multiple ALTER TABLE actions on the same table into a single statement"`
 		BeforeApply           string   `long:"before-apply" description:"Execute the given string before applying the regular DDLs" value-name:"SQL"`
 
 		// Custom handlers for config flags to preserve order
@@ -96,6 +97,9 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 
 	if opts.EnableDrop {
 		config.EnableDrop = true
+	}
+	if opts.BulkAlter {
+		config.BulkAlter = true
 	}
 
 	options := sqldef.Options{

--- a/cmd/mysqldef/tests_bulk_alter.yml
+++ b/cmd/mysqldef/tests_bulk_alter.yml
@@ -1,0 +1,149 @@
+# yaml-language-server: $schema=../../testutil/testcase.schema.json
+
+# These cases exercise bulk_alter: a table's add/change ALTERs and its later
+# drop ALTERs are fused into one `ALTER TABLE t a1, a2, ...` statement.
+#
+# TiDB note: bundles that contain `ADD COLUMN ... AFTER <col-added-in-the
+# -same-ALTER>` fail on TiDB because it cannot resolve the just-added column
+# in subsequent subcommands of the same statement (MySQL processes the
+# subcommands sequentially and accepts this). Tests that emit such a bundle
+# are marked `flavor: !tidb`.
+# Ref. https://docs.pingcap.com/tidb/stable/sql-statement-alter-table/
+
+BulkAlterAddDropColumns:
+  legacy_ignore_quotes: false
+  flavor: "!tidb"
+  config:
+    bulk_alter: true
+  current: |
+    CREATE TABLE patients (
+      id bigint NOT NULL,
+      c int
+    );
+  desired: |
+    CREATE TABLE patients (
+      id bigint NOT NULL,
+      a int,
+      b int
+    );
+  up: |
+    ALTER TABLE patients ADD COLUMN a int AFTER id, ADD COLUMN b int AFTER a, DROP COLUMN `c`;
+  down: |
+    ALTER TABLE patients ADD COLUMN c int AFTER id, DROP COLUMN `b`, DROP COLUMN `a`;
+
+BulkAlterDisabledByDefault:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TABLE patients (
+      id bigint NOT NULL,
+      c int
+    );
+  desired: |
+    CREATE TABLE patients (
+      id bigint NOT NULL,
+      a int,
+      b int
+    );
+  up: |
+    ALTER TABLE patients ADD COLUMN a int AFTER id;
+    ALTER TABLE patients ADD COLUMN b int AFTER a;
+    ALTER TABLE patients DROP COLUMN `c`;
+  down: |
+    ALTER TABLE patients ADD COLUMN c int AFTER id;
+    ALTER TABLE patients DROP COLUMN `b`;
+    ALTER TABLE patients DROP COLUMN `a`;
+
+BulkAlterQuotedTableNames:
+  flavor: "!tidb"
+  config:
+    bulk_alter: true
+  current: |
+    CREATE TABLE patients (
+      id bigint NOT NULL,
+      c int
+    );
+  desired: |
+    CREATE TABLE patients (
+      id bigint NOT NULL,
+      a int,
+      b int
+    );
+  up: |
+    ALTER TABLE `patients` ADD COLUMN `a` int AFTER `id`, ADD COLUMN `b` int AFTER `a`, DROP COLUMN `c`;
+  down: |
+    ALTER TABLE `patients` ADD COLUMN `c` int AFTER `id`, DROP COLUMN `b`, DROP COLUMN `a`;
+
+BulkAlterPerTableScope:
+  legacy_ignore_quotes: false
+  flavor: "!tidb"
+  config:
+    bulk_alter: true
+  current: |
+    CREATE TABLE a (
+      id bigint NOT NULL
+    );
+    CREATE TABLE b (
+      id bigint NOT NULL
+    );
+  desired: |
+    CREATE TABLE a (
+      id bigint NOT NULL,
+      x int,
+      y int
+    );
+    CREATE TABLE b (
+      id bigint NOT NULL,
+      x int,
+      y int
+    );
+  up: |
+    ALTER TABLE a ADD COLUMN x int AFTER id, ADD COLUMN y int AFTER x;
+    ALTER TABLE b ADD COLUMN x int AFTER id, ADD COLUMN y int AFTER x;
+  down: |
+    ALTER TABLE a DROP COLUMN `y`, DROP COLUMN `x`;
+    ALTER TABLE b DROP COLUMN `y`, DROP COLUMN `x`;
+
+BulkAlterKeepsDropStandaloneWhenDropDisabled:
+  legacy_ignore_quotes: false
+  flavor: "!tidb"
+  enable_drop: false
+  config:
+    bulk_alter: true
+  current: |
+    CREATE TABLE patients (
+      id bigint NOT NULL,
+      c int
+    );
+  desired: |
+    CREATE TABLE patients (
+      id bigint NOT NULL,
+      a int,
+      b int
+    );
+  up: |
+    ALTER TABLE patients ADD COLUMN a int AFTER id, ADD COLUMN b int AFTER a;
+    -- Skipped: ALTER TABLE patients DROP COLUMN `c`;
+  down: |
+    -- Skipped: ALTER TABLE patients DROP COLUMN `b`;
+    -- Skipped: ALTER TABLE patients DROP COLUMN `a`;
+
+BulkAlterFusesCleanupIndexDropInQuoteAwareMode:
+  legacy_ignore_quotes: false
+  flavor: "!tidb"
+  config:
+    bulk_alter: true
+  current: |
+    CREATE TABLE items (
+      id bigint NOT NULL,
+      c int,
+      KEY idx_c (c)
+    );
+  desired: |
+    CREATE TABLE items (
+      id bigint NOT NULL,
+      a int
+    );
+  up: |
+    ALTER TABLE items ADD COLUMN a int AFTER id, DROP INDEX `idx_c`, DROP COLUMN `c`;
+  down: |
+    ALTER TABLE items ADD COLUMN c int AFTER id, ADD KEY idx_c (c), DROP COLUMN `a`;

--- a/database/database.go
+++ b/database/database.go
@@ -62,6 +62,7 @@ type GeneratorConfig struct {
 	EnableDrop              bool     // Whether to enable DROP/REVOKE operations
 	CreateIndexConcurrently bool     // Whether to add CONCURRENTLY to CREATE INDEX statements
 	DisableDdlTransaction   bool     // Do not use a transaction for DDL statements
+	BulkAlter               bool     // Bundle multiple ALTER TABLE actions on the same table into a single statement (MySQL only)
 	LegacyIgnoreQuotes      bool     // true = ignore quotes (legacy), false = preserve quotes
 
 	ManageExtensions *[]ManageObjectRule
@@ -361,6 +362,9 @@ func MergeGeneratorConfig(base, override GeneratorConfig) GeneratorConfig {
 	if override.DisableDdlTransaction {
 		result.DisableDdlTransaction = override.DisableDdlTransaction
 	}
+	if override.BulkAlter {
+		result.BulkAlter = override.BulkAlter
+	}
 	// LegacyIgnoreQuotes: override always takes precedence (set by first config with database-specific default)
 	result.LegacyIgnoreQuotes = override.LegacyIgnoreQuotes
 
@@ -380,6 +384,7 @@ func parseGeneratorConfigFromBytes(buf []byte, defaults GeneratorConfig) Generat
 		EnableDrop              bool                       `yaml:"enable_drop"`
 		CreateIndexConcurrently bool                       `yaml:"create_index_concurrently"`
 		DisableDdlTransaction   bool                       `yaml:"disable_ddl_transaction"`
+		BulkAlter               bool                       `yaml:"bulk_alter"`
 		LegacyIgnoreQuotes      *bool                      `yaml:"legacy_ignore_quotes"`
 		Manage                  map[string]yaml.RawMessage `yaml:"manage"`
 	}
@@ -440,6 +445,7 @@ func parseGeneratorConfigFromBytes(buf []byte, defaults GeneratorConfig) Generat
 		EnableDrop:              config.EnableDrop,
 		CreateIndexConcurrently: config.CreateIndexConcurrently,
 		DisableDdlTransaction:   config.DisableDdlTransaction,
+		BulkAlter:               config.BulkAlter,
 		LegacyIgnoreQuotes:      legacyIgnoreQuotes,
 		ManageExtensions:        manageExtensions,
 	}

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -209,6 +209,9 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 	exclusionDDLs := []string{}
 	viewDDLs := []string{}
 
+	// bulkAlter fuses per-table ALTER TABLE actions when --bulk-alter is set (MySQL only).
+	bulkAlter := newAlterBundler(g, g.config.BulkAlter && g.mode == GeneratorModeMysql)
+
 	// Incrementally examine desiredDDLs
 	for _, ddl := range desiredDDLs {
 		switch desired := ddl.(type) {
@@ -222,8 +225,8 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 				for _, tableDDL := range tableDDLs {
 					if isAddConstraintForeignKey(tableDDL) {
 						foreignKeyDDLs = append(foreignKeyDDLs, tableDDL)
-					} else {
-						interDDLs = append(interDDLs, tableDDL)
+					} else if out := bulkAlter.emit(&desired.table, tableDDL); out != "" {
+						interDDLs = append(interDDLs, out)
 					}
 				}
 				mergeTable(currentTable, desired.table)
@@ -250,8 +253,8 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 						for _, tableDDL := range tableDDLs {
 							if isAddConstraintForeignKey(tableDDL) {
 								foreignKeyDDLs = append(foreignKeyDDLs, tableDDL)
-							} else {
-								interDDLs = append(interDDLs, tableDDL)
+							} else if out := bulkAlter.emit(&desired.table, tableDDL); out != "" {
+								interDDLs = append(interDDLs, out)
 							}
 						}
 						mergeTable(oldTable, desired.table)
@@ -471,11 +474,21 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 		}
 	}
 
-	// Clean up obsoleted indexes, columns in remaining tables
+	// Clean up obsoleted indexes, columns in remaining tables. Cleanup drops are
+	// routed through appendDDL so bulk_alter can fuse them with the table's
+	// diff-phase ALTER TABLE.
 	for _, currentTable := range g.currentTables {
 		desiredTable := g.findTableByName(g.desiredTables, currentTable.name)
 		if desiredTable == nil {
 			continue // Already handled in drop tables above
+		}
+
+		appendDDL := func(in ...string) {
+			for _, ddl := range in {
+				if out := bulkAlter.emit(desiredTable, ddl); out != "" {
+					ddls = append(ddls, out)
+				}
+			}
 		}
 
 		// Table is expected to exist. Drop foreign keys prior to index deletion
@@ -506,7 +519,7 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 
 			// The foreign key seems obsoleted. Check and drop it as needed.
 			foreignKeyDDLs := g.generateDDLsForAbsentForeignKey(foreignKey, *currentTable, *desiredTable)
-			ddls = append(ddls, foreignKeyDDLs...)
+			appendDDL(foreignKeyDDLs...)
 			// TODO: simulate to remove foreign key from `currentTable.foreignKeys`?
 		}
 
@@ -521,7 +534,7 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 				continue
 			}
 
-			ddls = append(ddls, fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s", g.escapeTableName(currentTable), g.escapeSQLIdent(exclusion.constraintName)))
+			appendDDL(fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s", g.escapeTableName(currentTable), g.escapeSQLIdent(exclusion.constraintName)))
 		}
 
 		// Check indexes
@@ -563,7 +576,7 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 			if err != nil {
 				return ddls, err
 			}
-			ddls = append(ddls, indexDDLs...)
+			appendDDL(indexDDLs...)
 			g.trackDroppedIndex(currentTable, index)
 			// TODO: simulate to remove index from `currentTable.indexes`?
 		}
@@ -588,7 +601,7 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 			// MySQL 8.0.16+, MariaDB 10.2+, TiDB, PostgreSQL, MSSQL, SQLite. MySQL
 			// 5.7 parses but does not enforce CHECK, so this branch never fires for
 			// it. MariaDB does not accept DROP CHECK <name>, only DROP CONSTRAINT.
-			ddls = append(ddls, fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s", g.escapeTableName(currentTable), g.escapeSQLIdent(check.constraintName)))
+			appendDDL(fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s", g.escapeTableName(currentTable), g.escapeSQLIdent(check.constraintName)))
 		}
 
 		// Check columns.
@@ -613,7 +626,7 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 			if !isRenamed {
 				// Column is obsoleted. Drop column.
 				columnDDLs := g.generateDDLsForAbsentColumn(currentTable, desiredTable, column)
-				ddls = append(ddls, columnDDLs...)
+				appendDDL(columnDDLs...)
 				// Track dropped column for later (to skip generating COMMENT cleanup DDLs)
 				g.trackDroppedColumn(currentTable, column)
 			}
@@ -624,7 +637,7 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 			if g.findPolicyByName(desiredTable.policies, policy.name) != nil {
 				continue
 			}
-			ddls = append(ddls, fmt.Sprintf("DROP POLICY %s ON %s", g.escapeSQLIdent(policy.name), g.escapeTableName(currentTable)))
+			appendDDL(fmt.Sprintf("DROP POLICY %s ON %s", g.escapeSQLIdent(policy.name), g.escapeTableName(currentTable)))
 		}
 
 		// Check row level security.
@@ -635,6 +648,10 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 			ddls = append(ddls, fmt.Sprintf("ALTER TABLE %s DISABLE ROW LEVEL SECURITY", g.escapeTableName(currentTable)))
 		}
 	}
+
+	// Must run before the ALGORITHM/LOCK suffixing and drop-commenting below so
+	// those passes see each table's fused statement, not the placeholder.
+	ddls = bulkAlter.finalize(ddls)
 
 	// Clean up obsoleted domains
 	for _, currentDomain := range g.currentDomains {
@@ -815,6 +832,106 @@ func isDropStatement(ddl string) bool {
 		strings.Contains(ddl, "DISABLE ROW LEVEL SECURITY") ||
 		strings.Contains(ddl, "NO FORCE ROW LEVEL SECURITY") ||
 		strings.Contains(ddl, "REVOKE ")
+}
+
+// alterTablePrefix returns "ALTER TABLE <escaped-table-name> ", the prefix the
+// generator prepends to every ALTER TABLE statement for the table.
+func (g *Generator) alterTablePrefix(table *Table) string {
+	return "ALTER TABLE " + g.escapeTableName(table) + " "
+}
+
+// alterBundler fuses the ALTER TABLE actions on one table into a single
+// `ALTER TABLE t a1, a2, ...` statement (--bulk-alter, MySQL only). The caller
+// passes emit() the owning *Table, so the table is known structurally rather
+// than rediscovered from the statement text. See emit and finalize.
+type alterBundler struct {
+	g       *Generator
+	enabled bool
+	byTable map[string]*alterBundle // keyed by ALTER TABLE prefix
+}
+
+// alterBundle accumulates the action texts of one table's ALTER TABLE
+// statements, sharing the common prefix `ALTER TABLE <name> `.
+type alterBundle struct {
+	prefix  string
+	actions []string
+}
+
+func (b *alterBundle) render() string {
+	return b.prefix + strings.Join(b.actions, ", ")
+}
+
+func newAlterBundler(g *Generator, enabled bool) *alterBundler {
+	b := &alterBundler{g: g, enabled: enabled}
+	if enabled {
+		b.byTable = map[string]*alterBundle{}
+	}
+	return b
+}
+
+// emit records stmt as an action of table's bundle and returns what to append
+// in its place. When bundling is off, or stmt is not an ALTER TABLE for table,
+// stmt is returned unchanged. The first action for a table returns a
+// placeholder (the table's prefix, which no complete statement equals) holding
+// the bundle's position; later actions fold in and return "" (append nothing).
+// finalize later rewrites the placeholder into the fused statement.
+func (b *alterBundler) emit(table *Table, stmt string) string {
+	if !b.enabled {
+		return stmt
+	}
+	// When drops are disabled they are commented out individually later by
+	// commentOutDropStatements. Fusing a drop with non-drop actions would make
+	// the whole statement match isDropStatement, so the entire ALTER TABLE
+	// (including its ADD/MODIFY actions) would be commented out. Keep such
+	// statements standalone so only the drop itself is skipped.
+	if !b.g.config.EnableDrop && isDropStatement(stmt) {
+		return stmt
+	}
+	// The bundle key uses the desired table's quoting, matching the diff phase.
+	// Cleanup DROP INDEX / DROP CONSTRAINT statements escape the table with the
+	// current schema's quoting, which can differ in quote-aware mode, so accept
+	// either quoting of the same table name.
+	key := b.g.alterTablePrefix(table)
+	action, ok := b.cutAlterPrefix(table, stmt)
+	if !ok {
+		return stmt // not a plain ALTER TABLE for this table
+	}
+	if bundle := b.byTable[key]; bundle != nil {
+		bundle.actions = append(bundle.actions, action)
+		return ""
+	}
+	b.byTable[key] = &alterBundle{prefix: key, actions: []string{action}}
+	return key
+}
+
+// cutAlterPrefix strips the "ALTER TABLE <name> " prefix for table from stmt,
+// accepting both the unquoted and quoted forms of the table name. The diff phase
+// escapes the table with the desired schema's quoting while some cleanup drops
+// use the current schema's quoting; in quote-aware mode these differ, and both
+// must fold into the same bundle. Returns the remaining action text and whether
+// a prefix matched.
+func (b *alterBundler) cutAlterPrefix(table *Table, stmt string) (string, bool) {
+	raw := table.name.Name.Name
+	for _, name := range []string{raw, b.g.forceEscapeSQLName(raw)} {
+		if action, ok := strings.CutPrefix(stmt, "ALTER TABLE "+name+" "); ok {
+			return action, true
+		}
+	}
+	return "", false
+}
+
+// finalize rewrites each table's placeholder into its fused ALTER TABLE
+// statement, mutating ddls in place.
+func (b *alterBundler) finalize(ddls []string) []string {
+	if !b.enabled {
+		return ddls
+	}
+	for i, ddl := range ddls {
+		if bundle, ok := b.byTable[ddl]; ok {
+			ddls[i] = bundle.render()
+		}
+	}
+	return ddls
 }
 
 func (g *Generator) generateDDLsForAbsentColumn(currentTable *Table, desiredTable *Table, column *Column) []string {

--- a/schema/generator_test.go
+++ b/schema/generator_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sqldef/sqldef/v3/database"
 	"github.com/sqldef/sqldef/v3/parser"
 	"github.com/stretchr/testify/assert"
 )
@@ -450,6 +451,90 @@ func TestAreSameForeignKeysConstraintOptionsNilVsDefault(t *testing.T) {
 		"FK with nil ConstraintOptions and FK with default ConstraintOptions{false, false} should be considered the same")
 	assert.True(t, g.areSameForeignKeys(fkDefault, fkNil),
 		"FK with default ConstraintOptions{false, false} and FK with nil ConstraintOptions should be considered the same")
+}
+
+func TestAlterBundler(t *testing.T) {
+	g := &Generator{mode: GeneratorModeMysql, config: database.GeneratorConfig{EnableDrop: true}}
+	tableA := &Table{name: QualifiedName{Name: Ident{Name: "a"}}}
+	tableB := &Table{name: QualifiedName{Name: Ident{Name: "b"}}}
+
+	bundler := newAlterBundler(g, true)
+
+	slotA := bundler.emit(tableA, "ALTER TABLE a ADD COLUMN x int")
+	assert.NotEqual(t, "ALTER TABLE a ADD COLUMN x int", slotA, "first action should be replaced by a placeholder")
+
+	slotB := bundler.emit(tableB, "ALTER TABLE b ADD COLUMN z int")
+	assert.NotEqual(t, slotA, slotB, "each table gets its own placeholder")
+
+	folded := bundler.emit(tableA, "ALTER TABLE a DROP COLUMN y")
+	assert.Equal(t, "", folded, "subsequent same-table action should fold, not emit")
+
+	other := bundler.emit(tableA, "DROP INDEX idx ON a")
+	assert.Equal(t, "DROP INDEX idx ON a", other, "non-ALTER statement should pass through")
+
+	ddls := bundler.finalize([]string{slotA, slotB, "DROP INDEX idx ON a"})
+	assert.Equal(t, []string{
+		"ALTER TABLE a ADD COLUMN x int, DROP COLUMN y",
+		"ALTER TABLE b ADD COLUMN z int",
+		"DROP INDEX idx ON a",
+	}, ddls)
+}
+
+// A table's ALTER TABLE actions can be escaped with the desired schema's quoting
+// (diff phase) or the current schema's quoting (cleanup DROP INDEX/CONSTRAINT).
+// In quote-aware mode these differ, but both must fold into one bundle.
+func TestAlterBundlerFusesMixedQuoting(t *testing.T) {
+	g := &Generator{mode: GeneratorModeMysql, config: database.GeneratorConfig{EnableDrop: true}}
+	desiredTable := &Table{name: QualifiedName{Name: Ident{Name: "patients", Quoted: false}}}
+
+	bundler := newAlterBundler(g, true)
+
+	// Diff phase emits with the desired (unquoted) table name.
+	slot := bundler.emit(desiredTable, "ALTER TABLE patients ADD COLUMN a int")
+	assert.Equal(t, "ALTER TABLE patients ", slot)
+
+	// Cleanup emits DROP INDEX with the current (backtick-quoted) table name.
+	folded := bundler.emit(desiredTable, "ALTER TABLE `patients` DROP INDEX `idx_c`")
+	assert.Equal(t, "", folded, "the differently-quoted drop should fold into the same bundle")
+
+	ddls := bundler.finalize([]string{slot})
+	assert.Equal(t, []string{
+		"ALTER TABLE patients ADD COLUMN a int, DROP INDEX `idx_c`",
+	}, ddls)
+}
+
+// With enable_drop disabled, a drop must not be fused with non-drop actions:
+// commentOutDropStatements would otherwise comment out the whole statement and
+// silently skip the ADD/MODIFY actions too.
+func TestAlterBundlerKeepsDropsStandaloneWhenDropDisabled(t *testing.T) {
+	g := &Generator{mode: GeneratorModeMysql, config: database.GeneratorConfig{EnableDrop: false}}
+	table := &Table{name: QualifiedName{Name: Ident{Name: "a"}}}
+
+	bundler := newAlterBundler(g, true)
+
+	slot := bundler.emit(table, "ALTER TABLE a ADD COLUMN x int")
+	assert.Equal(t, "ALTER TABLE a ", slot, "non-drop action starts a bundle")
+
+	drop := bundler.emit(table, "ALTER TABLE a DROP COLUMN y")
+	assert.Equal(t, "ALTER TABLE a DROP COLUMN y", drop, "drop stays standalone so it can be commented out individually")
+
+	ddls := bundler.finalize([]string{slot, "ALTER TABLE a DROP COLUMN y"})
+	assert.Equal(t, []string{
+		"ALTER TABLE a ADD COLUMN x int",
+		"ALTER TABLE a DROP COLUMN y",
+	}, ddls)
+}
+
+func TestAlterBundlerDisabledPassesThrough(t *testing.T) {
+	g := &Generator{mode: GeneratorModeMysql}
+	table := &Table{name: QualifiedName{Name: Ident{Name: "a"}}}
+	bundler := newAlterBundler(g, false)
+
+	stmt := bundler.emit(table, "ALTER TABLE a ADD COLUMN x int")
+	assert.Equal(t, "ALTER TABLE a ADD COLUMN x int", stmt)
+
+	ddls := bundler.finalize([]string{stmt})
+	assert.Equal(t, []string{"ALTER TABLE a ADD COLUMN x int"}, ddls)
 }
 
 func TestCheckConstraintMSSQLInVsOrNormalization(t *testing.T) {

--- a/testutil/testcase.schema.json
+++ b/testutil/testcase.schema.json
@@ -111,6 +111,11 @@
               "type": "boolean",
               "description": "Disable DDL transaction wrapping",
               "default": false
+            },
+            "bulk_alter": {
+              "type": "boolean",
+              "description": "Bundle multiple ALTER TABLE actions on the same table into a single statement (MySQL only)",
+              "default": false
             }
           },
           "additionalProperties": false

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -41,6 +41,7 @@ type TestCase struct {
 	Config             struct { // Optional config settings for the test
 		CreateIndexConcurrently bool `yaml:"create_index_concurrently"`
 		DisableDdlTransaction   bool `yaml:"disable_ddl_transaction"`
+		BulkAlter               bool `yaml:"bulk_alter"`
 	} `yaml:"config"`
 	Manage struct {
 		Extension *[]database.ManageObjectRule `yaml:"extension"`
@@ -197,6 +198,7 @@ func RunTest(t *testing.T, db database.Database, test TestCase, mode schema.Gene
 		EnableDrop:              *test.EnableDrop,
 		CreateIndexConcurrently: test.Config.CreateIndexConcurrently,
 		DisableDdlTransaction:   test.Config.DisableDdlTransaction,
+		BulkAlter:               test.Config.BulkAlter,
 		LegacyIgnoreQuotes:      legacyIgnoreQuotes,
 	}
 


### PR DESCRIPTION
# motivation
To reduce DDL locks on large tables for every `ALTER TABLE` statement, multiple actions are fused into a single `ALTER TABLE t act1, act2, ...`.

# note

- <del>PostgreSQL and</del> MySQL only. PostgreSQL already uses a transaction for DDL. SQLite3 and MSSQL grammar seemingly disallow comma-separated action lists, so the flag is a documented no-op.
- CREATE/DROP INDEX and ADD/DROP FOREIGN KEY are unchanged; only the per-table inter DDLs and cleanup-phase ALTER TABLE statements are fused.
- RENAME forms (RENAME COLUMN / RENAME TO / RENAME CONSTRAINT) cannot be combined per PostgreSQL/MySQL grammar and remain standalone.
