### PR TITLE
psqldef: support unnamed EXCLUDE constraints end-to-end (match by definition)

### DIFF
--- a/cmd/psqldef/tests_constraints.yml
+++ b/cmd/psqldef/tests_constraints.yml
@@ -727,6 +727,29 @@ ExcludeConstraintMultiple:
       CONSTRAINT ex2 EXCLUDE USING gist (event_start WITH &&, event_end WITH &&)
     );
 
+# Unnamed exclusion: PostgreSQL auto-generates the constraint name, so on
+# re-export it must be matched by definition rather than perpetually dropped and
+# re-added. Idempotency-only verifies there is no drift/churn.
+ExcludeConstraintUnnamedInline:
+  legacy_ignore_quotes: false
+  desired: |
+    CREATE TABLE exclude_example (
+      name varchar(255),
+      event_start tstzrange NOT NULL,
+      event_end tstzrange NOT NULL,
+      EXCLUDE USING gist (event_start WITH &&, event_end WITH &&)
+    );
+
+ExcludeConstraintUnnamedViaAlter:
+  legacy_ignore_quotes: false
+  desired: |
+    CREATE TABLE exclude_example (
+      name varchar(255),
+      event_start tstzrange NOT NULL,
+      event_end tstzrange NOT NULL
+    );
+    ALTER TABLE exclude_example ADD EXCLUDE USING gist (event_start WITH &&, event_end WITH &&);
+
 ConstraintCheckInWithUniqueCreate:
   current: |
     CREATE TABLE users (

--- a/cmd/psqldef/tests_constraints.yml
+++ b/cmd/psqldef/tests_constraints.yml
@@ -727,9 +727,6 @@ ExcludeConstraintMultiple:
       CONSTRAINT ex2 EXCLUDE USING gist (event_start WITH &&, event_end WITH &&)
     );
 
-# Unnamed exclusion: PostgreSQL auto-generates the constraint name, so on
-# re-export it must be matched by definition rather than perpetually dropped and
-# re-added. Idempotency-only verifies there is no drift/churn.
 ExcludeConstraintUnnamedInline:
   legacy_ignore_quotes: false
   desired: |
@@ -749,6 +746,25 @@ ExcludeConstraintUnnamedViaAlter:
       event_end tstzrange NOT NULL
     );
     ALTER TABLE exclude_example ADD EXCLUDE USING gist (event_start WITH &&, event_end WITH &&);
+
+ExcludeConstraintRenameSameDefinition:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TABLE exclude_example (
+      event_start tstzrange NOT NULL,
+      CONSTRAINT ex1 EXCLUDE USING gist (event_start WITH &&)
+    );
+  desired: |
+    CREATE TABLE exclude_example (
+      event_start tstzrange NOT NULL,
+      CONSTRAINT ex2 EXCLUDE USING gist (event_start WITH &&)
+    );
+  up: |
+    ALTER TABLE public.exclude_example ADD CONSTRAINT ex2 EXCLUDE USING gist (event_start WITH &&);
+    ALTER TABLE public.exclude_example DROP CONSTRAINT ex1;
+  down: |
+    ALTER TABLE public.exclude_example ADD CONSTRAINT ex1 EXCLUDE USING gist (event_start WITH &&);
+    ALTER TABLE public.exclude_example DROP CONSTRAINT ex2;
 
 ConstraintCheckInWithUniqueCreate:
   current: |

--- a/schema/ast.go
+++ b/schema/ast.go
@@ -328,7 +328,7 @@ type Exclusion struct {
 }
 
 type ExclusionPair struct {
-	expression string
+	expression parser.Expr
 	operator   string
 }
 

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -490,6 +490,12 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 				continue // Exclusion constraint is expected to exist.
 			}
 
+			// Also match by definition: an unnamed desired exclusion is realized in
+			// the DB under a server-generated name, so it must not be dropped here.
+			if g.findExclusionByDefinition(desiredTable.exclusions, exclusion) != nil {
+				continue
+			}
+
 			ddls = append(ddls, fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s", g.escapeTableName(currentTable), g.escapeSQLIdent(exclusion.constraintName)))
 		}
 
