### PR TITLE
psqldef: escape embedded double quotes when quoting identifiers

### DIFF
--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -1040,7 +1040,7 @@ func postgresBuildDSN(config database.Config) string {
 }
 
 func forceQuoteIdentifier(name string) string {
-	return fmt.Sprintf("\"%s\"", name)
+	return fmt.Sprintf("\"%s\"", strings.ReplaceAll(name, "\"", "\"\""))
 }
 
 // quoteIdent quotes a constraint name for DDL output.

--- a/database/postgres/quoting_test.go
+++ b/database/postgres/quoting_test.go
@@ -1,0 +1,27 @@
+package postgres
+
+import "testing"
+
+// A double-quoted PostgreSQL identifier escapes an embedded double quote by
+// doubling it, so forceQuoteIdentifier must do the same. The scanner already
+// collapses "" back to a single " when it reads a quoted identifier, which means
+// a name such as a"b reaches DDL output with a raw " in it. Re-emitting that
+// without doubling terminates the identifier early and produces invalid SQL.
+func TestForceQuoteIdentifierEscapesDoubleQuote(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "plain", `"plain"`},
+		{"embedded double quote", `a"b`, `"a""b"`},
+		{"only a double quote", `"`, `""""`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := forceQuoteIdentifier(tc.in); got != tc.want {
+				t.Errorf("forceQuoteIdentifier(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`forceQuoteIdentifier` wraps a name in double quotes but does not double a double quote that appears inside the name:

```go
func forceQuoteIdentifier(name string) string {
	return fmt.Sprintf("\"%s\"", name)
}
```

So a PostgreSQL identifier such as `a"b` is emitted as `"a"b"`, which is invalid: the embedded quote closes the identifier early. The scanner already collapses `""` back to a single `"` when it reads a quoted identifier (`scanLiteralIdentifier`), so a name with a literal `"` does reach this path, both from a desired schema written as `"a""b"` and from an existing object read back during export.

Every other place that quotes a delimited string here doubles its terminator: `StringConstant` doubles `'`, and the SQL Server path (`forceQuoteName`) doubles `]`. The PostgreSQL identifier path was the one spot that skipped it. This makes it consistent:

```go
return fmt.Sprintf("\"%s\"", strings.ReplaceAll(name, "\"", "\"\""))
```

Added a unit test covering the plain, embedded-quote, and bare-quote cases.
