### PR TITLE
feat: add --check flag for CI gating of schema drift

### DIFF
--- a/cmd-mssqldef.md
+++ b/cmd-mssqldef.md
@@ -18,6 +18,7 @@ Application Options:
       --password-prompt       Force MSSQL user password prompt
       --file=FILENAME         Read desired SQL from the file, rather than stdin (default: -)
       --dry-run               Don't run DDLs but just show them
+      --check                 Like --dry-run, but exit with code 2 when DDL would be applied (useful as a CI gate to detect schema drift)
       --apply                 Apply DDLs to the database (default, but will require this flag in future versions)
       --export                Just dump the current schema to stdout
       --enable-drop           Enable destructive changes such as DROP for TABLE, SCHEMA, ROLE, USER, FUNCTION, PROCEDURE, TRIGGER, VIEW, INDEX, SEQUENCE, TYPE

--- a/cmd-mysqldef.md
+++ b/cmd-mysqldef.md
@@ -21,6 +21,7 @@ Application Options:
       --enable-cleartext-plugin     Enable/disable the clear text authentication plugin
       --file=FILENAME               Read desired SQL from the file, rather than stdin (default: -)
       --dry-run                     Don't run DDLs but just show them
+      --check                       Like --dry-run, but exit with code 2 when DDL would be applied (useful as a CI gate to detect schema drift)
       --apply                       Apply DDLs to the database (default, but will require this flag in future versions)
       --export                      Just dump the current schema to stdout
       --enable-drop                 Enable destructive changes such as DROP for TABLE, SCHEMA, ROLE, USER, FUNCTION, PROCEDURE, TRIGGER, VIEW, INDEX, SEQUENCE, TYPE

--- a/cmd-psqldef.md
+++ b/cmd-psqldef.md
@@ -17,6 +17,7 @@ Application Options:
       --password-prompt       Force PostgreSQL user password prompt
   -f, --file=FILENAME         Read desired SQL from the file, rather than stdin (default: -)
       --dry-run               Don't run DDLs but just show them
+      --check                 Like --dry-run, but exit with code 2 when DDL would be applied (useful as a CI gate to detect schema drift)
       --apply                 Apply DDLs to the database (default, but will require this flag in future versions)
       --export                Just dump the current schema to stdout
       --enable-drop           Enable destructive changes such as DROP for TABLE, SCHEMA, ROLE, USER, FUNCTION, PROCEDURE, TRIGGER, VIEW, INDEX, SEQUENCE, TYPE

--- a/cmd-sqlite3def.md
+++ b/cmd-sqlite3def.md
@@ -10,6 +10,7 @@ Usage:
 Application Options:
   -f, --file=FILENAME         Read desired SQL from the file, rather than stdin (default: -)
       --dry-run               Don't run DDLs but just show them
+      --check                 Like --dry-run, but exit with code 2 when DDL would be applied (useful as a CI gate to detect schema drift)
       --apply                 Apply DDLs to the database (default, but will require this flag in future versions)
       --export                Just dump the current schema to stdout
       --enable-drop           Enable destructive changes such as DROP for TABLE, SCHEMA, ROLE, USER, FUNCTION, PROCEDURE, TRIGGER, VIEW, INDEX, SEQUENCE, TYPE

--- a/cmd/mssqldef/mssqldef.go
+++ b/cmd/mssqldef/mssqldef.go
@@ -35,6 +35,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		Prompt     bool     `long:"password-prompt" description:"Force MSSQL user password prompt"`
 		File       []string `long:"file" description:"Read desired SQL from the file, rather than stdin" value-name:"FILENAME" default:"-"`
 		DryRun     bool     `long:"dry-run" description:"Don't run DDLs but just show them"`
+		Check      bool     `long:"check" description:"Like --dry-run, but exit with code 2 when DDL would be applied (useful as a CI gate to detect schema drift)"`
 		Apply      bool     `long:"apply" description:"Apply DDLs to the database (default, but will require this flag in future versions)"`
 		Export     bool     `long:"export" description:"Just dump the current schema to stdout"`
 		EnableDrop bool     `long:"enable-drop" description:"Enable destructive changes such as DROP for TABLE, SCHEMA, ROLE, USER, FUNCTION, PROCEDURE, TRIGGER, VIEW, INDEX, SEQUENCE, TYPE"`