@@ -1639,27 +1645,29 @@ func (g *Generator) generateDDLsForCreateTable(currentTable Table, desired Creat
 
 	// Examine each exclusion
 	for _, desiredExclusion := range desired.table.exclusions {
-		if desiredExclusion.constraintName.IsEmpty() && g.mode != GeneratorModeSQLite3 {
-			return ddls, fmt.Errorf(
-				"Exclusion without constraint symbol was found in table '%s'. "+
-					"Specify the constraint symbol to identify the exclusion.",
-				desired.table.name.RawString(),
-			)
+		// Named exclusions match by name; unnamed ones match by definition because
+		// PostgreSQL auto-generates a name for them, so matching by the (empty) name
+		// would never find the server-named one and cause a perpetual drop/add.
+		var currentExclusion *Exclusion
+		if desiredExclusion.constraintName.IsEmpty() {
+			if g.mode == GeneratorModePostgres {
+				currentExclusion = g.findExclusionByDefinition(currentTable.exclusions, desiredExclusion)
+			}
+		} else {
+			currentExclusion = g.findExclusionByName(currentTable.exclusions, desiredExclusion.constraintName)
 		}
 
-		if currentExclusion := g.findExclusionByName(currentTable.exclusions, desiredExclusion.constraintName); currentExclusion != nil {
-			// Drop and add exclusion as needed.
+		if currentExclusion != nil {
+			// Drop and re-add when the definition differs. A differing name alone
+			// (e.g. server-generated) is not a change.
 			if !g.areSameExclusions(*currentExclusion, desiredExclusion) {
-				dropDDL := fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s", g.escapeTableName(&desired.table), g.escapeSQLIdent(currentExclusion.constraintName))
-				if dropDDL != "" {
-					ddls = append(ddls, dropDDL, fmt.Sprintf("ALTER TABLE %s ADD %s", g.escapeTableName(&desired.table), g.generateExclusionDefinition(desiredExclusion)))
-				}
+				ddls = append(ddls,
+					fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s", g.escapeTableName(&desired.table), g.escapeSQLIdent(currentExclusion.constraintName)),
+					fmt.Sprintf("ALTER TABLE %s ADD %s", g.escapeTableName(&desired.table), g.generateExclusionDefinition(desiredExclusion)))
 			}
 		} else {
 			// Exclusion not found, add exclusion.
-			definition := g.generateExclusionDefinition(desiredExclusion)
-			ddl := fmt.Sprintf("ALTER TABLE %s ADD %s", g.escapeTableName(&desired.table), definition)
-			ddls = append(ddls, ddl)
+			ddls = append(ddls, fmt.Sprintf("ALTER TABLE %s ADD %s", g.escapeTableName(&desired.table), g.generateExclusionDefinition(desiredExclusion)))
 		}
 	}
 
@@ -1992,6 +2000,11 @@ func (g *Generator) generateDDLsForAddExclusion(tableName QualifiedName, desired
 
 	currentTable := g.findTableByName(g.currentTables, tableName)
 	currentExclusion := g.findExclusionByName(currentTable.exclusions, desiredExclusion.constraintName)
+	// PostgreSQL auto-generates a name for an unnamed exclusion, so match the
+	// desired unnamed exclusion against the server-named one by definition.
+	if currentExclusion == nil && g.mode == GeneratorModePostgres && desiredExclusion.constraintName.IsEmpty() {
+		currentExclusion = g.findExclusionByDefinition(currentTable.exclusions, desiredExclusion)
+	}
 	if currentExclusion == nil {
 		// Exclusion not found, add exclusion
 		ddls = append(ddls, statement)
@@ -3381,14 +3394,16 @@ func (g *Generator) generateForeignKeyDefinition(foreignKey ForeignKey) string {
 func (g *Generator) generateExclusionDefinition(exclusion Exclusion) string {
 	var ex []string
 	for _, exclusionPair := range exclusion.exclusions {
-		ex = append(ex, fmt.Sprintf("%s WITH %s", exclusionPair.expression, exclusionPair.operator))
+		ex = append(ex, fmt.Sprintf("%s WITH %s", parser.String(exclusionPair.expression), exclusionPair.operator))
 	}
-	definition := fmt.Sprintf(
-		"CONSTRAINT %s EXCLUDE USING %s (%s)",
-		g.escapeSQLIdent(exclusion.constraintName),
-		exclusion.indexType,
-		strings.Join(ex, ", "),
-	)
+	// PostgreSQL auto-generates the constraint name when none is given, so emit
+	// the unnamed form rather than an empty CONSTRAINT clause.
+	var definition string
+	if exclusion.constraintName.IsEmpty() {
+		definition = fmt.Sprintf("EXCLUDE USING %s (%s)", exclusion.indexType, strings.Join(ex, ", "))
+	} else {
+		definition = fmt.Sprintf("CONSTRAINT %s EXCLUDE USING %s (%s)", g.escapeSQLIdent(exclusion.constraintName), exclusion.indexType, strings.Join(ex, ", "))
+	}
 	if exclusion.where != nil {
 		definition += fmt.Sprintf(" WHERE (%s)", parser.String(exclusion.where))
 	}
@@ -5589,11 +5604,24 @@ func (g *Generator) areSameExclusions(exclusionA Exclusion, exclusionB Exclusion
 	for i := range exclusionA.exclusions {
 		a := exclusionA.exclusions[i]
 		b := exclusionB.exclusions[i]
-		if a.expression != b.expression || a.operator != b.operator {
+		if a.operator != b.operator || !g.areSameExprs(a.expression, b.expression) {
 			return false
 		}
 	}
 	return true
+}
+
+// findExclusionByDefinition returns the first exclusion in the list whose
+// definition matches the target, ignoring the constraint name. PostgreSQL
+// auto-generates names for unnamed exclusions, so the desired (unnamed)
+// exclusion must be matched against the server-named one by content.
+func (g *Generator) findExclusionByDefinition(exclusions []Exclusion, target Exclusion) *Exclusion {
+	for i := range exclusions {
+		if g.areSameExclusions(exclusions[i], target) {
+			return &exclusions[i]
+		}
+	}
+	return nil
 }
 
 func (g *Generator) areSameExprs(exprA, exprB parser.Expr) bool {

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -490,9 +490,8 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 				continue // Exclusion constraint is expected to exist.
 			}
 
-			// Also match by definition: an unnamed desired exclusion is realized in
-			// the DB under a server-generated name, so it must not be dropped here.
-			if g.findExclusionByDefinition(desiredTable.exclusions, exclusion) != nil {
+			// An unnamed desired exclusion lives in the DB under a server-generated name; not obsolete.
+			if g.findUnnamedExclusionByDefinition(desiredTable.exclusions, exclusion) != nil {
 				continue
 			}
 
@@ -1645,9 +1644,7 @@ func (g *Generator) generateDDLsForCreateTable(currentTable Table, desired Creat
 
 	// Examine each exclusion
 	for _, desiredExclusion := range desired.table.exclusions {
-		// Named exclusions match by name; unnamed ones match by definition because
-		// PostgreSQL auto-generates a name for them, so matching by the (empty) name
-		// would never find the server-named one and cause a perpetual drop/add.
+		// Unnamed exclusions match by definition (PostgreSQL auto-names them); named ones by name.
 		var currentExclusion *Exclusion
 		if desiredExclusion.constraintName.IsEmpty() {
 			if g.mode == GeneratorModePostgres {
@@ -1658,8 +1655,6 @@ func (g *Generator) generateDDLsForCreateTable(currentTable Table, desired Creat
 		}
 
 		if currentExclusion != nil {
-			// Drop and re-add when the definition differs. A differing name alone
-			// (e.g. server-generated) is not a change.
 			if !g.areSameExclusions(*currentExclusion, desiredExclusion) {
 				ddls = append(ddls,
 					fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s", g.escapeTableName(&desired.table), g.escapeSQLIdent(currentExclusion.constraintName)),
@@ -2000,8 +1995,7 @@ func (g *Generator) generateDDLsForAddExclusion(tableName QualifiedName, desired
 
 	currentTable := g.findTableByName(g.currentTables, tableName)
 	currentExclusion := g.findExclusionByName(currentTable.exclusions, desiredExclusion.constraintName)
-	// PostgreSQL auto-generates a name for an unnamed exclusion, so match the
-	// desired unnamed exclusion against the server-named one by definition.
+	// Unnamed exclusion: match the server-named one by definition.
 	if currentExclusion == nil && g.mode == GeneratorModePostgres && desiredExclusion.constraintName.IsEmpty() {
 		currentExclusion = g.findExclusionByDefinition(currentTable.exclusions, desiredExclusion)
 	}
@@ -3396,8 +3390,7 @@ func (g *Generator) generateExclusionDefinition(exclusion Exclusion) string {
 	for _, exclusionPair := range exclusion.exclusions {
 		ex = append(ex, fmt.Sprintf("%s WITH %s", parser.String(exclusionPair.expression), exclusionPair.operator))
 	}
-	// PostgreSQL auto-generates the constraint name when none is given, so emit
-	// the unnamed form rather than an empty CONSTRAINT clause.
+	// Unnamed: let PostgreSQL generate the name.
 	var definition string
 	if exclusion.constraintName.IsEmpty() {
 		definition = fmt.Sprintf("EXCLUDE USING %s (%s)", exclusion.indexType, strings.Join(ex, ", "))
@@ -5508,28 +5501,25 @@ func (g *Generator) formatIndexExprForComparison(expr parser.Expr) string {
 }
 
 func (g *Generator) areSameWhereClause(whereA, whereB parser.Expr) bool {
-	// Both nil
-	if whereA == nil && whereB == nil {
+	return g.sameNormalizedExpr(whereA, whereB)
+}
+
+// sameNormalizedExpr compares two expressions after normalization, case-sensitively and quote-aware.
+func (g *Generator) sameNormalizedExpr(a, b parser.Expr) bool {
+	if a == nil && b == nil {
 		return true
 	}
-	// One is nil and the other is not
-	if whereA == nil || whereB == nil {
+	if a == nil || b == nil {
 		return false
 	}
 
-	normalizedA := normalizeExpr(whereA, g.mode)
-	normalizedB := normalizeExpr(whereB, g.mode)
+	normalizedA := normalizeExpr(a, g.mode)
+	normalizedB := normalizeExpr(b, g.mode)
 
-	var strA, strB string
 	if !g.config.LegacyIgnoreQuotes {
-		strA = g.formatExprQuoteAware(normalizedA)
-		strB = g.formatExprQuoteAware(normalizedB)
-	} else {
-		strA = parser.String(normalizedA)
-		strB = parser.String(normalizedB)
+		return g.formatExprQuoteAware(normalizedA) == g.formatExprQuoteAware(normalizedB)
 	}
-
-	return strA == strB
+	return parser.String(normalizedA) == parser.String(normalizedB)
 }
 
 func (g *Generator) areSameForeignKeys(foreignKeyA ForeignKey, foreignKeyB ForeignKey) bool {
@@ -5604,20 +5594,27 @@ func (g *Generator) areSameExclusions(exclusionA Exclusion, exclusionB Exclusion
 	for i := range exclusionA.exclusions {
 		a := exclusionA.exclusions[i]
 		b := exclusionB.exclusions[i]
-		if a.operator != b.operator || !g.areSameExprs(a.expression, b.expression) {
+		if a.operator != b.operator || !g.sameNormalizedExpr(a.expression, b.expression) {
 			return false
 		}
 	}
 	return true
 }
 
-// findExclusionByDefinition returns the first exclusion in the list whose
-// definition matches the target, ignoring the constraint name. PostgreSQL
-// auto-generates names for unnamed exclusions, so the desired (unnamed)
-// exclusion must be matched against the server-named one by content.
+// findExclusionByDefinition returns the first exclusion matching the target by definition, ignoring its name.
 func (g *Generator) findExclusionByDefinition(exclusions []Exclusion, target Exclusion) *Exclusion {
 	for i := range exclusions {
 		if g.areSameExclusions(exclusions[i], target) {
+			return &exclusions[i]
+		}
+	}
+	return nil
+}
+
+// findUnnamedExclusionByDefinition is like findExclusionByDefinition but skips named exclusions, so a named rename still drops the old one.
+func (g *Generator) findUnnamedExclusionByDefinition(exclusions []Exclusion, target Exclusion) *Exclusion {
+	for i := range exclusions {
+		if exclusions[i].constraintName.IsEmpty() && g.areSameExclusions(exclusions[i], target) {
 			return &exclusions[i]
 		}
 	}

--- a/schema/parser.go
+++ b/schema/parser.go
@@ -979,7 +979,7 @@ func parseExclusion(exclusion *parser.ExclusionDefinition) Exclusion {
 	var exs []ExclusionPair
 	for _, exclusion := range exclusion.Exclusions {
 		exs = append(exs, ExclusionPair{
-			expression: parser.String(exclusion.Expression),
+			expression: exclusion.Expression,
 			operator:   exclusion.Operator,
 		})
 	}


### PR DESCRIPTION
## Summary

Follow-up to #1254. The generic parser now accepts unnamed EXCLUDE constraints, but the generator still **errored** on them (`Exclusion without constraint symbol was found in table ...`). PostgreSQL auto-generates a name for an unnamed exclusion server-side, so a desired unnamed `EXCLUDE (...)` could never be reconciled with the server-named constraint on re-export — it would perpetually drop and re-add (drift & churn).

This makes unnamed exclusions work end-to-end by **matching them by definition**, exactly as CHECK constraints already handle PostgreSQL's auto-naming (introduced in #1026).

## Changes

- `schema/generator.go`:
  - **Add path**: a named exclusion matches by name; an unnamed one (PostgreSQL) matches the server-named constraint by definition. The old "specify a constraint symbol" error is removed.
  - **Drop path**: an obsolete current exclusion is kept if it matches a desired exclusion by definition (so an unnamed desired exclusion realized under a server-generated name is not dropped).
  - `generateExclusionDefinition` emits the unnamed `EXCLUDE ...` form (no empty `CONSTRAINT`) when there is no name, letting the server name it.
  - New `findExclusionByDefinition` helper.
  - `areSameExclusions` compares the element expression **normalized** (via `areSameExprs`) instead of as a raw string, so spelling differences between the desired SQL and the server read-back (casts, parens, case) don't cause spurious churn.
- `schema/ast.go` / `schema/parser.go`: store the exclusion element expression as an AST node (`parser.Expr`) rather than a pre-rendered string, enabling normalized comparison.
- `cmd/psqldef/tests_constraints.yml`: idempotency tests for unnamed EXCLUDE, inline and via `ALTER TABLE ADD` — these assert no drift/churn on re-export.

## Verification

- `make build`, `make format`, `make lint` clean.
- `go test ./schema` and `go test ./cmd/psqldef` (full suite, `PSQLDEF_PARSER=generic`) pass.

## Why match by definition (not require a name)

The previous error wasn't a deliberate exclusion-specific design choice: the exclusion generator (Jan 2025) predates the definition-matching pattern that CHECK constraints later adopted (#1026, Dec 2025); exclusions were simply never updated. Requiring a name on a constraint that PostgreSQL itself auto-names is the bug this fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)