### PR TITLE
psqldef: emit USING clause for ALTER COLUMN TYPE between string and enum types

### DIFF
--- a/cmd/psqldef/tests_types.yml
+++ b/cmd/psqldef/tests_types.yml
@@ -255,6 +255,177 @@ RenameEnumValueWithSchema:
   down: |
     ALTER TYPE "myschema"."status" ADD VALUE 'pending';
 
+ChangeColumnTypeFromTextToEnum:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE EXTENSION IF NOT EXISTS citext;
+    CREATE TABLE items (
+      id bigint NOT NULL PRIMARY KEY,
+      status_text text NOT NULL,
+      status_varchar varchar(20) NOT NULL,
+      status_citext citext NOT NULL,
+      status_name name NOT NULL
+    );
+  desired: |
+    CREATE EXTENSION IF NOT EXISTS citext;
+    CREATE TYPE item_status AS ENUM ('active', 'inactive');
+    CREATE TABLE items (
+      id bigint NOT NULL PRIMARY KEY,
+      status_text item_status NOT NULL,
+      status_varchar item_status NOT NULL,
+      status_citext item_status NOT NULL,
+      status_name item_status NOT NULL
+    );
+  up: |
+    CREATE TYPE item_status AS ENUM ('active', 'inactive');
+    ALTER TABLE public.items ALTER COLUMN status_text TYPE item_status USING status_text::item_status;
+    ALTER TABLE public.items ALTER COLUMN status_varchar TYPE item_status USING status_varchar::item_status;
+    ALTER TABLE public.items ALTER COLUMN status_citext TYPE item_status USING status_citext::item_status;
+    ALTER TABLE public.items ALTER COLUMN status_name TYPE item_status USING status_name::item_status;
+  down: |
+    ALTER TABLE public.items ALTER COLUMN status_text TYPE text;
+    ALTER TABLE public.items ALTER COLUMN status_varchar TYPE varchar(20);
+    ALTER TABLE public.items ALTER COLUMN status_citext TYPE citext;
+    ALTER TABLE public.items ALTER COLUMN status_name TYPE name;
+    DROP TYPE public.item_status;
+
+ChangeColumnTypeFromTextWithDefaultToEnum:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TABLE items (
+      id bigint NOT NULL PRIMARY KEY,
+      status text NOT NULL DEFAULT 'pending'
+    );
+  desired: |
+    CREATE TYPE item_status AS ENUM ('active', 'inactive', 'pending');
+    CREATE TABLE items (
+      id bigint NOT NULL PRIMARY KEY,
+      status item_status NOT NULL DEFAULT 'pending'
+    );
+  up: |
+    CREATE TYPE item_status AS ENUM ('active', 'inactive', 'pending');
+    ALTER TABLE public.items ALTER COLUMN status DROP DEFAULT;
+    ALTER TABLE public.items ALTER COLUMN status TYPE item_status USING status::item_status;
+    ALTER TABLE public.items ALTER COLUMN status SET DEFAULT 'pending';
+  down: |
+    ALTER TABLE public.items ALTER COLUMN status DROP DEFAULT;
+    ALTER TABLE public.items ALTER COLUMN status TYPE text;
+    ALTER TABLE public.items ALTER COLUMN status SET DEFAULT 'pending';
+    DROP TYPE public.item_status;
+
+ChangeColumnTypeFromTextToEnumAddingDefault:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TABLE items (
+      id bigint NOT NULL PRIMARY KEY,
+      status text NOT NULL
+    );
+  desired: |
+    CREATE TYPE item_status AS ENUM ('active', 'inactive', 'pending');
+    CREATE TABLE items (
+      id bigint NOT NULL PRIMARY KEY,
+      status item_status NOT NULL DEFAULT 'pending'
+    );
+  up: |
+    CREATE TYPE item_status AS ENUM ('active', 'inactive', 'pending');
+    ALTER TABLE public.items ALTER COLUMN status TYPE item_status USING status::item_status;
+    ALTER TABLE public.items ALTER COLUMN status SET DEFAULT 'pending';
+  down: |
+    ALTER TABLE public.items ALTER COLUMN status DROP DEFAULT;
+    ALTER TABLE public.items ALTER COLUMN status TYPE text;
+    DROP TYPE public.item_status;
+
+ChangeColumnTypeFromTextWithDefaultToEnumDroppingDefault:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TABLE items (
+      id bigint NOT NULL PRIMARY KEY,
+      status text NOT NULL DEFAULT 'pending'
+    );
+  desired: |
+    CREATE TYPE item_status AS ENUM ('active', 'inactive');
+    CREATE TABLE items (
+      id bigint NOT NULL PRIMARY KEY,
+      status item_status NOT NULL
+    );
+  up: |
+    CREATE TYPE item_status AS ENUM ('active', 'inactive');
+    ALTER TABLE public.items ALTER COLUMN status DROP DEFAULT;
+    ALTER TABLE public.items ALTER COLUMN status TYPE item_status USING status::item_status;
+  down: |
+    ALTER TABLE public.items ALTER COLUMN status TYPE text;
+    ALTER TABLE public.items ALTER COLUMN status SET DEFAULT 'pending';
+    DROP TYPE public.item_status;
+
+ChangeColumnTypeFromTextWithDefaultToEnumChangingDefault:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TABLE items (
+      id bigint NOT NULL PRIMARY KEY,
+      status text NOT NULL DEFAULT 'active'
+    );
+  desired: |
+    CREATE TYPE item_status AS ENUM ('active', 'inactive', 'pending');
+    CREATE TABLE items (
+      id bigint NOT NULL PRIMARY KEY,
+      status item_status NOT NULL DEFAULT 'pending'
+    );
+  up: |
+    CREATE TYPE item_status AS ENUM ('active', 'inactive', 'pending');
+    ALTER TABLE public.items ALTER COLUMN status DROP DEFAULT;
+    ALTER TABLE public.items ALTER COLUMN status TYPE item_status USING status::item_status;
+    ALTER TABLE public.items ALTER COLUMN status SET DEFAULT 'pending';
+  down: |
+    ALTER TABLE public.items ALTER COLUMN status DROP DEFAULT;
+    ALTER TABLE public.items ALTER COLUMN status TYPE text;
+    ALTER TABLE public.items ALTER COLUMN status SET DEFAULT 'active';
+    DROP TYPE public.item_status;
+
+ChangeColumnTypeFromEnumToDifferentEnum:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TYPE old_status AS ENUM ('a', 'b');
+    CREATE TABLE items (
+      id bigint NOT NULL PRIMARY KEY,
+      status old_status NOT NULL
+    );
+  desired: |
+    CREATE TYPE new_status AS ENUM ('a', 'b');
+    CREATE TABLE items (
+      id bigint NOT NULL PRIMARY KEY,
+      status new_status NOT NULL
+    );
+  up: |
+    CREATE TYPE new_status AS ENUM ('a', 'b');
+    ALTER TABLE public.items ALTER COLUMN status TYPE new_status USING status::text::new_status;
+    DROP TYPE public.old_status;
+  down: |
+    CREATE TYPE old_status AS ENUM ('a', 'b');
+    ALTER TABLE public.items ALTER COLUMN status TYPE old_status USING status::text::old_status;
+    DROP TYPE public.new_status;
+
+ChangeColumnTypeFromEnumWithSchemaToText:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE SCHEMA myschema;
+    CREATE TYPE myschema.item_status AS ENUM ('active', 'inactive');
+    CREATE TABLE items (
+      id bigint NOT NULL PRIMARY KEY,
+      status myschema.item_status NOT NULL
+    );
+  desired: |
+    CREATE SCHEMA myschema;
+    CREATE TABLE items (
+      id bigint NOT NULL PRIMARY KEY,
+      status text NOT NULL
+    );
+  up: |
+    ALTER TABLE public.items ALTER COLUMN status TYPE text;
+    DROP TYPE myschema.item_status;
+  down: |
+    CREATE TYPE myschema.item_status AS ENUM ('active', 'inactive');
+    ALTER TABLE public.items ALTER COLUMN status TYPE myschema.item_status USING status::myschema.item_status;
+
 EnumTypeDefaultIdempotent:
   legacy_ignore_quotes: false
   current: |

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -1052,6 +1052,10 @@ func (g *Generator) generateDDLsForCreateTable(currentTable Table, desired Creat
 					"currentTypeIdent", currentColumn.typeIdent,
 					"desiredTypeName", desiredColumn.typeName,
 					"desiredTypeIdent", desiredColumn.typeIdent)
