### PR TITLE
psqldef: handle || in policy expression cast stripping, add unit tests

### DIFF
--- a/schema/normalize.go
+++ b/schema/normalize.go
@@ -631,6 +631,8 @@ func stripFuncResultTextCasts(expr parser.Expr) parser.Expr {
 		return &parser.AndExpr{Left: stripFuncResultTextCasts(e.Left), Right: stripFuncResultTextCasts(e.Right)}
 	case *parser.OrExpr:
 		return &parser.OrExpr{Left: stripFuncResultTextCasts(e.Left), Right: stripFuncResultTextCasts(e.Right)}
+	case *parser.ConcatExpr:
+		return &parser.ConcatExpr{Left: stripFuncResultTextCasts(e.Left), Right: stripFuncResultTextCasts(e.Right)}
 	case *parser.ComparisonExpr:
 		return &parser.ComparisonExpr{
 			Operator: e.Operator,

--- a/schema/normalize_policy_test.go
+++ b/schema/normalize_policy_test.go
@@ -1,0 +1,182 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/sqldef/sqldef/v3/parser"
+)
+
+func extractPolicyUsingExpr(t *testing.T, exprSQL string) parser.Expr {
+	t.Helper()
+	sql := "CREATE POLICY p ON t USING (" + exprSQL + ")"
+	stmt, err := parser.ParseDDL(sql, parser.ParserModePostgres)
+	if err != nil {
+		t.Fatalf("ParseDDL(%q) failed: %v", sql, err)
+	}
+	ddl, ok := stmt.(*parser.DDL)
+	if !ok {
+		t.Fatalf("expected *parser.DDL, got %T", stmt)
+	}
+	if ddl.Policy == nil || ddl.Policy.Using == nil {
+		t.Fatalf("no USING expression found in %q", sql)
+	}
+	return ddl.Policy.Using.Expr
+}
+
+func TestStripFuncResultTextCasts(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "strips text cast on function result",
+			input: "current_setting('app.tenant_id', true)::text = tenant_id::text",
+			want:  "current_setting('app.tenant_id', true) = tenant_id::text",
+		},
+		{
+			name:  "strips text cast on parenthesized function result",
+			input: "(current_setting('app.tenant_id', true))::text = 'x'",
+			want:  "current_setting('app.tenant_id', true) = 'x'",
+		},
+		{
+			name:  "strips character varying cast on function result",
+			input: "current_user::character varying = 'x'",
+			want:  "current_user::character varying = 'x'", // current_user is a keyword, not a function call
+		},
+		{
+			name:  "strips character varying cast on function call",
+			input: "lower('X')::character varying = 'x'",
+			want:  "lower('X') = 'x'",
+		},
+		{
+			name:  "keeps non-text cast on function result",
+			input: "current_setting('app.tenant_id', true)::integer = 1",
+			want:  "current_setting('app.tenant_id', true)::integer = 1",
+		},
+		{
+			name:  "keeps text cast on column",
+			input: "tenant_id::text = 'x'",
+			want:  "tenant_id::text = 'x'",
+		},
+		{
+			name:  "keeps text cast on literal",
+			input: "'x'::text = name",
+			want:  "'x'::text = name",
+		},
+		{
+			name:  "strips inner text cast under outer non-text cast",
+			input: "lower('X')::text::integer = 1",
+			want:  "lower('X')::integer = 1",
+		},
+		{
+			name:  "recurses into NOT",
+			input: "NOT (lower('X')::text = 'x')",
+			want:  "NOT (lower('X') = 'x')",
+		},
+		{
+			name:  "recurses into AND and OR",
+			input: "lower('a')::text = 'a' AND (lower('b')::text = 'b' OR tenant_id = 1)",
+			want:  "lower('a') = 'a' AND (lower('b') = 'b' OR tenant_id = 1)",
+		},
+		{
+			name:  "recurses into string concatenation",
+			input: "lower('a')::text || 'x' = 'ax'",
+			want:  "lower('a') || 'x' = 'ax'",
+		},
+		{
+			name:  "recurses into binary operator",
+			input: "tenant_id + 1 = 2",
+			want:  "tenant_id + 1 = 2",
+		},
+		{
+			name:  "recurses into BETWEEN",
+			input: "name BETWEEN lower('a')::text AND lower('z')::text",
+			want:  "name BETWEEN lower('a') AND lower('z')",
+		},
+		{
+			name:  "recurses into IS NULL",
+			input: "current_setting('app.tenant_id', true)::text IS NULL",
+			want:  "current_setting('app.tenant_id', true) IS NULL",
+		},
+		{
+			name:  "recurses into function arguments",
+			input: "upper(lower('x')::text) = 'X'",
+			want:  "upper(lower('x')) = 'X'",
+		},
+		{
+			name:  "keeps other node types as-is",
+			input: "count(*) > 0",
+			want:  "count(*) > 0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := extractPolicyUsingExpr(t, tc.input)
+			want := extractPolicyUsingExpr(t, tc.want)
+
+			got := parser.String(stripFuncResultTextCasts(input))
+			if got != parser.String(want) {
+				t.Errorf("stripFuncResultTextCasts(%q) = %q, want %q", tc.input, got, parser.String(want))
+			}
+		})
+	}
+
+	t.Run("nil expression", func(t *testing.T) {
+		if got := stripFuncResultTextCasts(nil); got != nil {
+			t.Errorf("stripFuncResultTextCasts(nil) = %v, want nil", got)
+		}
+	})
+}
+
+func TestAreSamePolicyExprs(t *testing.T) {
+	g := &Generator{mode: GeneratorModePostgres}
+
+	testCases := []struct {
+		name  string
+		exprA string
+		exprB string
+		want  bool
+	}{
+		{
+			name:  "equal without stripping",
+			exprA: "tenant_id = 1",
+			exprB: "tenant_id = 1",
+			want:  true,
+		},
+		{
+			// PostgreSQL stores the left form for a policy written in the right form
+			name:  "equal after stripping text cast on function result",
+			exprA: "(tenant_id)::text = current_setting('app.tenant_id'::text, true)",
+			exprB: "tenant_id::text = current_setting('app.tenant_id', true)::text",
+			want:  true,
+		},
+		{
+			name:  "different expressions",
+			exprA: "tenant_id = 1",
+			exprB: "tenant_id = 2",
+			want:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			exprA := extractPolicyUsingExpr(t, tc.exprA)
+			exprB := extractPolicyUsingExpr(t, tc.exprB)
+
+			if got := g.areSamePolicyExprs(exprA, exprB); got != tc.want {
+				t.Errorf("areSamePolicyExprs(%q, %q) = %v, want %v", tc.exprA, tc.exprB, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("no cast stripping fallback for non-postgres mode", func(t *testing.T) {
+		mysqlG := &Generator{mode: GeneratorModeMysql}
+		exprA := extractPolicyUsingExpr(t, "lower('a')::text = 'a'")
+		exprB := extractPolicyUsingExpr(t, "lower('a') = 'a'")
+		if mysqlG.areSamePolicyExprs(exprA, exprB) {
+			t.Error("expected areSamePolicyExprs to be false for non-postgres mode")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Follow-up to #1271, prompted by the `codecov/patch` failure on its merge commit (71.42% of diff hit vs 71.45% target): `stripFuncResultTextCasts` recurses over expression node types, but only the comparison/function shapes were exercised by the integration tests.

Writing unit tests for the remaining branches revealed a **real gap**, not just missing coverage: string concatenation (`||`) parses as `ConcatExpr`, which the function did not recurse into. A policy expression like `USING ((lower(col)::text || '-suffix') = other_col)` would therefore never converge — psqldef would re-create the policy on every apply, the exact churn #1271 was meant to fix.

## Changes

- `schema/normalize.go`: add the `ConcatExpr` case to `stripFuncResultTextCasts` so casts inside `||` operands are stripped.
- `schema/normalize_policy_test.go` (new): table-driven unit tests covering every branch of `stripFuncResultTextCasts` (strip on function results incl. parenthesized and `character varying`; preserved casts on columns, literals, and non-text targets; recursion through NOT/AND/OR/`||`/arithmetic/BETWEEN/IS NULL/function arguments; pass-through default; nil) and of `areSamePolicyExprs` (fast path, strip fallback, mismatch, non-PostgreSQL mode).

Both functions are now at 100% statement coverage in the `schema` package tests (no database required).

## Verification

- `make build`, `make format`, `make lint` clean.
- `go test ./schema ./parser` pass.
- `go test ./cmd/psqldef` (full suite, `PSQLDEF_PARSER=generic`) passes against PostgreSQL 18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)