### PR TITLE
fix: mysql treat MariaDB longtext+json_valid CHECK as equivalent to json

### DIFF
--- a/cmd/mysqldef/tests_datatypes.yml
+++ b/cmd/mysqldef/tests_datatypes.yml
@@ -26,7 +26,7 @@ BooleanValue:
   up: |
   down: |
 AddColumnWithDefaultExpression:
-  flavor: mysql
+  flavor: "!tidb"
   current: |
     CREATE TABLE users (id BIGINT PRIMARY KEY);
   desired: |
@@ -40,7 +40,6 @@ AddColumnWithDefaultExpression:
     ALTER TABLE `users` DROP COLUMN `friend_ids`;
   min_version: '8.0'
 AddDefaultExpression:
-  flavor: "!mariadb"
   current: |
     CREATE TABLE users (
       id BIGINT PRIMARY KEY,
@@ -57,7 +56,6 @@ AddDefaultExpression:
     ALTER TABLE `users` CHANGE COLUMN `friend_ids` `friend_ids` json;
   min_version: '8.0'
 RemoveDefaultExpression:
-  flavor: "!mariadb"
   current: |
     CREATE TABLE users (
       id BIGINT PRIMARY KEY,
@@ -506,5 +504,55 @@ UUIDBinary:
   desired: |
     CREATE TABLE users (
       id BINARY(16) NOT NULL DEFAULT (UNHEX(REPLACE(UUID(), '-', ''))),
+      PRIMARY KEY (id)
+    );
+
+# MariaDB does not store JSON natively: `CREATE TABLE t (j JSON)` is rewritten
+# internally as `j longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin
+# CHECK (json_valid(j))`, and SHOW CREATE TABLE returns that verbatim. Without
+# normalization, the comparer sees `json` (desired) vs `longtext + utf8mb4_bin +
+# json_valid CHECK` (current) and emits a spurious `CHANGE COLUMN ... json` per
+# JSON column on every diff. These tests assert idempotency on both flavors —
+# trivial on MySQL (native json round-trips), exercising the normalization on
+# MariaDB.
+JsonColumnIdempotency:
+  current: |
+    CREATE TABLE t (
+      id int(11) NOT NULL,
+      metadata json DEFAULT NULL,
+      PRIMARY KEY (id)
+    );
+  desired: |
+    CREATE TABLE t (
+      id int(11) NOT NULL,
+      metadata json DEFAULT NULL,
+      PRIMARY KEY (id)
+    );
+
+JsonColumnNotNullIdempotency:
+  current: |
+    CREATE TABLE t (
+      id int(11) NOT NULL,
+      payload json NOT NULL,
+      PRIMARY KEY (id)
+    );
+  desired: |
+    CREATE TABLE t (
+      id int(11) NOT NULL,
+      payload json NOT NULL,
+      PRIMARY KEY (id)
+    );
+
+JsonColumnWithCommentIdempotency:
+  current: |
+    CREATE TABLE t (
+      id int(11) NOT NULL,
+      details json DEFAULT NULL COMMENT 'metadata blob',
+      PRIMARY KEY (id)
+    );
+  desired: |
+    CREATE TABLE t (
+      id int(11) NOT NULL,
+      details json DEFAULT NULL COMMENT 'metadata blob',
       PRIMARY KEY (id)
     );

--- a/cmd/mysqldef/tests_generated.yml
+++ b/cmd/mysqldef/tests_generated.yml
@@ -62,7 +62,6 @@ CreateTableGeneratedAlwaysAsAbbreviationChangeExpr80:
     ALTER TABLE `test_table` CHANGE COLUMN `test_expr` `test_expr` varchar(45) GENERATED ALWAYS AS (test_value / test_value) STORED NOT NULL;
   min_version: '8.0'
 ChangeGenerateColumnGemerayedAlwaysAs:
-  flavor: "!mariadb"
   desired: |
     CREATE TABLE test_table (
       id int(11) NOT NULL AUTO_INCREMENT,
@@ -73,7 +72,6 @@ ChangeGenerateColumnGemerayedAlwaysAs:
       PRIMARY KEY (id)
     );
 ChangeGenerateColumnJsonExpressionChange:
-  flavor: "!mariadb"
   current: |
     CREATE TABLE test_table (
       id int(11) NOT NULL AUTO_INCREMENT,
@@ -97,7 +95,7 @@ ChangeGenerateColumnJsonExpressionChange:
   down: |
     ALTER TABLE `test_table` CHANGE COLUMN `name` `name` varchar(20) GENERATED ALWAYS AS (json_extract(data, '$.name1')) VIRTUAL;
 ChangeGenerateColumnVirtualToStored:
-  flavor: mysql
+  flavor: "!tidb"
   current: |
     CREATE TABLE test_table (
       id int(11) NOT NULL AUTO_INCREMENT,
@@ -127,7 +125,7 @@ ChangeGenerateColumnVirtualToStored:
     ALTER TABLE `test_table` DROP COLUMN `name`;
     ALTER TABLE `test_table` ADD COLUMN `name` varchar(20) GENERATED ALWAYS AS (json_extract(data, '$.name2')) VIRTUAL AFTER `data`;
 ChangeGenerateColumnStoredToVirtual:
-  flavor: mysql
+  flavor: "!tidb"
   current: |
     CREATE TABLE test_table (
       id int(11) NOT NULL AUTO_INCREMENT,
@@ -157,7 +155,6 @@ ChangeGenerateColumnStoredToVirtual:
     ALTER TABLE `test_table` DROP COLUMN `name`;
     ALTER TABLE `test_table` ADD COLUMN `name` varchar(20) GENERATED ALWAYS AS (json_extract(data, '$.name2')) STORED AFTER `data`;
 ChangeGenerateColumnSpacingIgnored:
-  flavor: "!mariadb"
   current: |
     CREATE TABLE test_table (
       id int(11) NOT NULL AUTO_INCREMENT,

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -4709,7 +4709,7 @@ func (g *Generator) haveSameDataType(current Column, desired Column) bool {
 		}
 	} else {
 		// Legacy behavior: case-insensitive normalized comparison
-		if normalizeTypeName(current.typeName, g.mode) != normalizeTypeName(desired.typeName, g.mode) {
+		if effectiveTypeName(current, desired, g.mode) != effectiveTypeName(desired, current, g.mode) {
 			return false
 		}
 	}

--- a/schema/normalize.go
+++ b/schema/normalize.go
@@ -48,6 +48,58 @@ var (
 	}
 )
 
+// effectiveTypeName returns the comparison-canonical type of a column, after applying
+// equivalences that depend on the column's full definition (charset/collate/CHECK), not
+// just its declared typeName.
+//
+// MariaDB does not have a native JSON storage type: `CREATE TABLE t (j JSON)` is rewritten
+// internally to `j longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin CHECK (json_valid(j))`,
+// and that is exactly what SHOW CREATE TABLE returns. Without this equivalence, every
+// `--dry-run` and `--export` against a MariaDB database that contains JSON columns reports a
+// spurious `CHANGE COLUMN ... json` for each one, because the desired side parses as `json`
+// while the readback parses as `longtext`.
+//
+// The normalization is applied symmetrically: only when the *other* side is also a JSON
+// column (either declared as `json` or already matching the MariaDB storage pattern). This
+// preserves comparison parity on MySQL, where the same `longtext + inline CHECK` text in a
+// user schema is stored with the CHECK lifted to a table-level constraint at readback —
+// asymmetric inline-vs-table CHECK placement that would otherwise break this fix on MySQL.
+func effectiveTypeName(col Column, other Column, mode GeneratorMode) string {
+	if mode == GeneratorModeMysql && isMariaDBJSONColumn(col) {
+		if isMariaDBJSONColumn(other) || strings.EqualFold(other.typeName, "json") {
+			return "json"
+		}
+	}
+	return normalizeTypeName(col.typeName, mode)
+}
+
+// isMariaDBJSONColumn returns true if col matches the longtext+utf8mb4_bin+json_valid()
+// shape that MariaDB emits for JSON columns.
+func isMariaDBJSONColumn(col Column) bool {
+	if !strings.EqualFold(col.typeName, "longtext") {
+		return false
+	}
+	if !strings.EqualFold(col.charset, "utf8mb4") || !strings.EqualFold(col.collate, "utf8mb4_bin") {
+		return false
+	}
+	if col.check == nil || col.check.definition == nil {
+		return false
+	}
+	funcExpr, ok := col.check.definition.(*parser.FuncExpr)
+	if !ok || !strings.EqualFold(funcExpr.Name.Name, "json_valid") || len(funcExpr.Exprs) != 1 {
+		return false
+	}
+	aliased, ok := funcExpr.Exprs[0].(*parser.AliasedExpr)
+	if !ok {
+		return false
+	}
+	colName, ok := aliased.Expr.(*parser.ColName)
+	if !ok {
+		return false
+	}
+	return strings.EqualFold(colName.Name.Name, col.name.Name)
+}
+
 // normalizeTypeName normalizes a type name using dataTypeAliases and mode-specific aliases.
 // This is the central function for all type name normalization in the generator.
 func normalizeTypeName(typeName string, mode GeneratorMode) string {


### PR DESCRIPTION
## Summary

MariaDB has no native JSON storage type. `CREATE TABLE t (j JSON)` is rewritten internally to:

```sql
j longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin CHECK (json_valid(j))
```

and that is exactly what `SHOW CREATE TABLE` returns. As a result, every `--dry-run` / `--export` against a MariaDB database with JSON columns reports a spurious `CHANGE COLUMN ... json DEFAULT null` for each one — pure cosmetic noise that pollutes the diff output (commonly 5–10+ false ALTERs per real deploy) and triggers unnecessary table rewrites if applied.

## Repro (5 lines, MariaDB 10.11)

```sql
-- schema.sql
CREATE TABLE t (id int PRIMARY KEY, metadata json DEFAULT NULL);
```

```
$ mysqldef --dry-run db < schema.sql
-- dry run --
BEGIN;
ALTER TABLE `t` CHANGE COLUMN `metadata` `metadata` json DEFAULT null;
COMMIT;
```

The user wrote `json`. The DB stores it as `longtext + utf8mb4_bin + json_valid CHECK`. mysqldef sees a diff and emits an ALTER. After applying it, MariaDB stores the same thing again, and the next dry-run shows the same false diff.

## Fix

In `haveSameDataType`, when one side matches the MariaDB JSON storage pattern (`longtext + utf8mb4_bin + inline json_valid(col) CHECK`) **and** the other side is also JSON-equivalent (declared as `json`, or matching the same pattern), treat both as `json` for typeName comparison.

The normalization is applied **symmetrically** — only when both sides are JSON-equivalent. This preserves comparison parity on MySQL, where a user-written `longtext + inline CHECK` is stored with the CHECK *lifted to a table-level constraint*. Without the symmetric guard, that asymmetry (inline CHECK on the YAML side, no inline CHECK on the readback side) would break the existing comparison logic on MySQL.

```go
func effectiveTypeName(col Column, other Column, mode GeneratorMode) string {
	if mode == GeneratorModeMysql && isMariaDBJSONColumn(col) {
		if isMariaDBJSONColumn(other) || strings.EqualFold(other.typeName, "json") {
			return "json"
		}
	}
	return normalizeTypeName(col.typeName, mode)
}
```

## Test coverage

- **3 new idempotency tests** in `tests_datatypes.yml` (`JsonColumnIdempotency`, `JsonColumnNotNullIdempotency`, `JsonColumnWithCommentIdempotency`) that round-trip a JSON column across `desired → current` and assert no diff. Trivial pass on MySQL (native json round-trips), exercise the normalization on MariaDB.
- **Removes 8 obsolete `flavor: !mariadb` / `flavor: mysql` annotations** from pre-existing tests in `tests_datatypes.yml` and `tests_generated.yml`. These tests assert behavior unrelated to JSON storage (default expressions, generated column changes), but were previously failing on MariaDB *only* because of the spurious json↔longtext diff masking the real changes. With this fix, they now pass on both flavors and the annotations are no longer needed — the framework's `expectFailure` check actively flags stale flavor annotations, so removing them keeps CI green.

## Verification

- **MySQL 8.4**: full `TestApply` suite, **0 failures**.
- **MariaDB 10.11**: full `TestApply` suite, only the 4 pre-existing `*VectorIndex*` baseline failures (MariaDB 10.11 doesn't support VECTOR — unrelated to this PR).
- End-to-end against a real 165-table production schema with 6 JSON columns: `--dry-run` now reports `Nothing is modified` (was: 6 spurious `CHANGE COLUMN ... json` ALTERs).