+				// enumTypeChange is true when the type change involves an enum on
+				// either side. In that case the column default must be re-applied
+				// around the ALTER (see classifyEnumTypeChange's docstring).
+				var enumTypeChange bool
 				if !g.haveSameDataType(*currentColumn, desiredColumn) {
 					// Serial types require changing both column type and sequence type
 					if isPostgresSerialType(currentColumn.typeName) && isPostgresSerialType(desiredColumn.typeName) {
@@ -1062,8 +1066,17 @@ func (g *Generator) generateDDLsForCreateTable(currentTable Table, desired Creat
 						seqDDL := g.generateSerialSequenceAlterDDL(&desired.table, &desiredColumn, underlyingType)
 						ddls = append(ddls, seqDDL)
 					} else {
+						usingClause, enumInvolved := g.classifyEnumTypeChange(*currentColumn, desiredColumn)
+						enumTypeChange = enumInvolved
+						if enumTypeChange && currentColumn.defaultDef != nil {
+							ddls = append(ddls, fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s DROP DEFAULT",
+								g.escapeTableName(&desired.table), g.escapeColumnName(&desiredColumn)))
+						}
 						// Change type - use desiredColumn for escaping to match user's quote style
 						ddl := fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s TYPE %s", g.escapeTableName(&desired.table), g.escapeColumnName(&desiredColumn), g.generateDataType(desiredColumn))
+						if usingClause != "" {
+							ddl += " USING " + usingClause
+						}
 						ddls = append(ddls, ddl)
 					}
 				}
