### PR TITLE
psqldef: retry generic parser for ignored statements in auto mode

### DIFF
--- a/database/postgres/parser.go
+++ b/database/postgres/parser.go
@@ -138,6 +138,21 @@ func (p PostgresParser) parsePgquery(sql string) ([]database.DDLStatement, error
 			continue
 		}
 
+		// In Auto mode, an Ignore means pgquery has no AST conversion for this node
+		// type (e.g. CREATE FUNCTION). The generic parser does support these, so retry
+		// the single statement before keeping the Ignore. Without this the desired
+		// schema silently loses the statement while the current schema (introspected
+		// from the DB) keeps it, producing a destructive diff such as a spurious
+		// DROP FUNCTION. Pgquery-only mode keeps the Ignore unchanged (PR #1116 intent).
+		if _, isIgnore := stmt.(*parser.Ignore); isIgnore && p.mode == PsqldefParserModeAuto {
+			stmts, retryErr := p.parser.Parse(ddl)
+			if retryErr == nil {
+				statements = append(statements, stmts...)
+				continue
+			}
+			slog.Debug("generic parser also failed for Ignore-d statement, keeping Ignore", "error", retryErr.Error())
+		}
+
 		statements = append(statements, database.DDLStatement{
 			DDL:       ddl,
 			Statement: stmt,

--- a/database/postgres/parser_test.go
+++ b/database/postgres/parser_test.go
@@ -144,6 +144,44 @@ func TestCreateFunctionWithPgquery(t *testing.T) {
 	}
 }
 
+func TestCreateFunctionAutoModeFallbackRetry(t *testing.T) {
+	// Force Auto mode regardless of an ambient PSQLDEF_PARSER (the dev/CI default
+	// is generic, which would skip pgquery entirely and never exercise this path).
+	t.Setenv("PSQLDEF_PARSER", "")
+	postgresParser := NewParserWithMode(PsqldefParserModeAuto)
+
+	// The table uses a storage parameter the generic parser rejects, forcing a
+	// whole-file fallback to pgquery. The CREATE FUNCTION must survive that
+	// fallback instead of being dropped as an Ignore, otherwise the diff engine
+	// emits a spurious DROP FUNCTION for a function that is in the desired schema.
+	statements, err := postgresParser.Parse(`
+    CREATE TABLE t (id int) WITH (fillfactor = 70);
+    CREATE FUNCTION increment(i integer) RETURNS integer
+    LANGUAGE plpgsql
+    AS $$
+      BEGIN
+        RETURN i + 1;
+      END;
+    $$;
+	`)
+	if err != nil {
+		t.Fatalf("failed to parse: %v", err)
+	}
+
+	var foundFunction bool
+	for _, stmt := range statements {
+		if _, ok := stmt.Statement.(*parser.Ignore); ok {
+			t.Errorf("statement was dropped as Ignore: %q", stmt.DDL)
+		}
+		if ddl, ok := stmt.Statement.(*parser.DDL); ok && ddl.Action == parser.CreateFunction {
+			foundFunction = true
+		}
+	}
+	if !foundFunction {
+		t.Error("CREATE FUNCTION was not preserved across pgquery fallback in Auto mode")
+	}
+}
+
 func TestCreatePolicyWithPgquery(t *testing.T) {
 	t.Setenv("PSQLDEF_PARSER", "pgquery")
 


### PR DESCRIPTION
## Why

In auto mode (the default `PSQLDEF_PARSER` setting), the generic parser is
tried first on the whole desired schema, and on failure psqldef falls back to
pgquery. During that fallback, pgquery returns `parser.Ignore` for every
`CREATE FUNCTION` statement (`database/postgres/parser.go`, introduced in
#1116), and `Ignore` is treated as a successful parse.

Because `Ignore` is not an error, it bypasses the existing per-statement
generic-parser retry that only fires on `error` returns. The function is
therefore silently dropped from the **desired** schema, while the **current**
schema (introspected from the database via `pg_get_functiondef()`) still
contains it. The diff engine then sees a function that exists in current but
not in desired and emits a spurious `DROP FUNCTION`. With `--enable-drop` this
destroys user-defined functions, or fails on dependency errors and rolls back
the whole migration:

```
DROP FUNCTION "public"."set_updated_at";
pq: cannot drop function set_updated_at() because other objects depend on it (2BP01)
ROLLBACK;
```

Any DDL the generic parser cannot handle (e.g. a table storage parameter,
`INHERITS`, certain `CREATE POLICY` expressions) triggers the whole-file
fallback and reproduces this.

## What

Extend the existing auto-mode, per-statement retry so it also fires when
pgquery returns `Ignore`: retry that single statement with the generic parser
(which does support `CREATE FUNCTION`) and use its result. If the generic
parser also fails, the `Ignore` is kept unchanged.

This is the same fallback strategy already used for `parseStmt` errors a few
lines above — it just extends the trigger from `error` to `Ignore`, rather than
adding a special case. `PSQLDEF_PARSER=pgquery` (pgquery-only) mode is
intentionally excluded, so the behavior added in #1116 and
`TestCreateFunctionWithPgquery` are preserved.

| Mode | pgquery returns | Behavior |
|---|---|---|
| Auto | `Ignore` | **Retry with generic parser; keep `Ignore` on failure (new)** |
| Pgquery-only | `Ignore` | Keep `Ignore` (unchanged, #1116 intent) |
| Auto/Pgquery-only | `error` / concrete AST | unchanged |

## Tests

Added `TestCreateFunctionAutoModeFallbackRetry` in
`database/postgres/parser_test.go`. It forces auto mode (CI and local
development run psqldef with `PSQLDEF_PARSER=generic`), feeds a fallback-
triggering table plus a `CREATE FUNCTION`, and asserts the function survives as
a real DDL rather than an `Ignore`.

A YAML end-to-end test was considered but is not viable: CI runs psqldef with
`PSQLDEF_PARSER=generic` (generic-only, no fallback), and there is no per-test
parser-mode selector, so a YAML case containing a fallback-triggering statement
would error out under generic-only mode. The parser-level test is the only way
to exercise the fallback path in CI.
