### PR TITLE
ci: run all packages with tests in CI via a test-core job

### DIFF
--- a/.github/workflows/sqldef.yml
+++ b/.github/workflows/sqldef.yml
@@ -149,10 +149,30 @@ jobs:
           PGVECTOR_VERSION: ${{ matrix.pgvector_version }}
           MSSQL_VERSION: ${{ matrix.mssql_version }}
 
+  test-core:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+        with:
+          go-version-file: go.mod
+
+      - run: make test-core
+        id: test
+        env:
+          GOTESTFLAGS: -coverprofile=coverage.out -coverpkg=./...
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-core
+          path: coverage.out
+          retention-days: 1
+
   upload-coverage:
     runs-on: ubuntu-latest
-    needs: test
-    if: always() && !contains(needs.test.result, 'cancelled')
+    needs: [test, test-core]
+    if: always() && !contains(needs.test.result, 'cancelled') && !contains(needs.test-core.result, 'cancelled')
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
@@ -228,7 +248,7 @@ jobs:
   test-result:
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    needs: [test, integrity]
+    needs: [test, test-core, integrity]
     steps:
       - name: test jobs have failed
         run: exit 1

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ test:
 .PHONY: test
 
 test-mysqldef:
-	MYSQL_FLAVOR=$${MYSQL_FLAVOR:-mysql} $(GOTEST) ./cmd/mysqldef
+	MYSQL_FLAVOR=$${MYSQL_FLAVOR:-mysql} $(GOTEST) ./cmd/mysqldef ./database/mysql
 .PHONY: test-mysqldef
 
 test-psqldef:
@@ -108,7 +108,7 @@ test-mssqldef:
 .PHONY: test-mssqldef
 
 test-core:
-	$(GOTEST) ./parser ./schema ./util
+	$(GOTEST) ./database ./parser ./schema ./util
 .PHONY: test-core
 
 test-example-offline:


### PR DESCRIPTION
## Why

The `test:` matrix in `.github/workflows/sqldef.yml` only runs `make test-<engine>`
jobs, and each engine target executes a narrow set of packages:

| target | packages executed |
|---|---|
| `test-mysqldef` | `./cmd/mysqldef` |
| `test-psqldef` | `./cmd/psqldef ./database/postgres` |
| `test-sqlite3def` | `./cmd/sqlite3def` |
| `test-mssqldef` | `./cmd/mssqldef ./database/mssql` |

As a result, the unit-test packages `./parser`, `./schema`, and `./util` are
**never executed in CI**. `make test-core` covers them locally but was not wired
into any GitHub Actions job. This gap causes two concrete problems:

1. **Codecov `patch` reports 0% on parser-only PRs.** Because no CI job runs
   `./parser`, coverage for parser changes never reaches Codecov, producing a
   misleading "uncovered patch" signal on every parser-only change (observed on
   #1224).
2. **Parser-only regressions can land green.** If a PR only touches `./parser`,
   `./schema`, or `./util` and breaks their tests, all four engine jobs still
   pass, so the failure is only caught indirectly (and non-deterministically) by
   engine-routed tests.

While auditing for this gap, two more packages with tests turned out to run in
no CI job either: `./database` (an engine-independent unit test) and
`./database/mysql` (a service-less unix-socket test). Notably `test-mysqldef`
was the only engine target not running its `./database/<engine>` package, unlike
`test-psqldef` / `test-mssqldef`.

## What

Add a dedicated `test-core` job that runs `./parser ./schema ./util` exactly once
per workflow and feeds its coverage into the existing Codecov upload, and close
the remaining CI test-coverage gaps:

1. **New `test-core` job** — runs `make test-core` with the same
   `GOTESTFLAGS` as the engine matrix jobs and uploads a `coverage-core` artifact.
   It needs no database service or engine-specific env, so it is a standalone job
   rather than a matrix entry.
2. **`upload-coverage` now depends on `test-core`** (`needs: [test, test-core]`,
   with the `if:` guard widened for `test-core` cancellation) so the merged
   coverage upload waits for the core artifact instead of uploading without it.
3. **`test-result` aggregates `test-core`** (`needs: [test, test-core, integrity]`)
   so a `test-core` failure propagates into the aggregate check.
4. **Makefile: cover the last two stragglers** — add `./database/mysql` to
   `test-mysqldef` (matching the other engine targets) and `./database` to
   `test-core`. After this, every package that has tests is run in CI.

The download (`pattern: coverage-*`), filter, and `gocovmerge` steps already
operate on every `coverage-*` artifact generically, so the new `coverage-core`
file is picked up and merged with no further changes.

## Notes for reviewers

- **Artifacts are not overwritten.** Each job uploads under a distinct artifact
  name (engine jobs use `coverage-<target>...`, the new job uses `coverage-core`),
  and `gocovmerge` combines them into a single `coverage.out` before the Codecov
  upload.
- **No required-check changes.** Making `codecov/patch` or `test-core` a required
  check lives in the branch ruleset (repo settings), not in workflow YAML, and is
  intentionally out of scope here.
- The existing per-engine matrix jobs are unchanged; their narrow scope is kept
  intentional for CI cycle time.
