### PR TITLE
fix: mysql emit DROP CONSTRAINT (not DROP CHECK) for MariaDB compatibility

### DIFF
--- a/cmd/mysqldef/tests_constraints.yml
+++ b/cmd/mysqldef/tests_constraints.yml
@@ -144,7 +144,6 @@ CheckInClauseWithMultipleConditions:
     );
   min_version: '8.0'
 AddCheckConstraintWithIn:
-  flavor: "!mariadb"
   current: |
     CREATE TABLE `documents` (
       `id` int PRIMARY KEY,
@@ -159,10 +158,9 @@ AddCheckConstraintWithIn:
   up: |
     ALTER TABLE `documents` ADD CONSTRAINT `documents_state_chk` CHECK (state in ('draft', 'review', 'published', 'archived'));
   down: |
-    ALTER TABLE `documents` DROP CHECK `documents_state_chk`;
+    ALTER TABLE `documents` DROP CONSTRAINT `documents_state_chk`;
   min_version: '8.0'
 ModifyCheckConstraintIn:
-  flavor: "!mariadb"
   current: |
     CREATE TABLE `tasks` (
       `id` int PRIMARY KEY,
@@ -176,14 +174,13 @@ ModifyCheckConstraintIn:
       CONSTRAINT `tasks_status_chk` CHECK (`status` IN ('todo', 'in_progress', 'done'))
     );
   up: |
-    ALTER TABLE `tasks` DROP CHECK `tasks_status_chk`;
+    ALTER TABLE `tasks` DROP CONSTRAINT `tasks_status_chk`;
     ALTER TABLE `tasks` ADD CONSTRAINT `tasks_status_chk` CHECK (status in ('todo', 'in_progress', 'done'));
   down: |
-    ALTER TABLE `tasks` DROP CHECK `tasks_status_chk`;
+    ALTER TABLE `tasks` DROP CONSTRAINT `tasks_status_chk`;
     ALTER TABLE `tasks` ADD CONSTRAINT `tasks_status_chk` CHECK (status in ('todo', 'in_progress'));
   min_version: '8.0'
 DropCheckConstraintWithIn:
-  flavor: "!mariadb"
   current: |
     CREATE TABLE `events` (
       `id` int PRIMARY KEY,
@@ -196,7 +193,7 @@ DropCheckConstraintWithIn:
       `type` varchar(20)
     );
   up: |
-    ALTER TABLE `events` DROP CHECK `events_type_chk`;
+    ALTER TABLE `events` DROP CONSTRAINT `events_type_chk`;
   down: |
     ALTER TABLE `events` ADD CONSTRAINT `events_type_chk` CHECK (type in ('public', 'private'));
   min_version: '8.0'
@@ -281,7 +278,6 @@ CheckDuplicateValuesInOrChain:
   down: ""
   min_version: '8.0'
 CheckRowValueConstructorMultipleInnerValues:
-  flavor: "!mariadb"
   current: |
     CREATE TABLE `test_multi` (
       `col_a` int,
@@ -295,10 +291,10 @@ CheckRowValueConstructorMultipleInnerValues:
       CONSTRAINT `test_multi_chk` CHECK ((`col_a`, `col_b`) IN ((1, 3), (2, 4)))
     );
   up: |
-    ALTER TABLE `test_multi` DROP CHECK `test_multi_chk`;
+    ALTER TABLE `test_multi` DROP CONSTRAINT `test_multi_chk`;
     ALTER TABLE `test_multi` ADD CONSTRAINT `test_multi_chk` CHECK ((col_a, col_b) in ((1, 3), (2, 4)));
   down: |
-    ALTER TABLE `test_multi` DROP CHECK `test_multi_chk`;
+    ALTER TABLE `test_multi` DROP CONSTRAINT `test_multi_chk`;
     ALTER TABLE `test_multi` ADD CONSTRAINT `test_multi_chk` CHECK ((col_a, col_b) in ((3, 1), (2, 4)));
   min_version: '8.0'
 CheckRowValueConstructorOuterOrderShouldMatch:

--- a/cmd/mysqldef/tests_datatypes.yml
+++ b/cmd/mysqldef/tests_datatypes.yml
@@ -439,7 +439,6 @@ TypedLiteralsChangeDefault:
     ALTER TABLE `events` CHANGE COLUMN `event_time` `event_time` time DEFAULT '12:00:00';
     ALTER TABLE `events` CHANGE COLUMN `event_timestamp` `event_timestamp` timestamp DEFAULT '2024-01-01 12:00:00';
 TypedLiteralsInCheck:
-  flavor: "!mariadb"
   min_version: '8.0'
   current: |
     CREATE TABLE events (
@@ -459,7 +458,7 @@ TypedLiteralsInCheck:
     ALTER TABLE `events` ADD COLUMN `event_end_date` date AFTER `event_date`;
     ALTER TABLE `events` ADD CONSTRAINT `chk_date_range` CHECK (event_date >= date '2020-01-01' and event_end_date <= date '2030-12-31');
   down: |
-    ALTER TABLE `events` DROP CHECK `chk_date_range`;
+    ALTER TABLE `events` DROP CONSTRAINT `chk_date_range`;
     ALTER TABLE `events` DROP COLUMN `event_end_date`;
     ALTER TABLE `events` DROP COLUMN `event_date`;
 YearWithLength:

--- a/cmd/mysqldef/tests_mariadb.yml
+++ b/cmd/mysqldef/tests_mariadb.yml
@@ -235,3 +235,52 @@ CreateTableWithAutoIncrementPrimaryKeyAndAddMorePrimaryKeyMariaDB:
     ALTER TABLE `friends` CHANGE COLUMN `id` `id` bigint(20) NOT NULL AUTO_INCREMENT;
   flavor: mariadb
   min_version: '10.0'
+
+# CHECK constraint replacement on MariaDB.
+# MariaDB rejects `ALTER TABLE ... DROP CHECK <name>` (syntax error 1064); only
+# `ALTER TABLE ... DROP CONSTRAINT <name>` works. Repro from upstream report:
+# https://github.com/sqldef/sqldef/issues (DROP CHECK parasite on MariaDB).
+ModifyCheckConstraintMariaDB:
+  current: |
+    CREATE TABLE `quote_sections` (
+      `id` int PRIMARY KEY,
+      `service_period_start` date,
+      `service_period_end` date,
+      CONSTRAINT `chk_quote_sections_service_period` CHECK (`service_period_start` IS NULL AND `service_period_end` IS NULL OR `service_period_end` >= `service_period_start`)
+    );
+  desired: |
+    CREATE TABLE `quote_sections` (
+      `id` int PRIMARY KEY,
+      `service_period_start` date,
+      `service_period_end` date,
+      CONSTRAINT `chk_quote_sections_service_period` CHECK (`service_period_start` IS NULL OR `service_period_end` IS NULL OR `service_period_end` >= `service_period_start`)
+    );
+  up: |
+    ALTER TABLE `quote_sections` DROP CONSTRAINT `chk_quote_sections_service_period`;
+    ALTER TABLE `quote_sections` ADD CONSTRAINT `chk_quote_sections_service_period` CHECK (service_period_start is null or service_period_end is null or service_period_end >= service_period_start);
+  down: |
+    ALTER TABLE `quote_sections` DROP CONSTRAINT `chk_quote_sections_service_period`;
+    ALTER TABLE `quote_sections` ADD CONSTRAINT `chk_quote_sections_service_period` CHECK (service_period_start is null and service_period_end is null or service_period_end >= service_period_start);
+  flavor: mariadb
+  min_version: '10.2'
+
+DropCheckConstraintMariaDB:
+  current: |
+    CREATE TABLE `quote_sections` (
+      `id` int PRIMARY KEY,
+      `service_period_start` date,
+      `service_period_end` date,
+      CONSTRAINT `chk_quote_sections_service_period` CHECK (`service_period_end` >= `service_period_start`)
+    );
+  desired: |
+    CREATE TABLE `quote_sections` (
+      `id` int PRIMARY KEY,
+      `service_period_start` date,
+      `service_period_end` date
+    );
+  up: |
+    ALTER TABLE `quote_sections` DROP CONSTRAINT `chk_quote_sections_service_period`;
+  down: |
+    ALTER TABLE `quote_sections` ADD CONSTRAINT `chk_quote_sections_service_period` CHECK (service_period_end >= service_period_start);
+  flavor: mariadb
+  min_version: '10.2'

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -553,12 +553,11 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 				continue
 			}
 
-			switch g.mode {
-			case GeneratorModePostgres, GeneratorModeMssql, GeneratorModeSQLite3:
-				ddls = append(ddls, fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s", g.escapeTableName(currentTable), g.escapeSQLIdent(check.constraintName)))
-			case GeneratorModeMysql:
-				ddls = append(ddls, fmt.Sprintf("ALTER TABLE %s DROP CHECK %s", g.escapeTableName(currentTable), g.escapeSQLIdent(check.constraintName)))
-			}
+			// DROP CONSTRAINT is supported across all targets that enforce CHECK:
+			// MySQL 8.0.16+, MariaDB 10.2+, TiDB, PostgreSQL, MSSQL, SQLite. MySQL
+			// 5.7 parses but does not enforce CHECK, so this branch never fires for
+			// it. MariaDB does not accept DROP CHECK <name>, only DROP CONSTRAINT.
+			ddls = append(ddls, fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s", g.escapeTableName(currentTable), g.escapeSQLIdent(check.constraintName)))
 		}
 
 		// Check columns.
@@ -1683,11 +1682,10 @@ func (g *Generator) generateDDLsForCreateTable(currentTable Table, desired Creat
 				currentNameIdent := currentCheck.constraintName
 				desiredNameIdent := desiredCheck.constraintName
 				switch g.mode {
-				case GeneratorModePostgres, GeneratorModeMssql:
+				case GeneratorModePostgres, GeneratorModeMssql, GeneratorModeMysql:
+					// DROP CONSTRAINT works on MySQL 8.0.16+, MariaDB 10.2+, TiDB,
+					// PostgreSQL, and MSSQL. MariaDB does not accept DROP CHECK.
 					ddls = append(ddls, fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s", g.escapeTableName(&desired.table), g.escapeSQLIdent(currentNameIdent)))
-					ddls = append(ddls, fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT %s CHECK (%s)", g.escapeTableName(&desired.table), g.escapeSQLIdent(desiredNameIdent), g.normalizeCheckExprString(desiredCheck.definition)))
-				case GeneratorModeMysql:
-					ddls = append(ddls, fmt.Sprintf("ALTER TABLE %s DROP CHECK %s", g.escapeTableName(&desired.table), g.escapeSQLIdent(currentNameIdent)))
 					ddls = append(ddls, fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT %s CHECK (%s)", g.escapeTableName(&desired.table), g.escapeSQLIdent(desiredNameIdent), g.normalizeCheckExprString(desiredCheck.definition)))
 				case GeneratorModeSQLite3:
 					// SQLite does not support ALTER TABLE for CHECK constraints


### PR DESCRIPTION
## What

`ALTER TABLE ... DROP CHECK <name>` is MySQL-only syntax. MariaDB rejects it with:

```
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that
corresponds to your MariaDB server version for the right syntax to use near
'CHECK `chk_xxx`' at line 1
```

So today, any mysqldef run targeting MariaDB that needs to drop or replace a named CHECK constraint fails. Five existing tests carry `flavor: "!mariadb"` annotations precisely because of this — the bug was known and worked around at the test layer rather than fixed.

## Fix

Emit `ALTER TABLE ... DROP CONSTRAINT <name>` instead of `DROP CHECK <name>` in both branches that previously discriminated on `GeneratorModeMysql`.

`DROP CONSTRAINT` is the portable form:
- **MySQL 8.0.16+** — same release that introduced CHECK enforcement, accepts both `DROP CONSTRAINT` and `DROP CHECK`.
- **MariaDB 10.2+** — accepts only `DROP CONSTRAINT`.
- **TiDB** — follows MySQL 8.0 dialect.
- **PostgreSQL, MSSQL** — already used `DROP CONSTRAINT`.

MySQL 5.7 parses CHECK but does not enforce it, so this code path never fires there — verified by the fact that all affected tests already carry `min_version: '8.0'`.

## Test coverage

The harness self-reports tests that no longer need flavor gates. After the generator change, it flagged five tests as "now passing on mariadb":

- `AddCheckConstraintWithIn`
- `ModifyCheckConstraintIn`
- `DropCheckConstraintWithIn`
- `CheckRowValueConstructorMultipleInnerValues`
- `TypedLiteralsInCheck`

The `flavor: "!mariadb"` gate is removed from each, giving MariaDB CI coverage of those scenarios for free.

Two new MariaDB-flavored tests (`ModifyCheckConstraintMariaDB`, `DropCheckConstraintMariaDB`) reproduce the original failing diff (named CHECK constraint replacement / removal). Without the fix they fail with the 1064 syntax error; with it they pass.

## Verification

- `MYSQL_FLAVOR=mariadb MYSQL_PORT=3307 go test ./cmd/mysqldef` — green on `mariadb:11.8`.
- `MYSQL_FLAVOR=mysql go test ./cmd/mysqldef` — green on `mysql:8.0`.
- `go test ./schema/...` — green.

## Real-world repro

Hit downstream in production (scapino-portal). A CHECK constraint relaxation (`AND` → `OR`) produced the diff:

```
ALTER TABLE `quote_sections` DROP CHECK `chk_quote_sections_service_period`;
ALTER TABLE `quote_sections` ADD CONSTRAINT `chk_quote_sections_service_period` CHECK (...);
```

mysqldef applied it against MariaDB 11.8 → 1064 error → migration aborted mid-transaction → CI auto-rolled back. Workaround was to manually run `ALTER TABLE ... DROP CONSTRAINT` outside mysqldef, which this PR makes unnecessary.