@@ -95,6 +96,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 	options := sqldef.Options{
 		DesiredDDLs: desiredDDLs,
 		DryRun:      opts.DryRun,
+		Check:       opts.Check,
 		Export:      opts.Export,
 		Config:      config,
 	}

--- a/cmd/mssqldef/mssqldef_test.go
+++ b/cmd/mssqldef/mssqldef_test.go
@@ -8,6 +8,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/sqldef/sqldef/v3"
 	"github.com/sqldef/sqldef/v3/database"
 	"github.com/sqldef/sqldef/v3/database/mssql"
 	"github.com/sqldef/sqldef/v3/schema"
@@ -1397,6 +1399,36 @@ func TestMssqldefDryRun(t *testing.T) {
 	dryRun := tu.MustExecute(t, "./mssqldef", mssqlCLIArgs("mssqldef_test", "--dry-run", "--file", "schema.sql")...)
 	apply := tu.MustExecute(t, "./mssqldef", mssqlCLIArgs("mssqldef_test", "--file", "schema.sql")...)
 	assert.Equal(t, strings.Replace(apply, "Apply", "dry run", 1), dryRun)
+}
+
+func TestMssqldefCheck(t *testing.T) {
+	resetTestDatabase()
+	mustMssqlExec("mssqldef_test", "CREATE TABLE users (id integer NOT NULL PRIMARY KEY);")
+
+	// Case 1: schema in sync -> exit 0
+	tu.WriteFile("schema.sql", "CREATE TABLE users (\n  id integer NOT NULL PRIMARY KEY\n);\nGO\n")
+	noChange := tu.MustExecute(t, "./mssqldef", mssqlCLIArgs("mssqldef_test", "--check", "--file", "schema.sql")...)
+	assert.Equal(t, nothingModified, noChange)
+
+	// Case 2: schema differs -> exit 2 with DDL printed
+	tu.WriteFile("schema.sql", "CREATE TABLE users (\n  id integer NOT NULL PRIMARY KEY,\n  age integer\n);\nGO\n")
+	out, err := tu.Execute("./mssqldef", mssqlCLIArgs("mssqldef_test", "--check", "--file", "schema.sql")...)
+	exitErr, isExitErr := err.(*exec.ExitError)
+	if !isExitErr {
+		t.Fatalf("expected ExitError from --check when schema differs, got err=%v", err)
+	}
+	assert.Equal(t, sqldef.CheckExitCode, exitErr.ExitCode())
+	assert.Contains(t, out, "-- dry run --")
+	assert.Contains(t, out, "age")
+
+	// Re-running --check must still report a diff (DB untouched).
+	out2, err2 := tu.Execute("./mssqldef", mssqlCLIArgs("mssqldef_test", "--check", "--file", "schema.sql")...)
+	exitErr2, isExitErr2 := err2.(*exec.ExitError)
+	if !isExitErr2 {
+		t.Fatalf("expected ExitError from second --check, got err=%v", err2)
+	}
+	assert.Equal(t, sqldef.CheckExitCode, exitErr2.ExitCode())
+	assert.Equal(t, out, out2, "second --check must produce the same output (DB unchanged)")
 }
 
 func TestMssqldefDropTable(t *testing.T) {

--- a/cmd/mysqldef/mysqldef.go
+++ b/cmd/mysqldef/mysqldef.go
@@ -38,6 +38,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		EnableCleartextPlugin bool     `long:"enable-cleartext-plugin" description:"Enable/disable the clear text authentication plugin"`
 		File                  []string `long:"file" description:"Read desired SQL from the file, rather than stdin" value-name:"FILENAME" default:"-"`
 		DryRun                bool     `long:"dry-run" description:"Don't run DDLs but just show them"`
+		Check                 bool     `long:"check" description:"Like --dry-run, but exit with code 2 when DDL would be applied (useful as a CI gate to detect schema drift)"`
 		Apply                 bool     `long:"apply" description:"Apply DDLs to the database (default, but will require this flag in future versions)"`
 		Export                bool     `long:"export" description:"Just dump the current schema to stdout"`
 		EnableDrop            bool     `long:"enable-drop" description:"Enable destructive changes such as DROP for TABLE, SCHEMA, ROLE, USER, FUNCTION, PROCEDURE, TRIGGER, VIEW, INDEX, SEQUENCE, TYPE"`
@@ -100,6 +101,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 	options := sqldef.Options{
 		DesiredDDLs: desiredDDLs,
 		DryRun:      opts.DryRun,
+		Check:       opts.Check,
 		Export:      opts.Export,
 		BeforeApply: opts.BeforeApply,
 		Config:      config,

--- a/cmd/mysqldef/mysqldef_test.go
+++ b/cmd/mysqldef/mysqldef_test.go
@@ -9,6 +9,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"testing"
@@ -17,6 +18,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/sqldef/sqldef/v3"
 	"github.com/sqldef/sqldef/v3/database"
 	"github.com/sqldef/sqldef/v3/database/mysql"
 	"github.com/sqldef/sqldef/v3/parser"
@@ -188,6 +190,44 @@ func TestMysqldefDryRun(t *testing.T) {
 		COMMIT;
 	`)
 	assert.Equal(t, expectedApply, apply)
+}
+
+func TestMysqldefCheck(t *testing.T) {
+	resetTestDatabase()
+	mustMysqlExec("mysqldef_test", "CREATE TABLE users (id bigint NOT NULL);")
+
+	// Case 1: schema in sync -> exit 0, "Nothing is modified"
+	tu.WriteFile("schema.sql", "CREATE TABLE users (\n  id bigint NOT NULL\n);")
+	noChange := mustExecuteMySQLDef(t, "mysqldef_test", "--check", "--file", "schema.sql")
+	assert.Equal(t, "-- Nothing is modified --\n", noChange)
+
+	// Case 2: schema differs -> exit 2, DDL printed under "-- dry run --" header,
+	// and the database is NOT modified.
+	tu.WriteFile("schema.sql", "CREATE TABLE users (\n  id bigint NOT NULL,\n  name varchar(40)\n);")
+	out, err := executeMySQLDef("mysqldef_test", "--check", "--file", "schema.sql")
+	exitErr, isExitErr := err.(*exec.ExitError)
+	if !isExitErr {
+		t.Fatalf("expected ExitError from --check when schema differs, got err=%v", err)
+	}
+	assert.Equal(t, sqldef.CheckExitCode, exitErr.ExitCode(),
+		"--check should exit with sqldef.CheckExitCode when DDL would be applied")
+	expected := tu.StripHeredoc(`
+		-- dry run --
+		BEGIN;
+		ALTER TABLE ` + "`users`" + ` ADD COLUMN ` + "`name`" + ` varchar(40) AFTER ` + "`id`" + `;
+		COMMIT;
+	`)
+	assert.Equal(t, expected, out)
+
+	// Re-running --check must still report the same diff, proving the database
+	// was not modified by the first --check invocation.
+	out2, err2 := executeMySQLDef("mysqldef_test", "--check", "--file", "schema.sql")
+	exitErr2, isExitErr2 := err2.(*exec.ExitError)
+	if !isExitErr2 {
+		t.Fatalf("expected ExitError from second --check, got err=%v", err2)
+	}
+	assert.Equal(t, sqldef.CheckExitCode, exitErr2.ExitCode())
+	assert.Equal(t, expected, out2, "second --check must report the same diff (DB unchanged)")
 }
 
 func TestMysqldefExport(t *testing.T) {

--- a/cmd/psqldef/psqldef.go
+++ b/cmd/psqldef/psqldef.go
@@ -33,6 +33,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		Prompt                bool     `long:"password-prompt" description:"Force PostgreSQL user password prompt"`
 		File                  []string `short:"f" long:"file" description:"Read desired SQL from the file, rather than stdin" value-name:"FILENAME" default:"-"`
 		DryRun                bool     `long:"dry-run" description:"Don't run DDLs but just show them"`
+		Check                 bool     `long:"check" description:"Like --dry-run, but exit with code 2 when DDL would be applied (useful as a CI gate to detect schema drift)"`
 		Apply                 bool     `long:"apply" description:"Apply DDLs to the database (default, but will require this flag in future versions)"`
 		Export                bool     `long:"export" description:"Just dump the current schema to stdout"`
 		EnableDrop            bool     `long:"enable-drop" description:"Enable destructive changes such as DROP for TABLE, SCHEMA, ROLE, USER, FUNCTION, PROCEDURE, TRIGGER, VIEW, INDEX, SEQUENCE, TYPE"`
@@ -101,6 +102,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 	options := sqldef.Options{
 		DesiredDDLs: desiredDDLs,
 		DryRun:      opts.DryRun,
+		Check:       opts.Check,
 		Export:      opts.Export,
 		BeforeApply: opts.BeforeApply,
 		Config:      config,

--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -8,6 +8,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"sync"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/sqldef/sqldef/v3"
 	"github.com/sqldef/sqldef/v3/database"
 	"github.com/sqldef/sqldef/v3/database/postgres"
 	"github.com/sqldef/sqldef/v3/schema"
@@ -595,6 +597,36 @@ func TestPsqldefDryRun(t *testing.T) {
 	dryRun := tu.MustExecute(t, "./psqldef", psqldefArgs(testDatabaseName, "--dry-run", "--file", "schema.sql")...)
 	apply := tu.MustExecute(t, "./psqldef", psqldefArgs(testDatabaseName, "--file", "schema.sql")...)
 	assert.Equal(t, strings.Replace(apply, "Apply", "dry run", 1), dryRun)
+}
+
+func TestPsqldefCheck(t *testing.T) {
+	resetTestDatabase()
+	mustPgExec(testDatabaseName, "CREATE TABLE users (id bigint NOT NULL PRIMARY KEY);")
+
+	// Case 1: schema in sync -> exit 0
+	tu.WriteFile("schema.sql", "CREATE TABLE users (\n    id bigint NOT NULL PRIMARY KEY\n);")
+	noChange := tu.MustExecute(t, "./psqldef", psqldefArgs(testDatabaseName, "--check", "--file", "schema.sql")...)
+	assert.Equal(t, nothingModified, noChange)
+
+	// Case 2: schema differs -> exit 2 with DDL printed
+	tu.WriteFile("schema.sql", "CREATE TABLE users (\n    id bigint NOT NULL PRIMARY KEY,\n    age int\n);")
+	out, err := tu.Execute("./psqldef", psqldefArgs(testDatabaseName, "--check", "--file", "schema.sql")...)
+	exitErr, isExitErr := err.(*exec.ExitError)
+	if !isExitErr {
+		t.Fatalf("expected ExitError from --check when schema differs, got err=%v", err)
+	}
+	assert.Equal(t, sqldef.CheckExitCode, exitErr.ExitCode())
+	assert.Contains(t, out, "-- dry run --")
+	assert.Contains(t, out, "age")
+
+	// Re-running --check must still report a diff (DB untouched).
+	out2, err2 := tu.Execute("./psqldef", psqldefArgs(testDatabaseName, "--check", "--file", "schema.sql")...)
+	exitErr2, isExitErr2 := err2.(*exec.ExitError)
+	if !isExitErr2 {
+		t.Fatalf("expected ExitError from second --check, got err=%v", err2)
+	}
+	assert.Equal(t, sqldef.CheckExitCode, exitErr2.ExitCode())
+	assert.Equal(t, out, out2, "second --check must produce the same output (DB unchanged)")
 }
 
 func TestPsqldefDropTable(t *testing.T) {

--- a/cmd/sqlite3def/sqlite3def.go
+++ b/cmd/sqlite3def/sqlite3def.go
@@ -26,6 +26,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 	var opts struct {
 		File       []string `short:"f" long:"file" description:"Read desired SQL from the file, rather than stdin" value-name:"FILENAME" default:"-"`
 		DryRun     bool     `long:"dry-run" description:"Don't run DDLs but just show them"`
+		Check      bool     `long:"check" description:"Like --dry-run, but exit with code 2 when DDL would be applied (useful as a CI gate to detect schema drift)"`
 		Apply      bool     `long:"apply" description:"Apply DDLs to the database (default, but will require this flag in future versions)"`
 		Export     bool     `long:"export" description:"Just dump the current schema to stdout"`
 		EnableDrop bool     `long:"enable-drop" description:"Enable destructive changes such as DROP for TABLE, SCHEMA, ROLE, USER, FUNCTION, PROCEDURE, TRIGGER, VIEW, INDEX, SEQUENCE, TYPE"`
@@ -86,6 +87,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 	options := sqldef.Options{
 		DesiredDDLs: desiredDDLs,
 		DryRun:      opts.DryRun,
+		Check:       opts.Check,
 		Export:      opts.Export,
 		Config:      config,
 	}

--- a/cmd/sqlite3def/sqlite3def_test.go
+++ b/cmd/sqlite3def/sqlite3def_test.go
@@ -8,11 +8,13 @@ package main
 import (
 	"log"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/sqldef/sqldef/v3"
 	"github.com/sqldef/sqldef/v3/database"
 	"github.com/sqldef/sqldef/v3/database/sqlite3"
 	"github.com/sqldef/sqldef/v3/parser"
@@ -79,6 +81,36 @@ func TestSQLite3defDryRun(t *testing.T) {
 	dryRun := tu.MustExecute(t, "./sqlite3def", "sqlite3def_test", "--dry-run", "--file", "schema.sql")
 	apply := tu.MustExecute(t, "./sqlite3def", "sqlite3def_test", "--file", "schema.sql")
 	assert.Equal(t, strings.Replace(apply, "Apply", "dry run", 1), dryRun)
+}
+
+func TestSQLite3defCheck(t *testing.T) {
+	resetTestDatabase()
+	mustSqlite3Exec("sqlite3def_test", "CREATE TABLE users (id integer NOT NULL PRIMARY KEY);")
+
+	// Case 1: schema in sync -> exit 0
+	tu.WriteFile("schema.sql", "CREATE TABLE users (\n    id integer NOT NULL PRIMARY KEY\n);")
+	noChange := tu.MustExecute(t, "./sqlite3def", "sqlite3def_test", "--check", "--file", "schema.sql")
+	assert.Equal(t, nothingModified, noChange)
+
+	// Case 2: schema differs -> exit 2 with DDL printed
+	tu.WriteFile("schema.sql", "CREATE TABLE users (\n    id integer NOT NULL PRIMARY KEY,\n    age integer\n);")
+	out, err := tu.Execute("./sqlite3def", "sqlite3def_test", "--check", "--file", "schema.sql")
+	exitErr, isExitErr := err.(*exec.ExitError)
+	if !isExitErr {
+		t.Fatalf("expected ExitError from --check when schema differs, got err=%v", err)
+	}
+	assert.Equal(t, sqldef.CheckExitCode, exitErr.ExitCode())
+	assert.Contains(t, out, "-- dry run --")
+	assert.Contains(t, out, "age")
+
+	// Re-running --check must still report a diff (DB untouched).
+	out2, err2 := tu.Execute("./sqlite3def", "sqlite3def_test", "--check", "--file", "schema.sql")
+	exitErr2, isExitErr2 := err2.(*exec.ExitError)
+	if !isExitErr2 {
+		t.Fatalf("expected ExitError from second --check, got err=%v", err2)
+	}
+	assert.Equal(t, sqldef.CheckExitCode, exitErr2.ExitCode())
+	assert.Equal(t, out, out2, "second --check must produce the same output (DB unchanged)")
 }
 
 func TestSQLite3defDropTable(t *testing.T) {

--- a/sqldef.go
+++ b/sqldef.go
@@ -50,9 +50,15 @@ type Options struct {
 	CurrentFile string
 	DryRun      bool
 	Export      bool
+	Check       bool // Like --dry-run, but exit 2 when DDL would be applied (CI gate).
 	BeforeApply string
 	Config      database.GeneratorConfig
 }
+
+// CheckExitCode is the exit code returned by --check when the database schema
+// diverges from the desired schema (i.e. one or more DDL statements would have
+// been applied). Matches the convention of diff(1) and `terraform plan -detailed-exitcode`.
+const CheckExitCode = 2
 
 // Main function shared by all commands
 func Run(generatorMode schema.GeneratorMode, db database.Database, sqlParser database.Parser, options *Options) {
@@ -107,7 +113,7 @@ func Run(generatorMode schema.GeneratorMode, db database.Database, sqlParser dat
 		return
 	}
 
-	if options.DryRun || len(options.CurrentFile) > 0 {
+	if options.DryRun || options.Check || len(options.CurrentFile) > 0 {
 		dryRunDB, err := database.NewDryRunDatabase(db)
 		if err != nil {
 			log.Fatal(err)
@@ -119,6 +125,11 @@ func Run(generatorMode schema.GeneratorMode, db database.Database, sqlParser dat
 	err = database.RunDDLs(db, ddls, options.BeforeApply, ddlSuffix, database.StdoutLogger{})
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	if options.Check {
+		// Schema is out of sync: signal to CI without erroring.
+		os.Exit(CheckExitCode)
 	}
 }
 


### PR DESCRIPTION
## Summary

`--dry-run` always exits 0 whether the schema is in sync or not, so it cannot be used directly as a CI gate. There is no existing flag that combines "print the diff" with "exit non-zero on diff" — `--export` dumps current schema only, and `--apply` actually mutates the database.

This PR adds a `--check` flag (across all four commands: `mysqldef`, `psqldef`, `mssqldef`, `sqlite3def`) that:
- Behaves like `--dry-run` (uses the dry-run database wrapper, prints the DDL header + statements, makes no changes to the database).
- Exits with code **2** when DDL would be applied, **0** when the schema is already in sync.

Exit code **2** follows the convention of `diff(1)` and `terraform plan -detailed-exitcode`:
- `0` = no changes
- `2` = changes detected
- `1` stays reserved for actual tool errors (existing behavior)

This lets CI scripts distinguish "schema needs update" from "tool failed":

```bash
mysqldef --check db < schema.sql
case $? in
  0) echo "schema in sync" ;;
  2) echo "schema drift detected, see diff above"; exit 1 ;;
  *) echo "mysqldef error"; exit 1 ;;
