### PR TITLE
fix(mysqldef): wrap functional key parts in ADD/CREATE INDEX emit (1064)

### DIFF
--- a/cmd/mysqldef/tests_tables.yml
+++ b/cmd/mysqldef/tests_tables.yml
@@ -854,7 +854,7 @@ AddFunctionalIndexIf:
   # parentheses, just like the CREATE TABLE path does. Without the wrap,
   # `ALTER TABLE ... ADD UNIQUE KEY (col, if(...))` is rejected by MySQL with
   # error 1064 because a bare function expression is not a valid key part.
-  flavor: "!mariadb"
+  flavor: mysql  # TiDB blocks `if`/`case` in expression indexes without allow-expression-index; MariaDB has no functional indexes
   min_version: '8.0'
   current: |
     CREATE TABLE `t1` (
@@ -879,7 +879,7 @@ AddFunctionalIndexIf:
     ALTER TABLE `t1` DROP INDEX `uniq_active`;
 AddFunctionalIndexCase:
   # Same regression as AddFunctionalIndexIf, covering the CASE expression form.
-  flavor: "!mariadb"
+  flavor: mysql  # TiDB blocks `if`/`case` in expression indexes without allow-expression-index; MariaDB has no functional indexes
   min_version: '8.0'
   current: |
     CREATE TABLE `t1` (

--- a/cmd/mysqldef/tests_tables.yml
+++ b/cmd/mysqldef/tests_tables.yml
@@ -879,7 +879,7 @@ AddFunctionalIndexIf:
     ALTER TABLE `t1` DROP INDEX `uniq_active`;
 AddFunctionalIndexCase:
   # Same regression as AddFunctionalIndexIf, covering the CASE expression form.
-  flavor: mysql  # TiDB blocks `if`/`case` in expression indexes without allow-expression-index; MariaDB has no functional indexes
+  flavor: "!mariadb"  # MariaDB has no functional indexes; TiDB allows CASE in expression indexes
   min_version: '8.0'
   current: |
     CREATE TABLE `t1` (

--- a/cmd/mysqldef/tests_tables.yml
+++ b/cmd/mysqldef/tests_tables.yml
@@ -849,6 +849,59 @@ CreateTableWithFunctionalIndex:
     );
   down: |
     DROP TABLE `app_badge_tag`;
+AddFunctionalIndexIf:
+  # Regression: the ALTER path must wrap functional key parts in their own
+  # parentheses, just like the CREATE TABLE path does. Without the wrap,
+  # `ALTER TABLE ... ADD UNIQUE KEY (col, if(...))` is rejected by MySQL with
+  # error 1064 because a bare function expression is not a valid key part.
+  flavor: "!mariadb"
+  min_version: '8.0'
+  current: |
+    CREATE TABLE `t1` (
+    `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+    `group_id` bigint unsigned NOT NULL,
+    `name` varchar(60) NOT NULL DEFAULT '',
+    `deleted` tinyint NOT NULL DEFAULT '0',
+    PRIMARY KEY (`id`)
+    );
+  desired: |
+    CREATE TABLE `t1` (
+    `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+    `group_id` bigint unsigned NOT NULL,
+    `name` varchar(60) NOT NULL DEFAULT '',
+    `deleted` tinyint NOT NULL DEFAULT '0',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uniq_active` (`group_id`,(if((`deleted` = 0),`name`,NULL)))
+    );
+  up: |
+    ALTER TABLE `t1` ADD UNIQUE KEY `uniq_active` (`group_id`, (if((deleted = 0), name, null)));
+  down: |
+    ALTER TABLE `t1` DROP INDEX `uniq_active`;
+AddFunctionalIndexCase:
+  # Same regression as AddFunctionalIndexIf, covering the CASE expression form.
+  flavor: "!mariadb"
+  min_version: '8.0'
+  current: |
+    CREATE TABLE `t1` (
+    `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+    `group_id` bigint unsigned NOT NULL,
+    `name` varchar(60) NOT NULL DEFAULT '',
+    `deleted` tinyint NOT NULL DEFAULT '0',
+    PRIMARY KEY (`id`)
+    );
+  desired: |
+    CREATE TABLE `t1` (
+    `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+    `group_id` bigint unsigned NOT NULL,
+    `name` varchar(60) NOT NULL DEFAULT '',
+    `deleted` tinyint NOT NULL DEFAULT '0',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uniq_active` (`group_id`,((case when (`deleted` = 0) then `name` else NULL end)))
+    );
+  up: |
+    ALTER TABLE `t1` ADD UNIQUE KEY `uniq_active` (`group_id`, (case when (deleted = 0) then name else null end));
+  down: |
+    ALTER TABLE `t1` DROP INDEX `uniq_active`;
 AlterColumnSetDefault:
   current: |
     CREATE TABLE users (

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -3029,6 +3029,24 @@ func indexExprNeedsParens(expr parser.Expr) bool {
 	}
 }
 
+// indexKeyPartNeedsParens reports whether an index key-part expression needs
+// its own wrapping parentheses for the current generator mode. MySQL is
+// stricter than PostgreSQL: any functional key part (anything that isn't a
+// bare column reference, including `if(...)` / `case ... end`) MUST be
+// wrapped, otherwise MySQL rejects the DDL with error 1064
+// (https://dev.mysql.com/doc/refman/8.0/en/create-index.html). For the other
+// modes, fall back to the PostgreSQL-flavored helper.
+func (g *Generator) indexKeyPartNeedsParens(expr parser.Expr) bool {
+	if g.mode == GeneratorModeMysql {
+		if _, alreadyWrapped := expr.(*parser.ParenExpr); alreadyWrapped {
+			return false
+		}
+		_, isCol := expr.(*parser.ColName)
+		return !isCol
+	}
+	return indexExprNeedsParens(expr)
+}
+
 // generateCreateIndexStatement generates a CREATE INDEX statement from an Index struct.
 // This is used to regenerate CREATE INDEX statements with proper schema-qualified table names.
 func (g *Generator) generateCreateIndexStatement(table QualifiedName, index Index) string {
@@ -3047,7 +3065,7 @@ func (g *Generator) generateCreateIndexStatement(table QualifiedName, index Inde
 				// Legacy mode: use parser.String for backward compatibility
 				column = parser.String(indexColumn.columnExpr)
 			}
-			if indexExprNeedsParens(indexColumn.columnExpr) {
+			if g.indexKeyPartNeedsParens(indexColumn.columnExpr) {
 				column = "(" + column + ")"
 			}
 		}
@@ -3147,6 +3165,9 @@ func (g *Generator) generateAddIndex(table QualifiedName, index Index) string {
 			} else {
 				// Legacy mode: use parser.String for backward compatibility
 				column = parser.String(indexColumn.columnExpr)
+			}
+			if g.indexKeyPartNeedsParens(indexColumn.columnExpr) {
+				column = "(" + column + ")"
 			}
 		}
 		if indexColumn.length != nil {


### PR DESCRIPTION
## Problem

mysqldef generates invalid DDL when adding a functional index via ALTER. Given a schema like:

```sql
UNIQUE KEY `uniq_active` (`group_id`, (if((`deleted` = 0), `name`, NULL)))
```

mysqldef emits:

```sql
ALTER TABLE `t1` ADD UNIQUE KEY `uniq_active` (`group_id`, if((deleted = 0), name, null));
                                                              ^ outer parens dropped → ERROR 1064
```

MySQL requires every functional key part to be wrapped in its own parentheses (the same wrap that `generateCreateIndexStatement` emits for general expressions). Two issues compound:

1. `generateAddIndex` is missing the wrap call entirely.
2. The shared `indexExprNeedsParens` helper is PostgreSQL-flavored and exempts `*parser.FuncExpr` / `*parser.FuncCallExpr` — so `if(...)` slips through even where the wrap call exists.

Reproducible on 3.11.0 through 3.11.11. Same failure mode for `case ... end`.

## Fix

Introduce `(*Generator).indexKeyPartNeedsParens` that returns true for any non-column, non-already-wrapped expression when the mode is `GeneratorModeMysql`, and falls back to the existing PG helper otherwise. Route both `generateCreateIndexStatement` and `generateAddIndex` through it. No PostgreSQL behavior change.

## Tests

Two new YAML regression cases in `cmd/mysqldef/tests_tables.yml`:

- `AddFunctionalIndexIf` — covers `if((deleted = 0), name, NULL)`
- `AddFunctionalIndexCase` — covers `case when (deleted = 0) then name else NULL end`

Both apply, round-trip via `SHOW CREATE TABLE`, and re-dry-run reports `-- Nothing is modified --`. Full `./cmd/mysqldef` and `./cmd/sqlite3def` test suites pass.

## References

- https://dev.mysql.com/doc/refman/8.0/en/create-index.html — "Each functional key part is wrapped in parentheses."