### PR TITLE
fix: mysql view normalization recurses into subqueries and unwraps JOIN parens

### DIFF
--- a/cmd/mysqldef/tests_views_triggers.yml
+++ b/cmd/mysqldef/tests_views_triggers.yml
@@ -104,7 +104,6 @@ CreateTriggerWithMultipleStatements:
   down: |
     DROP TABLE `test_trigger`;
 View:
-  flavor: "!tidb"
   desired: |
     CREATE TABLE users (
       id bigint(20) NOT NULL
@@ -116,7 +115,6 @@ View:
     );
     CREATE VIEW foo AS select u.id as id, p.id as post_id from  (mysqldef_test.users as u join mysqldef_test.posts as p on ((u.id = p.user_id)));
 ViewUpdate:
-  flavor: "!tidb"
   current: |
     CREATE TABLE users (
       id bigint(20) NOT NULL
@@ -142,7 +140,6 @@ ViewUpdate:
   down: |
     CREATE OR REPLACE VIEW `foo` AS select u.id as id, p.id as post_id from (mysqldef_test.users as u join mysqldef_test.posts as p on ((u.id = p.user_id)));
 ViewDropsWhenEmptyDesired:
-  flavor: "!tidb"
   current: |
     CREATE TABLE users (
       id bigint(20) NOT NULL
@@ -615,3 +612,97 @@ ViewSecurityType:
     CREATE OR REPLACE SQL SECURITY INVOKER VIEW `user_posts` AS select mysqldef_test.users.id as id, mysqldef_test.posts.id as post_id from (mysqldef_test.users join mysqldef_test.posts on (mysqldef_test.users.id = mysqldef_test.posts.user_id));
   down: |
     CREATE OR REPLACE SQL SECURITY DEFINER VIEW `user_posts` AS select mysqldef_test.users.id as id, mysqldef_test.posts.id as post_id from (mysqldef_test.users join mysqldef_test.posts on (mysqldef_test.users.id = mysqldef_test.posts.user_id));
+
+# When a view contains a correlated subquery, MariaDB's SHOW CREATE VIEW emits
+# database-qualified table references inside the subquery's FROM clause too.
+# Without recursing into Subquery during normalization, the outer FROM is
+# normalized but the inner FROM is not, producing a spurious view re-creation
+# on every diff.
+ViewWithSubqueryIdempotency:
+  # TiDB rewrites correlated subqueries inside views, so the round-trip
+  # comparison is not idempotent there even with this fix. The behavior
+  # being tested (Subquery recursion in normalizer) still benefits TiDB
+  # when the subquery shape matches, but this specific test exercises a
+  # MariaDB/MySQL shape.
+  flavor: "!tidb"
+  current: |
+    CREATE TABLE email_logs (
+      id int(11) NOT NULL AUTO_INCREMENT,
+      invoice_id int(11) DEFAULT NULL,
+      brevo_message_id varchar(255) DEFAULT NULL,
+      type varchar(50) NOT NULL,
+      delivery_status varchar(50) DEFAULT NULL,
+      PRIMARY KEY (id)
+    );
+    CREATE OR REPLACE VIEW v_invoice_email_status AS
+      SELECT el1.invoice_id, el1.delivery_status
+      FROM email_logs el1
+      WHERE el1.brevo_message_id IS NOT NULL
+        AND el1.type = 'invoice'
+        AND el1.id = (
+          SELECT MAX(el2.id) FROM email_logs el2
+          WHERE el2.invoice_id = el1.invoice_id
+            AND el2.brevo_message_id IS NOT NULL
+            AND el2.type = 'invoice'
+        );
+  desired: |
+    CREATE TABLE email_logs (
+      id int(11) NOT NULL AUTO_INCREMENT,
+      invoice_id int(11) DEFAULT NULL,
+      brevo_message_id varchar(255) DEFAULT NULL,
+      type varchar(50) NOT NULL,
+      delivery_status varchar(50) DEFAULT NULL,
+      PRIMARY KEY (id)
+    );
+    CREATE OR REPLACE VIEW v_invoice_email_status AS
+      SELECT el1.invoice_id, el1.delivery_status
+      FROM email_logs el1
+      WHERE el1.brevo_message_id IS NOT NULL
+        AND el1.type = 'invoice'
+        AND el1.id = (
+          SELECT MAX(el2.id) FROM email_logs el2
+          WHERE el2.invoice_id = el1.invoice_id
+            AND el2.brevo_message_id IS NOT NULL
+            AND el2.type = 'invoice'
+        );
+
+# MariaDB wraps JOIN clauses in parentheses inside views, e.g.
+# `from (a left join b on ...)`. PostgreSQL did the same and was already
+# unwrapped during normalization; this test asserts the same treatment for
+# MySQL/MariaDB so a user-written `from a left join b on ...` matches the
+# parenthesized readback.
+ViewWithJoinIdempotency:
+  current: |
+    CREATE TABLE purchase_orders (
+      id int(11) NOT NULL AUTO_INCREMENT,
+      project_id int(11) DEFAULT NULL,
+      status varchar(50) DEFAULT NULL,
+      PRIMARY KEY (id)
+    );
+    CREATE TABLE projects (
+      id int(11) NOT NULL AUTO_INCREMENT,
+      project_code varchar(50) DEFAULT NULL,
+      PRIMARY KEY (id)
+    );
+    CREATE OR REPLACE VIEW v_po_with_project AS
+      SELECT po.id AS purchase_order_id, sp.project_code, po.status
+      FROM purchase_orders po
+      LEFT JOIN projects sp ON sp.id = po.project_id
+      WHERE po.status IN ('ordered', 'received');
+  desired: |
+    CREATE TABLE purchase_orders (
+      id int(11) NOT NULL AUTO_INCREMENT,
+      project_id int(11) DEFAULT NULL,
+      status varchar(50) DEFAULT NULL,
+      PRIMARY KEY (id)
+    );
+    CREATE TABLE projects (
+      id int(11) NOT NULL AUTO_INCREMENT,
+      project_code varchar(50) DEFAULT NULL,
+      PRIMARY KEY (id)
+    );
+    CREATE OR REPLACE VIEW v_po_with_project AS
+      SELECT po.id AS purchase_order_id, sp.project_code, po.status
+      FROM purchase_orders po
+      LEFT JOIN projects sp ON sp.id = po.project_id
+      WHERE po.status IN ('ordered', 'received');

--- a/schema/normalize.go
+++ b/schema/normalize.go
@@ -832,6 +832,15 @@ func normalizeExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 			Operator: e.Operator,
 			Expr:     normalizeExpr(e.Expr, mode),
 		}
+	case *parser.Subquery:
+		// Recurse into subquery SELECT so that nested FROM clauses receive the
+		// same normalization as the outer SELECT (notably database-prefix
+		// stripping on MySQL — MariaDB's SHOW CREATE VIEW emits `db.table`
+		// everywhere including subquery FROM clauses, but user-written DDL
+		// rarely does, causing spurious view re-creations on every diff).
+		return &parser.Subquery{
+			Select: normalizeViewDefinition(e.Select, mode, nil),
+		}
 	case *parser.ConvertExpr:
 		// Normalize CAST(expr AS type) to expr::type (CastExpr) for consistency
 		// PostgreSQL represents both forms identically in its internal representation
@@ -975,13 +984,13 @@ func normalizeTableExpr(expr parser.TableExpr, mode GeneratorMode) parser.TableE
 			Condition: normalizeJoinCondition(e.Condition, mode),
 		}
 	case *parser.ParenTableExpr:
-		// PostgreSQL adds parentheses around JOINs when storing views
-		// Unwrap these to get a canonical form
-		if mode == GeneratorModePostgres && len(e.Exprs) == 1 {
+		// PostgreSQL and MariaDB add parentheses around JOINs when storing views.
+		// Unwrap these to get a canonical form.
+		if (mode == GeneratorModePostgres || mode == GeneratorModeMysql) && len(e.Exprs) == 1 {
 			// Single expression in parentheses - unwrap it
 			return normalizeTableExpr(e.Exprs[0], mode)
 		}
-		// Multiple expressions or non-Postgres mode - normalize but keep parens
+		// Multiple expressions - normalize but keep parens
 		normalized := make(parser.TableExprs, len(e.Exprs))
 		for i, expr := range e.Exprs {
 			normalized[i] = normalizeTableExpr(expr, mode)


### PR DESCRIPTION
## Summary

MariaDB's `SHOW CREATE VIEW` emits database-qualified table references and wraps `JOIN` clauses in parentheses, both of which differ from how users typically write the same view in their schema files. Two gaps in the existing view normalizer make these differences leak into the comparison, producing spurious `CREATE OR REPLACE VIEW` DDLs on every `--dry-run` / `--export`.

In a real production schema with 4 views, every diff run was emitting 4 spurious view re-creations — pure cosmetic noise that pollutes CI/CD output and triggers unnecessary view rebuilds if applied.

## Repro

```sql
CREATE TABLE email_logs (
  id int(11) NOT NULL AUTO_INCREMENT,
  invoice_id int(11) DEFAULT NULL,
  brevo_message_id varchar(255) DEFAULT NULL,
  type varchar(50) NOT NULL,
  PRIMARY KEY (id)
);

CREATE OR REPLACE VIEW v_invoice_email_status AS
  SELECT el1.invoice_id
  FROM email_logs el1
  WHERE el1.brevo_message_id IS NOT NULL
    AND el1.id = (
      SELECT MAX(el2.id) FROM email_logs el2
      WHERE el2.invoice_id = el1.invoice_id
    );
```

```
$ mysqldef --dry-run db < schema.sql
-- dry run --
BEGIN;
CREATE OR REPLACE VIEW `v_invoice_email_status` AS select el1.invoice_id from email_logs as el1 where el1.brevo_message_id is not null and el1.id = (select MAX(el2.id) from email_logs as el2 where el2.invoice_id = el1.invoice_id);
COMMIT;
```

Same shape, no change desired, spurious recreate every time.

## Root cause

Two gaps in `normalizeViewDefinition` (`schema/normalize.go`):

**1. `normalizeExpr` did not recurse into `*parser.Subquery`.** The outer `FROM` clause was normalized (database prefix stripped, etc.), but the subquery's inner SELECT and its FROM clause were not. Debug trace from a real view:

```
current_after_norm: ... from email_logs as el1 where ... and id = (
    select max(el2.id) from db_name.email_logs as el2 where ...  ← still qualified
)
desired_after_norm: ... from email_logs as el1 where ... and id = (
    select max(el2.id) from email_logs as el2 where ...
)
```

**2. `normalizeTableExpr` only unwrapped `*parser.ParenTableExpr` for PostgreSQL.** MariaDB also wraps stored JOINs in parens:

```
current: from (purchase_orders as po left join projects as sp on sp.id = po.project_id)
desired: from purchase_orders as po left join projects as sp on sp.id = po.project_id
```

The existing code already had the comment `"PostgreSQL adds parentheses around JOINs when storing views"` — same is true for MariaDB.

## Fix

Two small symmetric extensions, both in `schema/normalize.go`:

```go
case *parser.Subquery:
    return &parser.Subquery{
        Select: normalizeViewDefinition(e.Select, mode, nil),
    }
```

```go
case *parser.ParenTableExpr:
-   if mode == GeneratorModePostgres && len(e.Exprs) == 1 {
+   if (mode == GeneratorModePostgres || mode == GeneratorModeMysql) && len(e.Exprs) == 1 {
        return normalizeTableExpr(e.Exprs[0], mode)
    }
    ...
```

12 lines of source change total. Pattern matches the existing PostgreSQL handling — no new abstractions.

## Test coverage

Two new tests in `tests_views_triggers.yml`:

- `ViewWithSubqueryIdempotency` — view with a correlated subquery on the same table, asserts `desired == current` produces no DDL.
- `ViewWithJoinIdempotency` — view with a `LEFT JOIN`, same assertion.

Both pass on MySQL 8.4 and MariaDB 10.11.

## Verification

- **MySQL 8.4**: full `TestApply` suite, **0 failures**.
- **MariaDB 10.11**: full `TestApply` suite, only the 4 pre-existing `*VectorIndex*` baseline failures (MariaDB 10.11 doesn't support VECTOR — unrelated to this PR).
- End-to-end on a real production schema with 4 views: `--dry-run` now reports `Nothing is modified` (was: 4 spurious `CREATE OR REPLACE VIEW` per run).

## Scope note

This PR intentionally stays narrow — it adds the two missing recursive cases needed to match what the rest of the normalizer already does. It does not introduce a fuller "semantic" view comparator (column name resolution, commutative operand sorting, etc.); empirically the two surgical patches cover all 4 production views observed, and broader changes are best evaluated against concrete future cases.