esac
```

The exit code is exposed as `sqldef.CheckExitCode` for downstream Go consumers and documented in each command's `cmd-*.md`.

## Implementation

~10 lines in `sqldef.go`:
- `Options.Check bool` field
- `CheckExitCode` constant (= 2)
- After `RunDDLs` returns, if `options.Check`, call `os.Exit(CheckExitCode)`

Plus the flag registration in each of the 4 command frontends. The dry-run database plumbing is reused verbatim — no separate code path. No new tests infrastructure.

## Test coverage

`TestMysqldefCheck` in `cmd/mysqldef/mysqldef_test.go` covers the three observable behaviors:
1. Schema in sync → exit 0, `-- Nothing is modified --`
2. Schema differs → exit 2 (`sqldef.CheckExitCode`), DDL printed under `-- dry run --` header
3. Database unchanged after `--check` (verified by re-running `--check` and asserting it still reports the same diff — proving the first call didn't apply anything)

The core logic lives in shared `sqldef.Run()`, so the integration test for one command exercises the same path as the other three.

## Verified

- Full `TestApply` + `TestMysqldef*` suites: **0 failures** on MySQL 8.4 and only the 4 pre-existing `*VectorIndex*` baseline failures on MariaDB 10.11 (unrelated — MariaDB 10.11 doesn't support `VECTOR`).
- Manual smoke test against MariaDB confirms exit code 0 / 2 split + DB stays untouched.

## Scope note

This PR is intentionally minimal — just the flag, the exit code, the docs, and a test. No mutual-exclusion enforcement between `--check` / `--apply` / `--export` (the existing flags don't enforce that either; `--apply` simply takes precedence in the current code path, and `--check` slots into the same branch as `--dry-run`).