@@ -1111,7 +1124,17 @@ func (g *Generator) generateDDLsForCreateTable(currentTable Table, desired Creat
 				}
 
 				// default
-				if !g.areSameDefaultValue(currentColumn.defaultDef, desiredColumn.defaultDef, desiredColumn.typeName) {
+				if enumTypeChange {
+					// The default was already dropped (if present) before the ALTER
+					// COLUMN TYPE above; re-apply the desired default in the new type.
+					if desiredColumn.defaultDef != nil {
+						definition, err := g.generateDefaultDefinition(*desiredColumn.defaultDef)
+						if err != nil {
+							return ddls, err
+						}
+						ddls = append(ddls, fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s SET %s", g.escapeTableName(&desired.table), g.escapeColumnName(&desiredColumn), definition))
+					}
+				} else if !g.areSameDefaultValue(currentColumn.defaultDef, desiredColumn.defaultDef, desiredColumn.typeName) {
 					if desiredColumn.defaultDef == nil {
 						// drop - use desiredColumn for escaping to match user's quote style
 						ddls = append(ddls, fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s DROP DEFAULT", g.escapeTableName(&desired.table), g.escapeColumnName(&desiredColumn)))
@@ -4392,6 +4415,93 @@ func (g *Generator) findType(types []*Type, desiredType *Type) *Type {
 		}
 	}
 	return nil
+}
+
+// isEnumCastableStringType reports whether typeName is a PostgreSQL string-like
+// type that can be safely cast to/from an enum via "USING col::enum" for both
+// empty and populated tables.
+//
+// Fixed-length character(N) / bpchar is intentionally excluded: its values are
+// space-padded on the right, so "USING col::enum" would compare e.g.
+// 'active  ' against enum labels and fail at runtime. Supporting it would
+// require emitting rtrim() inside USING, which silently corrupts enum labels
+// that legitimately end with whitespace.
+func isEnumCastableStringType(typeName string) bool {
+	switch normalizeTypeName(typeName, GeneratorModePostgres) {
+	case "text", "character varying", "citext", "name":
+		return true
+	}
+	return false
+}
+
+// classifyEnumTypeChange inspects an ALTER COLUMN ... TYPE change that may
+// involve a PostgreSQL enum.
+//
+// using is the body of a USING expression when the cast has no implicit form:
+//   - string -> enum:                "col::enum_t"
+//   - enum_a -> enum_b (different):  "col::text::enum_b" (no direct cast)
+//
+// PostgreSQL has an assignment cast from enum to string types (text, varchar,
+// citext, name), so enum -> string returns no USING.
+//
+// enumInvolved is true whenever either side resolves to an enum (regardless of
+// whether USING is needed). Callers use it to drop and re-apply the column
+// default around the ALTER, since the existing default still references the
+// old type after the cast and would otherwise block DROP TYPE.
+func (g *Generator) classifyEnumTypeChange(currentColumn, desiredColumn Column) (using string, enumInvolved bool) {
+	if g.mode != GeneratorModePostgres {
+		return "", false
+	}
+
+	currentEnum := g.findEnumTypeForColumn(currentColumn, g.currentTypes)
+	desiredEnum := g.findEnumTypeForColumn(desiredColumn, g.desiredTypes)
+	enumInvolved = currentEnum != nil || desiredEnum != nil
+
+	stringToEnum := desiredEnum != nil && currentEnum == nil && isEnumCastableStringType(currentColumn.typeName)
+	enumToEnum := currentEnum != nil && desiredEnum != nil && !g.qualifiedNamesEqual(currentEnum.name, desiredEnum.name)
+	if !stringToEnum && !enumToEnum {
+		return "", enumInvolved
+	}
+
+	column := g.escapeColumnName(&desiredColumn)
+	target := g.generateDataType(desiredColumn)
+	if enumToEnum {
+		return fmt.Sprintf("%s::text::%s", column, target), enumInvolved
+	}
+	return fmt.Sprintf("%s::%s", column, target), enumInvolved
+}
+
+// findEnumTypeForColumn looks up the enum type that the column refers to in the given
+// types list, or returns nil if the column does not refer to an enum type.
+func (g *Generator) findEnumTypeForColumn(column Column, types []*Type) *Type {
+	if g.mode != GeneratorModePostgres || column.typeName == "" {
+		return nil
+	}
+
+	// typeIdent carries the quote info and is set for user-defined types
+	// (domains, enums, ...). The generic parser leaves it empty when the
+	// source SQL writes a schema-qualified custom type like "myschema.item",
+	// because parseTable splits "myschema.item" into references="myschema."
+	// + typeName="item" before typeIdent gets populated. Fall back to
+	// typeName so quoted schemas still find their unquoted enum.
+	typeIdent := column.typeIdent
+	if typeIdent.IsEmpty() {
+		typeIdent = Ident{Name: column.typeName}
+	}
+
+	target := &Type{name: QualifiedName{
+		Schema: Ident{
+			Name:   strings.TrimSuffix(column.references.Name, "."),
+			Quoted: column.references.Quoted,
+		},
+		Name: typeIdent,
+	}}
+
+	found := g.findType(types, target)
+	if found == nil || len(found.enumValues) == 0 {
+		return nil
+	}
+	return found
 }
 
 // findDomainByName finds a domain using quote-aware comparison including schema


### PR DESCRIPTION
## Why

`psqldef` currently generates `ALTER TABLE ... ALTER COLUMN ... TYPE <new_type>` without a `USING` clause when changing a column's type. That is fine when PostgreSQL has an implicit cast between the old and new types, but it is rejected for enum-related conversions:

```sql
-- current
CREATE TABLE items (status text NOT NULL);
-- desired
CREATE TYPE item_status AS ENUM ('active', 'inactive');
CREATE TABLE items (status item_status NOT NULL);
```

```
ERROR: column "status" cannot be cast automatically to type item_status
HINT:  You might need to specify "USING status::item_status".
```

The same problem reproduces between two distinct enum types. The reverse direction (enum → text/varchar/…) succeeds with no `USING` because PostgreSQL has an assignment cast from enum to text, but a separate issue surfaces there: the column default is rewritten as `'pending'::item_status` (still bound to the old type) and survives the `ALTER`, blocking the subsequent `DROP TYPE`. Both shapes need help from `psqldef` to produce a migration that actually applies.

## What

For PostgreSQL, when an `ALTER COLUMN ... TYPE` change crosses between a string-like type and an enum type — or between two different enum types — `psqldef` now appends a `USING` expression that PostgreSQL accepts:

| Direction | Generated USING |
| --- | --- |
| `text` / `varchar` / `citext` / `name` → `enum_t` | `USING col::enum_t` |
| `enum_t` → `text` / `varchar` / `citext` / `name` | _(none — PostgreSQL has an assignment cast)_ |
| `enum_a` → `enum_b` (different enums) | `USING col::text::enum_b` (enum-to-enum has no direct cast) |

Fixed-length `character(N)` (a.k.a. `bpchar`) is **intentionally excluded**: its values are space-padded on the right, so `USING col::enum` would compare e.g. `'active  '` against enum labels and fail at runtime. Supporting it would require emitting `rtrim()` inside the USING expression, which silently corrupts enum labels that legitimately end with whitespace. Users on `character(N)` should migrate the column to `text`/`varchar` first, or supply a hand-written USING expression.

When the column carries a `DEFAULT` and the type change involves an enum on either side, PostgreSQL keeps the existing default expression pointing at the old type — `'pending'` on the enum side is stored internally as `'pending'::item_status` and survives an enum→text ALTER as `'pending'::item_status`, which then blocks the subsequent `DROP TYPE`. In the string→enum direction the same default also fails the implicit re-cast even when the literal is unchanged on both sides. `psqldef` therefore drops the existing default before any enum-involving type change and re-applies the desired default afterwards, so the migration is:

```sql
ALTER TABLE public.items ALTER COLUMN status DROP DEFAULT;
ALTER TABLE public.items ALTER COLUMN status TYPE item_status USING status::item_status;
ALTER TABLE public.items ALTER COLUMN status SET DEFAULT 'pending';
```

### Out of scope

- Non-PostgreSQL dialects. The new logic is gated on `GeneratorModePostgres`.
- USING expressions for other incompatible casts (e.g. `text` → `integer`). Only the string ↔ enum / enum ↔ enum cases are addressed here.
- Validating that existing column data actually fits the destination enum's labels. That remains the user's responsibility — the cast will fail at runtime if data is incompatible, which is the expected PostgreSQL behavior.

## Test plan

New cases in `cmd/psqldef/tests_types.yml`, all with `legacy_ignore_quotes: false`:

USING-clause coverage:

- `ChangeColumnTypeFromTextToEnum` — four-column table covering text, varchar(20), citext, name converted to a shared enum, with reverse migration.
- `ChangeColumnTypeFromEnumWithSchemaToText` — enum in a non-default schema (`myschema.item_status`) converted to text, verifying schema-qualified lookup.
- `ChangeColumnTypeFromEnumToDifferentEnum` — `old_status` enum to `new_status` enum, asserting the `col::text::new_status` form.

DEFAULT handling across the four current/desired combinations:

- `ChangeColumnTypeFromTextToEnum` (above) also covers the **both-absent** case (no DEFAULT on either side).
- `ChangeColumnTypeFromTextToEnumAddingDefault` — DEFAULT **added** (current has none, desired sets `DEFAULT 'pending'`): no DROP, just ALTER USING + SET DEFAULT.
- `ChangeColumnTypeFromTextWithDefaultToEnumDroppingDefault` — DEFAULT **dropped** (current has `DEFAULT 'pending'`, desired has none): DROP DEFAULT + ALTER USING, no trailing SET.
- `ChangeColumnTypeFromTextWithDefaultToEnumChangingDefault` — DEFAULT **changed** (`'active'` → `'pending'`): DROP / ALTER USING / SET DEFAULT 'pending'.
- `ChangeColumnTypeFromTextWithDefaultToEnum` — DEFAULT **unchanged** literal (`'pending'` → `'pending'`): still DROP / ALTER USING / SET DEFAULT, because PostgreSQL otherwise tries to implicitly re-cast `'pending'::text` to the new enum and fails.

Verified locally against `postgres:18` from `compose.yml` with `PSQLDEF_PARSER=generic`:

- [x] `go test ./cmd/psqldef` (full suite, ~60s) — all green, no regressions on existing enum / type tests.
- [x] `go test ./schema/...` — green.
- [x] `make build` — green.