### PR TITLE
Fix pgquery multi-arg bool expressions

### DIFF
--- a/database/postgres/parser.go
+++ b/database/postgres/parser.go
@@ -569,36 +569,40 @@ func (p PostgresParser) parseExpr(stmt *pgquery.Node) (parser.Expr, error) {
 			return nil, fmt.Errorf("unknown AConst val type in parseExpr: %#v", cNode)
 		}
 	case *pgquery.Node_BoolExpr:
-		arg1, err := p.parseExpr(node.BoolExpr.Args[0])
+		expr, err := p.parseExpr(node.BoolExpr.Args[0])
 		if err != nil {
 			return nil, err
 		}
 
 		if node.BoolExpr.Boolop == pgquery.BoolExprType_NOT_EXPR {
 			return &parser.NotExpr{
-				Expr: arg1,
+				Expr: expr,
 			}, nil
 		}
 
-		arg2, err := p.parseExpr(node.BoolExpr.Args[1])
-		if err != nil {
-			return nil, err
+		for _, arg := range node.BoolExpr.Args[1:] {
+			right, err := p.parseExpr(arg)
+			if err != nil {
+				return nil, err
+			}
+
+			switch node.BoolExpr.Boolop {
+			case pgquery.BoolExprType_AND_EXPR:
+				expr = &parser.AndExpr{
+					Left:  expr,
+					Right: right,
+				}
+			case pgquery.BoolExprType_OR_EXPR:
+				expr = &parser.OrExpr{
+					Left:  expr,
+					Right: right,
+				}
+			default:
+				return nil, fmt.Errorf("unexpected boolop: %d", node.BoolExpr.Boolop)
+			}
 		}
 
-		switch node.BoolExpr.Boolop {
-		case pgquery.BoolExprType_AND_EXPR:
-			return &parser.AndExpr{
-				Left:  arg1,
-				Right: arg2,
-			}, nil
-		case pgquery.BoolExprType_OR_EXPR:
-			return &parser.OrExpr{
-				Left:  arg1,
-				Right: arg2,
-			}, nil
-		default:
-			return nil, fmt.Errorf("unexpected boolop: %d", node.BoolExpr.Boolop)
-		}
+		return expr, nil
 	case *pgquery.Node_CaseExpr:
 		caseStmt := stmt.GetCaseExpr()
 

--- a/database/postgres/parser_test.go
+++ b/database/postgres/parser_test.go
@@ -182,6 +182,36 @@ func TestCreateFunctionAutoModeFallbackRetry(t *testing.T) {
 	}
 }
 
+func TestParseCheckConstraintMultiArgBoolExprWithPgquery(t *testing.T) {
+	t.Setenv("PSQLDEF_PARSER", "pgquery")
+	postgresParser := NewParserWithMode(PsqldefParserModePgquery)
+
+	statements, err := postgresParser.Parse(`
+CREATE TABLE test (
+  status text NOT NULL,
+  quantity integer,
+  price integer,
+  CONSTRAINT chk CHECK (
+    (status = 'active' AND quantity > 0 AND price IS NOT NULL) OR
+    (status = 'archived' AND quantity = 0 AND price IS NULL) OR
+    (status = 'deleted' AND quantity IS NULL AND price IS NULL)
+  )
+);
+`)
+	require.NoError(t, err)
+	require.Len(t, statements, 1)
+
+	ddl, ok := statements[0].Statement.(*parser.DDL)
+	require.True(t, ok)
+	require.Len(t, ddl.TableSpec.Checks, 1)
+
+	checkExpr := parser.String(ddl.TableSpec.Checks[0].Where.Expr)
+	expected := "status = 'active' and quantity > 0 and price is not null" +
+		" or status = 'archived' and quantity = 0 and price is null" +
+		" or status = 'deleted' and quantity is null and price is null"
+	assert.Equal(t, expected, checkExpr)
+}
+
 func TestCreatePolicyWithPgquery(t *testing.T) {
 	t.Setenv("PSQLDEF_PARSER", "pgquery")
 


### PR DESCRIPTION
## What changed

- Fold all `pgquery` `BoolExpr.Args` into sqldef's binary `AndExpr` / `OrExpr` AST nodes.
- Add a regression test for a `CHECK` constraint with three `OR` branches.

## Why

`pg_query_go` represents chained boolean expressions such as `a OR b OR c` as a single `BoolExpr` with multiple `Args`. The pgquery parser path previously converted only the first two args, which dropped later predicates from parsed expressions.

This could lose parts of `CHECK` constraints when sqldef falls back to the pgquery parser.

## Validation

```sh
GOCACHE=/tmp/sqldef-gocache go test ./database/postgres -run '^TestParse'
```
