### PR TITLE
psqldef: convert JoinExpr in pgquery fallback

### DIFF
--- a/database/postgres/parser.go
+++ b/database/postgres/parser.go
@@ -547,9 +547,85 @@ func (p PostgresParser) parseFromItem(node *pgquery.Node) (parser.TableExpr, err
 			TableHints: []string{},
 			As:         parser.NewIdent(aliasName, false),
 		}, nil
+	case *pgquery.Node_JoinExpr:
+		return p.parseJoinExpr(n.JoinExpr)
 	default:
 		return nil, fmt.Errorf("unknown node in parseFromItem: %#v", n)
 	}
+}
+
+func (p PostgresParser) parseJoinExpr(join *pgquery.JoinExpr) (parser.TableExpr, error) {
+	if join.JoinUsingAlias != nil {
+		return nil, fmt.Errorf("unhandled join using alias in parseJoinExpr: %#v", join.JoinUsingAlias)
+	}
+	if join.Alias != nil {
+		return nil, fmt.Errorf("unhandled join alias in parseJoinExpr: %#v", join.Alias)
+	}
+
+	var joinType string
+	switch join.Jointype {
+	case pgquery.JoinType_JOIN_INNER:
+		if join.IsNatural {
+			joinType = parser.NaturalJoinStr
+		} else if join.UsingClause == nil && join.Quals == nil {
+			// pgquery has no dedicated CROSS join type: CROSS JOIN is
+			// represented as JOIN_INNER without a join condition
+			joinType = parser.CrossJoinStr
+		} else {
+			joinType = parser.JoinStr
+		}
+	case pgquery.JoinType_JOIN_LEFT:
+		if join.IsNatural {
+			joinType = parser.NaturalLeftJoinStr
+		} else {
+			joinType = parser.LeftJoinStr
+		}
+	case pgquery.JoinType_JOIN_RIGHT:
+		if join.IsNatural {
+			joinType = parser.NaturalRightJoinStr
+		} else {
+			joinType = parser.RightJoinStr
+		}
+	default:
+		// The generic AST has no representation for FULL/SEMI/ANTI joins
+		return nil, fmt.Errorf("unsupported join type in parseJoinExpr: %s", join.Jointype)
+	}
+
+	left, err := p.parseFromItem(join.Larg)
+	if err != nil {
+		return nil, err
+	}
+	right, err := p.parseFromItem(join.Rarg)
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := join.Rarg.Node.(*pgquery.Node_JoinExpr); ok {
+		// A JOIN on the right side must keep its parentheses; without them the
+		// formatted SQL would re-associate the join tree to the left
+		right = &parser.ParenTableExpr{Exprs: parser.TableExprs{right}}
+	}
+
+	var condition parser.JoinCondition
+	for _, using := range join.UsingClause {
+		s, ok := using.Node.(*pgquery.Node_String_)
+		if !ok {
+			return nil, fmt.Errorf("unknown using clause node in parseJoinExpr: %#v", using.Node)
+		}
+		condition.Using = append(condition.Using, parser.NewIdent(s.String_.Sval, false))
+	}
+	if join.Quals != nil {
+		condition.On, err = p.parseExpr(join.Quals)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &parser.JoinTableExpr{
+		LeftExpr:  left,
+		Join:      joinType,
+		RightExpr: right,
+		Condition: condition,
+	}, nil
 }
 
 func (p PostgresParser) parseResTarget(stmt *pgquery.ResTarget) (parser.SelectExpr, error) {

--- a/database/postgres/parser.go
+++ b/database/postgres/parser.go
@@ -614,7 +614,7 @@ func (p PostgresParser) parseJoinExpr(join *pgquery.JoinExpr) (parser.TableExpr,
 		condition.Using = append(condition.Using, parser.NewIdent(s.String_.Sval, false))
 	}
 	if join.Quals != nil {
-		condition.On, err = p.parseExpr(join.Quals)
+		condition.On, err = p.parseJoinQuals(join.Quals)
 		if err != nil {
 			return nil, err
 		}
@@ -626,6 +626,67 @@ func (p PostgresParser) parseJoinExpr(join *pgquery.JoinExpr) (parser.TableExpr,
 		RightExpr: right,
 		Condition: condition,
 	}, nil
+}
+
+// parseJoinQuals converts a JOIN ON condition. Unlike parseExpr, it keeps table
+// qualifiers on column references: dropping them can make the condition ambiguous
+// (e.g. ON u.id = p.id), and the generic parser keeps them as well.
+func (p PostgresParser) parseJoinQuals(node *pgquery.Node) (parser.Expr, error) {
+	switch n := node.Node.(type) {
+	case *pgquery.Node_ColumnRef:
+		return p.parseQualifiedColumnRef(n.ColumnRef)
+	case *pgquery.Node_BoolExpr:
+		return p.parseBoolExpr(n.BoolExpr, p.parseJoinQuals)
+	case *pgquery.Node_AExpr:
+		return p.parseAExpr(n.AExpr, p.parseJoinQuals)
+	case *pgquery.Node_FuncCall:
+		return p.parseFuncCall(n.FuncCall, p.parseJoinQuals)
+	case *pgquery.Node_NullTest:
+		return p.parseNullTest(n.NullTest, p.parseJoinQuals)
+	case *pgquery.Node_TypeCast:
+		return p.parseTypeCast(n.TypeCast, p.parseJoinQuals)
+	case *pgquery.Node_BooleanTest:
+		return p.parseBooleanTest(n.BooleanTest, p.parseJoinQuals)
+	case *pgquery.Node_CoalesceExpr:
+		return p.parseCoalesceExpr(n.CoalesceExpr, p.parseJoinQuals)
+	case *pgquery.Node_CaseExpr:
+		return p.parseCaseExpr(n.CaseExpr, p.parseJoinQuals)
+	default:
+		return p.parseExpr(node)
+	}
+}
+
+func (p PostgresParser) parseQualifiedColumnRef(columnRef *pgquery.ColumnRef) (parser.Expr, error) {
+	var names []string
+	for _, field := range columnRef.Fields {
+		s, ok := field.Node.(*pgquery.Node_String_)
+		if !ok {
+			return nil, fmt.Errorf("unknown column reference field in parseQualifiedColumnRef: %#v", field.Node)
+		}
+		names = append(names, s.String_.Sval)
+	}
+
+	switch len(names) {
+	case 1:
+		return &parser.ColName{
+			Name: parser.NewIdent(names[0], false),
+		}, nil
+	case 2:
+		return &parser.ColName{
+			Qualifier: parser.TableName{Name: parser.NewIdent(names[0], false)},
+			Name:      parser.NewIdent(names[1], false),
+		}, nil
+	case 3:
+		return &parser.ColName{
+			Qualifier: parser.TableName{
+				Schema: parser.NewIdent(names[0], false),
+				Name:   parser.NewIdent(names[1], false),
+			},
+			Name: parser.NewIdent(names[2], false),
+		}, nil
+	default:
+		return nil, fmt.Errorf("unexpected number of column reference fields in parseQualifiedColumnRef: %#v", columnRef)
+	}
 }
 
 func (p PostgresParser) parseResTarget(stmt *pgquery.ResTarget) (parser.SelectExpr, error) {

--- a/database/postgres/parser.go
+++ b/database/postgres/parser.go
@@ -438,51 +438,11 @@ func (p PostgresParser) parseSelectStmt(stmt *pgquery.SelectStmt) (parser.Select
 		return nil, fmt.Errorf("unhandled multiple FROM entries in parseSelectStmt: %#v", stmt.FromClause)
 	}
 	if len(stmt.FromClause) == 1 {
-		var fromExpr parser.SimpleTableExpr
-		var aliasName string
-		var aliasCols parser.Columns
-		switch node := stmt.FromClause[0].Node.(type) {
-		case *pgquery.Node_RangeVar:
-			tableName, err := p.parseTableName(node.RangeVar)
-			if err != nil {
-				return nil, err
-			}
-			fromExpr = tableName
-			if node.RangeVar.Alias != nil {
-				aliasName = node.RangeVar.Alias.Aliasname
-			}
-		case *pgquery.Node_RangeSubselect:
-			if node.RangeSubselect.Lateral {
-				return nil, fmt.Errorf("unhandled lateral subquery in parseSelectStmt")
-			}
-			subNode, ok := node.RangeSubselect.Subquery.Node.(*pgquery.Node_SelectStmt)
-			if !ok {
-				return nil, fmt.Errorf("unknown subquery node in parseSelectStmt: %#v", node.RangeSubselect.Subquery.Node)
-			}
-			sub, err := p.parseSelectStmt(subNode.SelectStmt)
-			if err != nil {
-				return nil, err
-			}
-			fromExpr = &parser.Subquery{Select: sub}
-			if node.RangeSubselect.Alias != nil {
-				aliasName = node.RangeSubselect.Alias.Aliasname
-				for _, col := range node.RangeSubselect.Alias.Colnames {
-					if s, ok := col.Node.(*pgquery.Node_String_); ok {
-						aliasCols = append(aliasCols, parser.NewIdent(s.String_.Sval, false))
-					}
-				}
-			}
-		default:
-			return nil, fmt.Errorf("unknown node in parseSelectStmt: %#v", node)
+		fromItem, err := p.parseFromItem(stmt.FromClause[0])
+		if err != nil {
+			return nil, err
 		}
-		from = parser.TableExprs{
-			&parser.AliasedTableExpr{
-				Expr:       fromExpr,
-				Columns:    aliasCols,
-				TableHints: []string{},
-				As:         parser.NewIdent(aliasName, false),
-			},
-		}
+		from = parser.TableExprs{fromItem}
 	}
 
 	var distinct *parser.DistinctClause
@@ -541,6 +501,55 @@ func (p PostgresParser) parseSelectStmt(stmt *pgquery.SelectStmt) (parser.Select
 		GroupBy:     groupBy,
 		Having:      having,
 	}, nil
+}
+
+func (p PostgresParser) parseFromItem(node *pgquery.Node) (parser.TableExpr, error) {
+	switch n := node.Node.(type) {
+	case *pgquery.Node_RangeVar:
+		tableName, err := p.parseTableName(n.RangeVar)
+		if err != nil {
+			return nil, err
+		}
+		var aliasName string
+		if n.RangeVar.Alias != nil {
+			aliasName = n.RangeVar.Alias.Aliasname
+		}
+		return &parser.AliasedTableExpr{
+			Expr:       tableName,
+			TableHints: []string{},
+			As:         parser.NewIdent(aliasName, false),
+		}, nil
+	case *pgquery.Node_RangeSubselect:
+		if n.RangeSubselect.Lateral {
+			return nil, fmt.Errorf("unhandled lateral subquery in parseFromItem")
+		}
+		subNode, ok := n.RangeSubselect.Subquery.Node.(*pgquery.Node_SelectStmt)
+		if !ok {
+			return nil, fmt.Errorf("unknown subquery node in parseFromItem: %#v", n.RangeSubselect.Subquery.Node)
+		}
+		sub, err := p.parseSelectStmt(subNode.SelectStmt)
+		if err != nil {
+			return nil, err
+		}
+		var aliasName string
+		var aliasCols parser.Columns
+		if n.RangeSubselect.Alias != nil {
+			aliasName = n.RangeSubselect.Alias.Aliasname
+			for _, col := range n.RangeSubselect.Alias.Colnames {
+				if s, ok := col.Node.(*pgquery.Node_String_); ok {
+					aliasCols = append(aliasCols, parser.NewIdent(s.String_.Sval, false))
+				}
+			}
+		}
+		return &parser.AliasedTableExpr{
+			Expr:       &parser.Subquery{Select: sub},
+			Columns:    aliasCols,
+			TableHints: []string{},
+			As:         parser.NewIdent(aliasName, false),
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown node in parseFromItem: %#v", n)
+	}
 }
 
 func (p PostgresParser) parseResTarget(stmt *pgquery.ResTarget) (parser.SelectExpr, error) {

--- a/database/postgres/parser.go
+++ b/database/postgres/parser.go
@@ -626,184 +626,24 @@ func (p PostgresParser) parseExpr(stmt *pgquery.Node) (parser.Expr, error) {
 			return nil, fmt.Errorf("unknown AConst val type in parseExpr: %#v", cNode)
 		}
 	case *pgquery.Node_BoolExpr:
-		expr, err := p.parseExpr(node.BoolExpr.Args[0])
-		if err != nil {
-			return nil, err
-		}
-
-		if node.BoolExpr.Boolop == pgquery.BoolExprType_NOT_EXPR {
-			return &parser.NotExpr{
-				Expr: expr,
-			}, nil
-		}
-
-		for _, arg := range node.BoolExpr.Args[1:] {
-			right, err := p.parseExpr(arg)
-			if err != nil {
-				return nil, err
-			}
-
-			switch node.BoolExpr.Boolop {
-			case pgquery.BoolExprType_AND_EXPR:
-				expr = &parser.AndExpr{
-					Left:  expr,
-					Right: right,
-				}
-			case pgquery.BoolExprType_OR_EXPR:
-				expr = &parser.OrExpr{
-					Left:  expr,
-					Right: right,
-				}
-			default:
-				return nil, fmt.Errorf("unexpected boolop: %d", node.BoolExpr.Boolop)
-			}
-		}
-
-		return expr, nil
+		return p.parseBoolExpr(node.BoolExpr, p.parseExpr)
 	case *pgquery.Node_CaseExpr:
-		caseStmt := stmt.GetCaseExpr()
-
-		var caseExpr parser.Expr
-		var err error
-		if caseStmt.Arg != nil {
-			caseExpr, err = p.parseExpr(caseStmt.Arg)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		var whenExprs []*parser.When
-		for _, arg := range caseStmt.Args {
-			caseWhen := arg.Node.(*pgquery.Node_CaseWhen).CaseWhen
-
-			cond, err := p.parseExpr(caseWhen.Expr)
-			if err != nil {
-				return nil, err
-			}
-
-			result, err := p.parseExpr(caseWhen.Result)
-			if err != nil {
-				return nil, err
-			}
-
-			whenExpr := &parser.When{
-				Cond: cond,
-				Val:  result,
-			}
-			whenExprs = append(whenExprs, whenExpr)
-		}
-
-		var elseExpr parser.Expr
-		if caseStmt.Defresult == nil {
-			elseExpr = &parser.NullVal{} // normalize
-		} else {
-			elseExpr, err = p.parseExpr(caseStmt.Defresult)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		return &parser.CaseExpr{
-			Expr:  caseExpr,
-			Whens: whenExprs,
-			Else:  elseExpr,
-		}, nil
+		return p.parseCaseExpr(node.CaseExpr, p.parseExpr)
 	case *pgquery.Node_ColumnRef:
 		field := node.ColumnRef.Fields[len(node.ColumnRef.Fields)-1] // Ignore table name for easy comparison
 		return &parser.ColName{
 			Name: parser.NewIdent(field.Node.(*pgquery.Node_String_).String_.Sval, false),
 		}, nil
 	case *pgquery.Node_FuncCall:
-		var exprs parser.SelectExprs
-
-		for _, arg := range stmt.GetFuncCall().Args {
-			expr, err := p.parseExpr(arg)
-			if err != nil {
-				return nil, err
-			}
-
-			exprs = append(exprs, &parser.AliasedExpr{
-				Expr: expr,
-			})
-		}
-		var tableName string
-		var funcName string
-		switch len(node.FuncCall.Funcname) {
-		case 1:
-			tableName = ""
-			funcName = node.FuncCall.Funcname[0].Node.(*pgquery.Node_String_).String_.Sval
-		case 2:
-			tableName = node.FuncCall.Funcname[0].Node.(*pgquery.Node_String_).String_.Sval
-			funcName = node.FuncCall.Funcname[1].Node.(*pgquery.Node_String_).String_.Sval
-		default:
-			return nil, fmt.Errorf("unexpected number of funcname: %#v", node.FuncCall.Funcname)
-		}
-
-		return &parser.FuncExpr{
-			Qualifier: parser.NewIdent(tableName, false),
-			Name:      parser.NewIdent(funcName, false),
-			Exprs:     exprs,
-		}, nil
+		return p.parseFuncCall(node.FuncCall, p.parseExpr)
 	case *pgquery.Node_Integer:
 		return parser.NewIntVal(fmt.Sprint(node.Integer.Ival)), nil
 	case *pgquery.Node_NullTest:
-		expr, err := p.parseExpr(node.NullTest.Arg)
-		if err != nil {
-			return nil, err
-		}
-
-		switch node.NullTest.Nulltesttype {
-		case pgquery.NullTestType_IS_NOT_NULL:
-			return &parser.IsExpr{
-				Operator: parser.IsNotNullStr,
-				Expr:     expr,
-			}, nil
-		case pgquery.NullTestType_IS_NULL:
-			return &parser.IsExpr{
-				Operator: parser.IsNullStr,
-				Expr:     expr,
-			}, nil
-		default:
-			return nil, fmt.Errorf("unexpected nulltesttype: %d", node.NullTest.Nulltesttype)
-		}
+		return p.parseNullTest(node.NullTest, p.parseExpr)
 	case *pgquery.Node_String_:
 		return parser.NewStrVal(node.String_.Sval), nil
 	case *pgquery.Node_TypeCast:
-		expr, err := p.parseExpr(node.TypeCast.Arg)
-		if err != nil {
-			return nil, err
-		}
-		columnType, err := p.parseTypeName(node.TypeCast.TypeName)
-		if err != nil {
-			return nil, err
-		}
-		if shouldDeleteTypeCast(node.TypeCast.Arg, columnType) {
-			return expr, nil
-		} else {
-			// For casts, use the raw type name from pgquery to preserve "bpchar" instead of "character"
-			// This matches what the generic parser produces from ::bpchar syntax
-			rawTypeName := p.getRawTypeName(node.TypeCast.TypeName)
-			typeName := rawTypeName
-			if typeName == "" {
-				// Fallback to normalized type if raw extraction fails
-				slog.Debug("Failed to extract raw type name from TypeCast, falling back to normalized type",
-					"normalized_type", columnType.Type,
-					"type_node", fmt.Sprintf("%#v", node.TypeCast.TypeName))
-				typeName = columnType.Type
-			}
-			if columnType.Array {
-				typeName += "[]"
-			}
-			return &parser.CastExpr{
-				Type: &parser.ConvertType{
-					Type:    typeName,
-					Length:  columnType.Length,
-					Scale:   columnType.Scale,
-					Charset: columnType.Charset,
-				},
-				Expr: expr,
-			}, nil
-		}
+		return p.parseTypeCast(node.TypeCast, p.parseExpr)
 	case *pgquery.Node_SqlvalueFunction:
 		switch node.SqlvalueFunction.Op {
 		case pgquery.SQLValueFunctionOp_SVFOP_CURRENT_TIMESTAMP:
@@ -825,115 +665,11 @@ func (p PostgresParser) parseExpr(stmt *pgquery.Node) (parser.Expr, error) {
 			return nil, fmt.Errorf("unexpected SqlvalueFunction: %#v", node)
 		}
 	case *pgquery.Node_AExpr:
-		opNode, ok := node.AExpr.GetName()[0].Node.(*pgquery.Node_String_)
-		if !ok {
-			return nil, fmt.Errorf("unexpected AExpr operation node: %#v", node)
-		}
-
-		// Convert lower case for compatibility with legacy parser
-		op := strings.ToLower(opNode.String_.Sval)
-
-		switch node.AExpr.Kind {
-		case pgquery.A_Expr_Kind_AEXPR_OP,
-			pgquery.A_Expr_Kind_AEXPR_LIKE,
-			pgquery.A_Expr_Kind_AEXPR_ILIKE,
-			pgquery.A_Expr_Kind_AEXPR_OP_ALL,
-			pgquery.A_Expr_Kind_AEXPR_OP_ANY,
-			pgquery.A_Expr_Kind_AEXPR_IN:
-			left, err := p.parseExpr(node.AExpr.GetLexpr())
-			if err != nil {
-				return nil, err
-			}
-			right, err := p.parseExpr(node.AExpr.GetRexpr())
-			if err != nil {
-				return nil, err
-			}
-			// IN operator is internally converted to = ANY (ARRAY[...]) in PostgreSQL
-			anyFlag := node.AExpr.Kind == pgquery.A_Expr_Kind_AEXPR_OP_ANY || node.AExpr.Kind == pgquery.A_Expr_Kind_AEXPR_IN
-
-			// For IN expressions, convert ValTuple to ArrayConstructor
-			if node.AExpr.Kind == pgquery.A_Expr_Kind_AEXPR_IN {
-				if valTuple, ok := right.(parser.ValTuple); ok {
-					// Convert ValTuple to ArrayConstructor
-					var elements parser.Exprs
-					for _, expr := range valTuple {
-						elem, err := p.parseArrayElement(expr)
-						if err != nil {
-							return nil, err
-						}
-						elements = append(elements, elem)
-					}
-					right = &parser.ArrayConstructor{
-						Elements: elements,
-					}
-				}
-			}
-
-			return &parser.ComparisonExpr{
-				Operator: op,
-				Left:     left,
-				Right:    right,
-				All:      node.AExpr.Kind == pgquery.A_Expr_Kind_AEXPR_OP_ALL,
-				Any:      anyFlag,
-			}, nil
-		default:
-			return nil, fmt.Errorf("unknown AExpr kind in parseExpr: %#v", node.AExpr)
-		}
+		return p.parseAExpr(node.AExpr, p.parseExpr)
 	case *pgquery.Node_CoalesceExpr:
-		var selectExprs parser.SelectExprs
-		for _, arg := range node.CoalesceExpr.Args {
-			expr, err := p.parseExpr(arg)
-			if err != nil {
-				return nil, err
-			}
-			selectExprs = append(selectExprs, &parser.AliasedExpr{
-				Expr: expr,
-			})
-		}
-		return &parser.FuncExpr{
-			Name:  parser.NewIdent("coalesce", false),
-			Exprs: selectExprs,
-		}, nil
+		return p.parseCoalesceExpr(node.CoalesceExpr, p.parseExpr)
 	case *pgquery.Node_BooleanTest:
-		expr, err := p.parseExpr(node.BooleanTest.Arg)
-		if err != nil {
-			return nil, err
-		}
-
-		switch node.BooleanTest.Booltesttype {
-		case pgquery.BoolTestType_IS_TRUE:
-			return &parser.IsExpr{
-				Expr:     expr,
-				Operator: parser.IsTrueStr,
-			}, nil
-		case pgquery.BoolTestType_IS_NOT_TRUE:
-			return &parser.IsExpr{
-				Expr:     expr,
-				Operator: parser.IsNotTrueStr,
-			}, nil
-		case pgquery.BoolTestType_IS_FALSE:
-			return &parser.IsExpr{
-				Expr:     expr,
-				Operator: parser.IsFalseStr,
-			}, nil
-		case pgquery.BoolTestType_IS_NOT_FALSE:
-			return &parser.IsExpr{
-				Expr:     expr,
-				Operator: parser.IsNotFalseStr,
-			}, nil
-		case pgquery.BoolTestType_IS_UNKNOWN:
-			return &parser.IsExpr{
-				Expr:     expr,
-				Operator: parser.IsUnknownStr,
-			}, nil
-		case pgquery.BoolTestType_IS_NOT_UNKNOWN:
-			return &parser.IsExpr{
-				Expr:     expr,
-				Operator: parser.IsNotUnknownStr,
-			}, nil
-		default:
-			return nil, fmt.Errorf("unexpected boolean test type: %d", node.BooleanTest.Booltesttype)
-		}
+		return p.parseBooleanTest(node.BooleanTest, p.parseExpr)
 	case *pgquery.Node_List:
 		// Handle list of values (used in IN expressions)
 		var exprs parser.Exprs
@@ -948,6 +684,295 @@ func (p PostgresParser) parseExpr(stmt *pgquery.Node) (parser.Expr, error) {
 	default:
 		return nil, fmt.Errorf("unknown node in parseExpr: %#v", node)
 	}
+}
+
+// parseBoolExpr converts a BoolExpr, delegating operand conversion to parseOperand
+// so that callers can control how column references are converted.
+func (p PostgresParser) parseBoolExpr(boolExpr *pgquery.BoolExpr, parseOperand func(*pgquery.Node) (parser.Expr, error)) (parser.Expr, error) {
+	expr, err := parseOperand(boolExpr.Args[0])
+	if err != nil {
+		return nil, err
+	}
+
+	if boolExpr.Boolop == pgquery.BoolExprType_NOT_EXPR {
+		return &parser.NotExpr{
+			Expr: expr,
+		}, nil
+	}
+
+	for _, arg := range boolExpr.Args[1:] {
+		right, err := parseOperand(arg)
+		if err != nil {
+			return nil, err
+		}
+
+		switch boolExpr.Boolop {
+		case pgquery.BoolExprType_AND_EXPR:
+			expr = &parser.AndExpr{
+				Left:  expr,
+				Right: right,
+			}
+		case pgquery.BoolExprType_OR_EXPR:
+			expr = &parser.OrExpr{
+				Left:  expr,
+				Right: right,
+			}
+		default:
+			return nil, fmt.Errorf("unexpected boolop: %d", boolExpr.Boolop)
+		}
+	}
+
+	return expr, nil
+}
+
+// parseAExpr converts an A_Expr, delegating operand conversion to parseOperand
+// so that callers can control how column references are converted.
+func (p PostgresParser) parseAExpr(aExpr *pgquery.A_Expr, parseOperand func(*pgquery.Node) (parser.Expr, error)) (parser.Expr, error) {
+	opNode, ok := aExpr.GetName()[0].Node.(*pgquery.Node_String_)
+	if !ok {
+		return nil, fmt.Errorf("unexpected AExpr operation node: %#v", aExpr)
+	}
+
+	// Convert lower case for compatibility with legacy parser
+	op := strings.ToLower(opNode.String_.Sval)
+
+	switch aExpr.Kind {
+	case pgquery.A_Expr_Kind_AEXPR_OP,
+		pgquery.A_Expr_Kind_AEXPR_LIKE,
+		pgquery.A_Expr_Kind_AEXPR_ILIKE,
+		pgquery.A_Expr_Kind_AEXPR_OP_ALL,
+		pgquery.A_Expr_Kind_AEXPR_OP_ANY,
+		pgquery.A_Expr_Kind_AEXPR_IN:
+		left, err := parseOperand(aExpr.GetLexpr())
+		if err != nil {
+			return nil, err
+		}
+		right, err := parseOperand(aExpr.GetRexpr())
+		if err != nil {
+			return nil, err
+		}
+		// IN operator is internally converted to = ANY (ARRAY[...]) in PostgreSQL
+		anyFlag := aExpr.Kind == pgquery.A_Expr_Kind_AEXPR_OP_ANY || aExpr.Kind == pgquery.A_Expr_Kind_AEXPR_IN
+
+		// For IN expressions, convert ValTuple to ArrayConstructor
+		if aExpr.Kind == pgquery.A_Expr_Kind_AEXPR_IN {
+			if valTuple, ok := right.(parser.ValTuple); ok {
+				// Convert ValTuple to ArrayConstructor
+				var elements parser.Exprs
+				for _, expr := range valTuple {
+					elem, err := p.parseArrayElement(expr)
+					if err != nil {
+						return nil, err
+					}
+					elements = append(elements, elem)
+				}
+				right = &parser.ArrayConstructor{
+					Elements: elements,
+				}
+			}
+		}
+
+		return &parser.ComparisonExpr{
+			Operator: op,
+			Left:     left,
+			Right:    right,
+			All:      aExpr.Kind == pgquery.A_Expr_Kind_AEXPR_OP_ALL,
+			Any:      anyFlag,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown AExpr kind in parseAExpr: %#v", aExpr)
+	}
+}
+
+func (p PostgresParser) parseFuncCall(funcCall *pgquery.FuncCall, parseOperand func(*pgquery.Node) (parser.Expr, error)) (parser.Expr, error) {
+	var exprs parser.SelectExprs
+	for _, arg := range funcCall.Args {
+		expr, err := parseOperand(arg)
+		if err != nil {
+			return nil, err
+		}
+		exprs = append(exprs, &parser.AliasedExpr{
+			Expr: expr,
+		})
+	}
+	var tableName string
+	var funcName string
+	switch len(funcCall.Funcname) {
+	case 1:
+		tableName = ""
+		funcName = funcCall.Funcname[0].Node.(*pgquery.Node_String_).String_.Sval
+	case 2:
+		tableName = funcCall.Funcname[0].Node.(*pgquery.Node_String_).String_.Sval
+		funcName = funcCall.Funcname[1].Node.(*pgquery.Node_String_).String_.Sval
+	default:
+		return nil, fmt.Errorf("unexpected number of funcname: %#v", funcCall.Funcname)
+	}
+	return &parser.FuncExpr{
+		Qualifier: parser.NewIdent(tableName, false),
+		Name:      parser.NewIdent(funcName, false),
+		Exprs:     exprs,
+	}, nil
+}
+
+func (p PostgresParser) parseNullTest(nullTest *pgquery.NullTest, parseOperand func(*pgquery.Node) (parser.Expr, error)) (parser.Expr, error) {
+	expr, err := parseOperand(nullTest.Arg)
+	if err != nil {
+		return nil, err
+	}
+	switch nullTest.Nulltesttype {
+	case pgquery.NullTestType_IS_NOT_NULL:
+		return &parser.IsExpr{
+			Operator: parser.IsNotNullStr,
+			Expr:     expr,
+		}, nil
+	case pgquery.NullTestType_IS_NULL:
+		return &parser.IsExpr{
+			Operator: parser.IsNullStr,
+			Expr:     expr,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unexpected nulltesttype: %d", nullTest.Nulltesttype)
+	}
+}
+
+func (p PostgresParser) parseTypeCast(typeCast *pgquery.TypeCast, parseOperand func(*pgquery.Node) (parser.Expr, error)) (parser.Expr, error) {
+	expr, err := parseOperand(typeCast.Arg)
+	if err != nil {
+		return nil, err
+	}
+	columnType, err := p.parseTypeName(typeCast.TypeName)
+	if err != nil {
+		return nil, err
+	}
+	if shouldDeleteTypeCast(typeCast.Arg, columnType) {
+		return expr, nil
+	}
+	rawTypeName := p.getRawTypeName(typeCast.TypeName)
+	typeName := rawTypeName
+	if typeName == "" {
+		slog.Debug("Failed to extract raw type name from TypeCast, falling back to normalized type",
+			"normalized_type", columnType.Type,
+			"type_node", fmt.Sprintf("%#v", typeCast.TypeName))
+		typeName = columnType.Type
+	}
+	if columnType.Array {
+		typeName += "[]"
+	}
+	return &parser.CastExpr{
+		Type: &parser.ConvertType{
+			Type:    typeName,
+			Length:  columnType.Length,
+			Scale:   columnType.Scale,
+			Charset: columnType.Charset,
+		},
+		Expr: expr,
+	}, nil
+}
+
+func (p PostgresParser) parseBooleanTest(boolTest *pgquery.BooleanTest, parseOperand func(*pgquery.Node) (parser.Expr, error)) (parser.Expr, error) {
+	expr, err := parseOperand(boolTest.Arg)
+	if err != nil {
+		return nil, err
+	}
+	switch boolTest.Booltesttype {
+	case pgquery.BoolTestType_IS_TRUE:
+		return &parser.IsExpr{
+			Expr:     expr,
+			Operator: parser.IsTrueStr,
+		}, nil
+	case pgquery.BoolTestType_IS_NOT_TRUE:
+		return &parser.IsExpr{
+			Expr:     expr,
+			Operator: parser.IsNotTrueStr,
+		}, nil
+	case pgquery.BoolTestType_IS_FALSE:
+		return &parser.IsExpr{
+			Expr:     expr,
+			Operator: parser.IsFalseStr,
+		}, nil
+	case pgquery.BoolTestType_IS_NOT_FALSE:
+		return &parser.IsExpr{
+			Expr:     expr,
+			Operator: parser.IsNotFalseStr,
+		}, nil
+	case pgquery.BoolTestType_IS_UNKNOWN:
+		return &parser.IsExpr{
+			Expr:     expr,
+			Operator: parser.IsUnknownStr,
+		}, nil
+	case pgquery.BoolTestType_IS_NOT_UNKNOWN:
+		return &parser.IsExpr{
+			Expr:     expr,
+			Operator: parser.IsNotUnknownStr,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unexpected boolean test type: %d", boolTest.Booltesttype)
+	}
+}
+
+func (p PostgresParser) parseCoalesceExpr(coalesceExpr *pgquery.CoalesceExpr, parseOperand func(*pgquery.Node) (parser.Expr, error)) (parser.Expr, error) {
+	var selectExprs parser.SelectExprs
+	for _, arg := range coalesceExpr.Args {
+		expr, err := parseOperand(arg)
+		if err != nil {
+			return nil, err
+		}
+		selectExprs = append(selectExprs, &parser.AliasedExpr{
+			Expr: expr,
+		})
+	}
+	return &parser.FuncExpr{
+		Name:  parser.NewIdent("coalesce", false),
+		Exprs: selectExprs,
+	}, nil
+}
+
+func (p PostgresParser) parseCaseExpr(caseExpr *pgquery.CaseExpr, parseOperand func(*pgquery.Node) (parser.Expr, error)) (parser.Expr, error) {
+	var caseExprVal parser.Expr
+	var err error
+	if caseExpr.Arg != nil {
+		caseExprVal, err = parseOperand(caseExpr.Arg)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var whenExprs []*parser.When
+	for _, arg := range caseExpr.Args {
+		caseWhen := arg.Node.(*pgquery.Node_CaseWhen).CaseWhen
+
+		cond, err := parseOperand(caseWhen.Expr)
+		if err != nil {
+			return nil, err
+		}
+
+		result, err := parseOperand(caseWhen.Result)
+		if err != nil {
+			return nil, err
+		}
+
+		whenExpr := &parser.When{
+			Cond: cond,
+			Val:  result,
+		}
+		whenExprs = append(whenExprs, whenExpr)
+	}
+
+	var elseExpr parser.Expr
+	if caseExpr.Defresult == nil {
+		elseExpr = &parser.NullVal{} // normalize
+	} else {
+		elseExpr, err = parseOperand(caseExpr.Defresult)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &parser.CaseExpr{
+		Expr:  caseExprVal,
+		Whens: whenExprs,
+		Else:  elseExpr,
+	}, nil
 }
 
 func (p PostgresParser) parseIndexColumn(stmt *pgquery.Node) (parser.IndexColumn, error) {

--- a/database/postgres/parser_test.go
+++ b/database/postgres/parser_test.go
@@ -330,7 +330,7 @@ func TestUnsupportedLateralSubselectWithPgquery(t *testing.T) {
 	postgresParser := NewParserWithMode(PsqldefParserModePgquery)
 
 	_, err := postgresParser.Parse(`CREATE VIEW v AS SELECT * FROM LATERAL (SELECT 1 AS id) AS s;`)
-	require.ErrorContains(t, err, "unhandled lateral subquery in parseSelectStmt")
+	require.ErrorContains(t, err, "unhandled lateral subquery in parseFromItem")
 }
 
 func TestUnsupportedSubselectSortWithPgquery(t *testing.T) {
@@ -367,7 +367,7 @@ func TestUnsupportedSubqueryNodeWithPgquery(t *testing.T) {
 	}
 
 	_, err := postgresParser.parseSelectStmt(stmt)
-	require.ErrorContains(t, err, "unknown subquery node in parseSelectStmt")
+	require.ErrorContains(t, err, "unknown subquery node in parseFromItem")
 }
 
 func TestAliasColumnNamesWithPgquery(t *testing.T) {

--- a/database/postgres/parser_test.go
+++ b/database/postgres/parser_test.go
@@ -436,6 +436,33 @@ func TestJoinExprVariantsWithPgquery(t *testing.T) {
 			sql:  "SELECT * FROM users AS u JOIN posts AS p ON coalesce(u.email, '') = p.author_email",
 			want: "select * from users as u join posts as p on coalesce(u.email, '') = p.author_email",
 		},
+		{
+			name: "join on in list",
+			sql:  "SELECT * FROM users AS u JOIN posts AS p ON u.id IN (1, 2, 3)",
+			want: "select * from users as u join posts as p on u.id = ANY (ARRAY[1, 2, 3])",
+		},
+		{
+			name: "join on boolean test variants",
+			sql: "SELECT * FROM users AS u JOIN posts AS p ON " +
+				"p.active IS NOT TRUE OR " +
+				"p.archived IS FALSE OR " +
+				"p.deleted IS NOT FALSE OR " +
+				"p.flag IS UNKNOWN OR " +
+				"p.ready IS NOT UNKNOWN",
+			want: "select * from users as u join posts as p on " +
+				"p.active is not true or " +
+				"p.archived is false or " +
+				"p.deleted is not false or " +
+				"p.flag is unknown or " +
+				"p.ready is not unknown",
+		},
+		{
+			name: "join on case expression",
+			sql: "SELECT * FROM users AS u JOIN posts AS p ON " +
+				"CASE WHEN u.kind = p.kind THEN u.id ELSE 0 END = p.user_id",
+			want: "select * from users as u join posts as p on " +
+				"case when u.kind = p.kind then u.id else 0 end = p.user_id",
+		},
 	}
 
 	for _, tt := range tests {
@@ -585,6 +612,263 @@ func TestJoinExprErrorsWithPgqueryNodes(t *testing.T) {
 			require.ErrorContains(t, err, tt.want)
 		})
 	}
+}
+
+func TestExpressionParserHelperErrorsWithPgqueryNodes(t *testing.T) {
+	postgresParser := PostgresParser{}
+
+	tests := []struct {
+		name string
+		run  func() error
+		want string
+	}{
+		{
+			name: "bool expr first operand",
+			run: func() error {
+				_, err := postgresParser.parseBoolExpr(&pgquery.BoolExpr{
+					Boolop: pgquery.BoolExprType_AND_EXPR,
+					Args:   []*pgquery.Node{{}},
+				}, postgresParser.parseExpr)
+				return err
+			},
+			want: "unknown node in parseExpr",
+		},
+		{
+			name: "bool expr later operand",
+			run: func() error {
+				_, err := postgresParser.parseBoolExpr(&pgquery.BoolExpr{
+					Boolop: pgquery.BoolExprType_AND_EXPR,
+					Args:   []*pgquery.Node{intConstNode(1), {}},
+				}, postgresParser.parseExpr)
+				return err
+			},
+			want: "unknown node in parseExpr",
+		},
+		{
+			name: "bool expr operator",
+			run: func() error {
+				_, err := postgresParser.parseBoolExpr(&pgquery.BoolExpr{
+					Boolop: pgquery.BoolExprType_BOOL_EXPR_TYPE_UNDEFINED,
+					Args:   []*pgquery.Node{intConstNode(1), intConstNode(2)},
+				}, postgresParser.parseExpr)
+				return err
+			},
+			want: "unexpected boolop",
+		},
+		{
+			name: "a expr operation node",
+			run: func() error {
+				_, err := postgresParser.parseAExpr(&pgquery.A_Expr{
+					Kind:  pgquery.A_Expr_Kind_AEXPR_OP,
+					Name:  []*pgquery.Node{intConstNode(1)},
+					Lexpr: intConstNode(1),
+					Rexpr: intConstNode(2),
+				}, postgresParser.parseExpr)
+				return err
+			},
+			want: "unexpected AExpr operation node",
+		},
+		{
+			name: "a expr left operand",
+			run: func() error {
+				_, err := postgresParser.parseAExpr(aExprNode(pgquery.A_Expr_Kind_AEXPR_OP, "=", &pgquery.Node{}, intConstNode(2)), postgresParser.parseExpr)
+				return err
+			},
+			want: "unknown node in parseExpr",
+		},
+		{
+			name: "a expr right operand",
+			run: func() error {
+				_, err := postgresParser.parseAExpr(aExprNode(pgquery.A_Expr_Kind_AEXPR_OP, "=", intConstNode(1), &pgquery.Node{}), postgresParser.parseExpr)
+				return err
+			},
+			want: "unknown node in parseExpr",
+		},
+		{
+			name: "a expr kind",
+			run: func() error {
+				_, err := postgresParser.parseAExpr(aExprNode(pgquery.A_Expr_Kind_AEXPR_DISTINCT, "=", intConstNode(1), intConstNode(2)), postgresParser.parseExpr)
+				return err
+			},
+			want: "unknown AExpr kind in parseAExpr",
+		},
+		{
+			name: "a expr in array element",
+			run: func() error {
+				rightNode := &pgquery.Node{}
+				parseOperand := func(node *pgquery.Node) (parser.Expr, error) {
+					if node == rightNode {
+						return parser.ValTuple{&parser.Default{}}, nil
+					}
+					return postgresParser.parseExpr(node)
+				}
+				_, err := postgresParser.parseAExpr(
+					aExprNode(pgquery.A_Expr_Kind_AEXPR_IN, "=", intConstNode(1), rightNode),
+					parseOperand,
+				)
+				return err
+			},
+			want: "unknown expr in parseArrayElement",
+		},
+		{
+			name: "func call argument",
+			run: func() error {
+				_, err := postgresParser.parseFuncCall(&pgquery.FuncCall{
+					Funcname: []*pgquery.Node{stringNode("lower")},
+					Args:     []*pgquery.Node{{}},
+				}, postgresParser.parseExpr)
+				return err
+			},
+			want: "unknown node in parseExpr",
+		},
+		{
+			name: "func call name length",
+			run: func() error {
+				_, err := postgresParser.parseFuncCall(&pgquery.FuncCall{
+					Funcname: []*pgquery.Node{stringNode("pg_catalog"), stringNode("public"), stringNode("lower")},
+				}, postgresParser.parseExpr)
+				return err
+			},
+			want: "unexpected number of funcname",
+		},
+		{
+			name: "null test argument",
+			run: func() error {
+				_, err := postgresParser.parseNullTest(&pgquery.NullTest{
+					Arg:          &pgquery.Node{},
+					Nulltesttype: pgquery.NullTestType_IS_NULL,
+				}, postgresParser.parseExpr)
+				return err
+			},
+			want: "unknown node in parseExpr",
+		},
+		{
+			name: "null test type",
+			run: func() error {
+				_, err := postgresParser.parseNullTest(&pgquery.NullTest{
+					Arg:          intConstNode(1),
+					Nulltesttype: pgquery.NullTestType_NULL_TEST_TYPE_UNDEFINED,
+				}, postgresParser.parseExpr)
+				return err
+			},
+			want: "unexpected nulltesttype",
+		},
+		{
+			name: "type cast argument",
+			run: func() error {
+				_, err := postgresParser.parseTypeCast(&pgquery.TypeCast{
+					Arg:      &pgquery.Node{},
+					TypeName: typeNameNode("int4"),
+				}, postgresParser.parseExpr)
+				return err
+			},
+			want: "unknown node in parseExpr",
+		},
+		{
+			name: "type cast type name",
+			run: func() error {
+				_, err := postgresParser.parseTypeCast(&pgquery.TypeCast{
+					Arg:      intConstNode(1),
+					TypeName: &pgquery.TypeName{TypeOid: 1, Typemod: -1},
+				}, postgresParser.parseExpr)
+				return err
+			},
+			want: "unhandled node in parseTypeName",
+		},
+		{
+			name: "boolean test argument",
+			run: func() error {
+				_, err := postgresParser.parseBooleanTest(&pgquery.BooleanTest{
+					Arg:          &pgquery.Node{},
+					Booltesttype: pgquery.BoolTestType_IS_TRUE,
+				}, postgresParser.parseExpr)
+				return err
+			},
+			want: "unknown node in parseExpr",
+		},
+		{
+			name: "boolean test type",
+			run: func() error {
+				_, err := postgresParser.parseBooleanTest(&pgquery.BooleanTest{
+					Arg:          intConstNode(1),
+					Booltesttype: pgquery.BoolTestType_BOOL_TEST_TYPE_UNDEFINED,
+				}, postgresParser.parseExpr)
+				return err
+			},
+			want: "unexpected boolean test type",
+		},
+		{
+			name: "case expr argument",
+			run: func() error {
+				_, err := postgresParser.parseCaseExpr(&pgquery.CaseExpr{
+					Arg: &pgquery.Node{},
+				}, postgresParser.parseExpr)
+				return err
+			},
+			want: "unknown node in parseExpr",
+		},
+		{
+			name: "case expr when condition",
+			run: func() error {
+				_, err := postgresParser.parseCaseExpr(&pgquery.CaseExpr{
+					Args: []*pgquery.Node{caseWhenNode(&pgquery.Node{}, intConstNode(1))},
+				}, postgresParser.parseExpr)
+				return err
+			},
+			want: "unknown node in parseExpr",
+		},
+		{
+			name: "case expr when result",
+			run: func() error {
+				_, err := postgresParser.parseCaseExpr(&pgquery.CaseExpr{
+					Args: []*pgquery.Node{caseWhenNode(intConstNode(1), &pgquery.Node{})},
+				}, postgresParser.parseExpr)
+				return err
+			},
+			want: "unknown node in parseExpr",
+		},
+		{
+			name: "case expr else",
+			run: func() error {
+				_, err := postgresParser.parseCaseExpr(&pgquery.CaseExpr{
+					Args:      []*pgquery.Node{caseWhenNode(intConstNode(1), intConstNode(2))},
+					Defresult: &pgquery.Node{},
+				}, postgresParser.parseExpr)
+				return err
+			},
+			want: "unknown node in parseExpr",
+		},
+		{
+			name: "list item",
+			run: func() error {
+				_, err := postgresParser.parseExpr(listNode(&pgquery.Node{}))
+				return err
+			},
+			want: "unknown node in parseExpr",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.ErrorContains(t, tt.run(), tt.want)
+		})
+	}
+}
+
+func TestTypeCastFallsBackWhenRawTypeNameIsEmpty(t *testing.T) {
+	postgresParser := PostgresParser{}
+
+	// pgquery normally supplies a non-empty type name; this malformed node only
+	// exercises the fallback branch after parseTypeName succeeds.
+	expr, err := postgresParser.parseTypeCast(&pgquery.TypeCast{
+		Arg:      intConstNode(1),
+		TypeName: typeNameNode(""),
+	}, postgresParser.parseExpr)
+	require.NoError(t, err)
+
+	cast, ok := expr.(*parser.CastExpr)
+	require.True(t, ok, "expected CastExpr, got %T", expr)
+	assert.Equal(t, "", cast.Type.Type)
 }
 
 func TestMultipleFromEntriesWithPgquery(t *testing.T) {
@@ -895,6 +1179,42 @@ func columnRefNode(fields ...*pgquery.Node) *pgquery.Node {
 			ColumnRef: &pgquery.ColumnRef{Fields: fields},
 		},
 	}
+}
+
+func listNode(items ...*pgquery.Node) *pgquery.Node {
+	return &pgquery.Node{
+		Node: &pgquery.Node_List{
+			List: &pgquery.List{Items: items},
+		},
+	}
+}
+
+func aExprNode(kind pgquery.A_Expr_Kind, op string, left *pgquery.Node, right *pgquery.Node) *pgquery.A_Expr {
+	return &pgquery.A_Expr{
+		Kind:  kind,
+		Name:  []*pgquery.Node{stringNode(op)},
+		Lexpr: left,
+		Rexpr: right,
+	}
+}
+
+func caseWhenNode(expr *pgquery.Node, result *pgquery.Node) *pgquery.Node {
+	return &pgquery.Node{
+		Node: &pgquery.Node_CaseWhen{
+			CaseWhen: &pgquery.CaseWhen{
+				Expr:   expr,
+				Result: result,
+			},
+		},
+	}
+}
+
+func typeNameNode(names ...string) *pgquery.TypeName {
+	typeName := &pgquery.TypeName{Typemod: -1}
+	for _, name := range names {
+		typeName.Names = append(typeName.Names, stringNode(name))
+	}
+	return typeName
 }
 
 func intConstNode(n int32) *pgquery.Node {

--- a/database/postgres/parser_test.go
+++ b/database/postgres/parser_test.go
@@ -871,6 +871,62 @@ func TestTypeCastFallsBackWhenRawTypeNameIsEmpty(t *testing.T) {
 	assert.Equal(t, "", cast.Type.Type)
 }
 
+func TestParseExprDispatchVariantsWithPgqueryNodes(t *testing.T) {
+	postgresParser := PostgresParser{}
+
+	tests := []struct {
+		name string
+		node *pgquery.Node
+		want string
+	}{
+		{
+			name: "case without else",
+			node: caseExprNode(nil, []*pgquery.Node{
+				caseWhenNode(intConstNode(1), intConstNode(2)),
+			}, nil),
+			want: "case when 1 then 2 else null end",
+		},
+		{
+			name: "schema qualified function",
+			node: funcCallNode([]string{"public", "normalize"}, intConstNode(1)),
+			want: "public.normalize(1)",
+		},
+		{
+			name: "not expression",
+			node: boolExprNode(pgquery.BoolExprType_NOT_EXPR, intConstNode(1)),
+			want: "not 1",
+		},
+		{
+			name: "coalesce expression",
+			node: coalesceExprNode(strConstNode(""), columnRefNode(stringNode("name"))),
+			want: "coalesce('', name)",
+		},
+		{
+			name: "boolean test",
+			node: booleanTestNode(columnRefNode(stringNode("active")), pgquery.BoolTestType_IS_TRUE),
+			want: "active is true",
+		},
+		{
+			name: "deleted text type cast",
+			node: typeCastNode(strConstNode("x"), typeNameNode("text")),
+			want: "'x'",
+		},
+		{
+			name: "array type cast",
+			node: typeCastNode(intConstNode(1), arrayTypeNameNode("int4")),
+			want: "1::integer[]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expr, err := postgresParser.parseExpr(tt.node)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, parser.String(expr))
+		})
+	}
+}
+
 func TestMultipleFromEntriesWithPgquery(t *testing.T) {
 	t.Setenv("PSQLDEF_PARSER", "pgquery")
 	postgresParser := NewParserWithMode(PsqldefParserModePgquery)
@@ -1209,11 +1265,85 @@ func caseWhenNode(expr *pgquery.Node, result *pgquery.Node) *pgquery.Node {
 	}
 }
 
+func caseExprNode(arg *pgquery.Node, args []*pgquery.Node, defresult *pgquery.Node) *pgquery.Node {
+	return &pgquery.Node{
+		Node: &pgquery.Node_CaseExpr{
+			CaseExpr: &pgquery.CaseExpr{
+				Arg:       arg,
+				Args:      args,
+				Defresult: defresult,
+			},
+		},
+	}
+}
+
+func funcCallNode(funcNames []string, args ...*pgquery.Node) *pgquery.Node {
+	funcNameNodes := make([]*pgquery.Node, 0, len(funcNames))
+	for _, name := range funcNames {
+		funcNameNodes = append(funcNameNodes, stringNode(name))
+	}
+	return &pgquery.Node{
+		Node: &pgquery.Node_FuncCall{
+			FuncCall: &pgquery.FuncCall{
+				Funcname: funcNameNodes,
+				Args:     args,
+			},
+		},
+	}
+}
+
+func boolExprNode(boolop pgquery.BoolExprType, args ...*pgquery.Node) *pgquery.Node {
+	return &pgquery.Node{
+		Node: &pgquery.Node_BoolExpr{
+			BoolExpr: &pgquery.BoolExpr{
+				Boolop: boolop,
+				Args:   args,
+			},
+		},
+	}
+}
+
+func coalesceExprNode(args ...*pgquery.Node) *pgquery.Node {
+	return &pgquery.Node{
+		Node: &pgquery.Node_CoalesceExpr{
+			CoalesceExpr: &pgquery.CoalesceExpr{Args: args},
+		},
+	}
+}
+
+func booleanTestNode(arg *pgquery.Node, booltesttype pgquery.BoolTestType) *pgquery.Node {
+	return &pgquery.Node{
+		Node: &pgquery.Node_BooleanTest{
+			BooleanTest: &pgquery.BooleanTest{
+				Arg:          arg,
+				Booltesttype: booltesttype,
+			},
+		},
+	}
+}
+
+func typeCastNode(arg *pgquery.Node, typeName *pgquery.TypeName) *pgquery.Node {
+	return &pgquery.Node{
+		Node: &pgquery.Node_TypeCast{
+			TypeCast: &pgquery.TypeCast{
+				Arg:      arg,
+				TypeName: typeName,
+			},
+		},
+	}
+}
+
 func typeNameNode(names ...string) *pgquery.TypeName {
 	typeName := &pgquery.TypeName{Typemod: -1}
 	for _, name := range names {
 		typeName.Names = append(typeName.Names, stringNode(name))
 	}
+	return typeName
+}
+
+func arrayTypeNameNode(names ...string) *pgquery.TypeName {
+	typeName := typeNameNode(names...)
+	typeName.ArrayBounds = []*pgquery.Node{intConstNode(-1)}
 	return typeName
 }
 
@@ -1223,6 +1353,18 @@ func intConstNode(n int32) *pgquery.Node {
 			AConst: &pgquery.A_Const{
 				Val: &pgquery.A_Const_Ival{
 					Ival: &pgquery.Integer{Ival: n},
+				},
+			},
+		},
+	}
+}
+
+func strConstNode(s string) *pgquery.Node {
+	return &pgquery.Node{
+		Node: &pgquery.Node_AConst{
+			AConst: &pgquery.A_Const{
+				Val: &pgquery.A_Const_Sval{
+					Sval: &pgquery.String{Sval: s},
 				},
 			},
 		},

--- a/database/postgres/parser_test.go
+++ b/database/postgres/parser_test.go
@@ -317,6 +317,208 @@ func TestSetOperationErrorsWithPgquery(t *testing.T) {
 	}
 }
 
+func TestJoinExprVariantsWithPgquery(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want string
+	}{
+		{
+			name: "join using",
+			sql:  "SELECT * FROM users JOIN posts USING (user_id)",
+			want: "select * from users join posts using (user_id)",
+		},
+		{
+			name: "join using multiple columns",
+			sql:  "SELECT * FROM users JOIN posts USING (user_id, tenant_id)",
+			want: "select * from users join posts using (user_id, tenant_id)",
+		},
+		{
+			name: "join on",
+			sql:  "SELECT * FROM users JOIN posts ON user_id = author_id",
+			want: "select * from users join posts on user_id = author_id",
+		},
+		{
+			name: "nested joins",
+			sql:  "SELECT * FROM users JOIN posts USING (user_id) JOIN comments USING (post_id)",
+			want: "select * from users join posts using (user_id) join comments using (post_id)",
+		},
+		{
+			name: "right nested join",
+			sql:  "SELECT * FROM users JOIN (posts JOIN comments USING (post_id)) USING (user_id)",
+			want: "select * from users join (posts join comments using (post_id)) using (user_id)",
+		},
+		{
+			name: "left join",
+			sql:  "SELECT * FROM users LEFT OUTER JOIN posts ON user_id = author_id",
+			want: "select * from users left join posts on user_id = author_id",
+		},
+		{
+			name: "right join",
+			sql:  "SELECT * FROM users RIGHT JOIN posts USING (user_id)",
+			want: "select * from users right join posts using (user_id)",
+		},
+		{
+			name: "natural join",
+			sql:  "SELECT * FROM users NATURAL JOIN posts",
+			want: "select * from users natural join posts",
+		},
+		{
+			name: "natural left join",
+			sql:  "SELECT * FROM users NATURAL LEFT JOIN posts",
+			want: "select * from users natural left join posts",
+		},
+		{
+			name: "natural right join",
+			sql:  "SELECT * FROM users NATURAL RIGHT JOIN posts",
+			want: "select * from users natural right join posts",
+		},
+		{
+			name: "cross join",
+			sql:  "SELECT * FROM users CROSS JOIN posts",
+			want: "select * from users cross join posts",
+		},
+		{
+			name: "union all of join using branches",
+			sql: "SELECT * FROM (" +
+				"(SELECT user_id, note FROM users JOIN posts USING (user_id))" +
+				" UNION ALL " +
+				"(SELECT user_id, note FROM users JOIN archived_posts USING (user_id))" +
+				") AS t",
+			want: "select * from (" +
+				"select user_id, note from users join posts using (user_id)" +
+				" union all " +
+				"select user_id, note from users join archived_posts using (user_id)" +
+				") as t",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("PSQLDEF_PARSER", "pgquery")
+			postgresParser := NewParserWithMode(PsqldefParserModePgquery)
+
+			statements, err := postgresParser.Parse("CREATE VIEW join_view AS " + tt.sql)
+			require.NoError(t, err)
+			require.Len(t, statements, 1)
+
+			ddl, ok := statements[0].Statement.(*parser.DDL)
+			require.True(t, ok, "expected DDL statement, got %T", statements[0].Statement)
+			require.NotNil(t, ddl.View)
+			assert.Equal(t, tt.want, parser.String(ddl.View.Definition))
+		})
+	}
+}
+
+func TestJoinExprErrorsWithPgquery(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want string
+	}{
+		{
+			name: "full join",
+			sql:  "CREATE VIEW v AS SELECT * FROM a FULL JOIN b USING (x);",
+			want: "unsupported join type in parseJoinExpr",
+		},
+		{
+			name: "full outer join",
+			sql:  "CREATE VIEW v AS SELECT * FROM a FULL OUTER JOIN b ON x = y;",
+			want: "unsupported join type in parseJoinExpr",
+		},
+		{
+			name: "join using alias",
+			sql:  "CREATE VIEW v AS SELECT * FROM a JOIN b USING (x) AS u;",
+			want: "unhandled join using alias in parseJoinExpr",
+		},
+		{
+			name: "join alias",
+			sql:  "CREATE VIEW v AS SELECT * FROM (a JOIN b USING (x)) AS j;",
+			want: "unhandled join alias in parseJoinExpr",
+		},
+		{
+			name: "lateral subquery in join",
+			sql:  "CREATE VIEW v AS SELECT * FROM a JOIN LATERAL (SELECT 1 AS n) AS s ON true;",
+			want: "unhandled lateral subquery in parseFromItem",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("PSQLDEF_PARSER", "pgquery")
+			postgresParser := NewParserWithMode(PsqldefParserModePgquery)
+
+			_, err := postgresParser.Parse(tt.sql)
+			require.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
+func TestJoinExprErrorsWithPgqueryNodes(t *testing.T) {
+	postgresParser := PostgresParser{}
+
+	tests := []struct {
+		name string
+		join *pgquery.JoinExpr
+		want string
+	}{
+		{
+			name: "semi join",
+			join: &pgquery.JoinExpr{
+				Jointype: pgquery.JoinType_JOIN_SEMI,
+				Larg:     rangeVarNode("a"),
+				Rarg:     rangeVarNode("b"),
+			},
+			want: "unsupported join type in parseJoinExpr",
+		},
+		{
+			name: "left from item",
+			join: &pgquery.JoinExpr{
+				Jointype: pgquery.JoinType_JOIN_INNER,
+				Larg:     intConstNode(1),
+				Rarg:     rangeVarNode("b"),
+			},
+			want: "unknown node in parseFromItem",
+		},
+		{
+			name: "right from item",
+			join: &pgquery.JoinExpr{
+				Jointype: pgquery.JoinType_JOIN_INNER,
+				Larg:     rangeVarNode("a"),
+				Rarg:     intConstNode(1),
+			},
+			want: "unknown node in parseFromItem",
+		},
+		{
+			name: "using clause node",
+			join: &pgquery.JoinExpr{
+				Jointype:    pgquery.JoinType_JOIN_INNER,
+				Larg:        rangeVarNode("a"),
+				Rarg:        rangeVarNode("b"),
+				UsingClause: []*pgquery.Node{intConstNode(1)},
+			},
+			want: "unknown using clause node in parseJoinExpr",
+		},
+		{
+			name: "on expression",
+			join: &pgquery.JoinExpr{
+				Jointype: pgquery.JoinType_JOIN_INNER,
+				Larg:     rangeVarNode("a"),
+				Rarg:     rangeVarNode("b"),
+				Quals:    &pgquery.Node{},
+			},
+			want: "unknown node in parseExpr",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := postgresParser.parseJoinExpr(tt.join)
+			require.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
 func TestMultipleFromEntriesWithPgquery(t *testing.T) {
 	t.Setenv("PSQLDEF_PARSER", "pgquery")
 	postgresParser := NewParserWithMode(PsqldefParserModePgquery)
@@ -601,6 +803,14 @@ func unsupportedSortSelectStmt() *pgquery.SelectStmt {
 	stmt := selectOneStmt()
 	stmt.SortClause = []*pgquery.Node{{}}
 	return stmt
+}
+
+func rangeVarNode(name string) *pgquery.Node {
+	return &pgquery.Node{
+		Node: &pgquery.Node_RangeVar{
+			RangeVar: &pgquery.RangeVar{Relname: name},
+		},
+	}
 }
 
 func intConstNode(n int32) *pgquery.Node {

--- a/database/postgres/parser_test.go
+++ b/database/postgres/parser_test.go
@@ -339,6 +339,21 @@ func TestJoinExprVariantsWithPgquery(t *testing.T) {
 			want: "select * from users join posts on user_id = author_id",
 		},
 		{
+			name: "join on qualified columns",
+			sql:  "SELECT * FROM users AS u JOIN posts AS p ON u.id = p.user_id",
+			want: "select * from users as u join posts as p on u.id = p.user_id",
+		},
+		{
+			name: "join on multiple conditions",
+			sql:  "SELECT * FROM users AS u JOIN posts AS p ON u.id = p.user_id AND u.tenant_id = p.tenant_id",
+			want: "select * from users as u join posts as p on u.id = p.user_id and u.tenant_id = p.tenant_id",
+		},
+		{
+			name: "join on schema qualified column",
+			sql:  "SELECT * FROM public.users JOIN posts AS p ON public.users.id = p.user_id",
+			want: "select * from public.users join posts as p on public.users.id = p.user_id",
+		},
+		{
 			name: "nested joins",
 			sql:  "SELECT * FROM users JOIN posts USING (user_id) JOIN comments USING (post_id)",
 			want: "select * from users join posts using (user_id) join comments using (post_id)",
@@ -390,6 +405,36 @@ func TestJoinExprVariantsWithPgquery(t *testing.T) {
 				" union all " +
 				"select user_id, note from users join archived_posts using (user_id)" +
 				") as t",
+		},
+		{
+			name: "join on function call with qualified columns",
+			sql:  "SELECT * FROM users AS u JOIN posts AS p ON lower(u.email) = lower(p.email)",
+			want: "select * from users as u join posts as p on lower(u.email) = lower(p.email)",
+		},
+		{
+			name: "join on null test",
+			sql:  "SELECT * FROM users AS u LEFT JOIN posts AS p ON u.id = p.user_id AND p.deleted_at IS NULL",
+			want: "select * from users as u left join posts as p on u.id = p.user_id and p.deleted_at is null",
+		},
+		{
+			name: "join on is not null",
+			sql:  "SELECT * FROM users AS u JOIN posts AS p ON u.id = p.user_id AND p.title IS NOT NULL",
+			want: "select * from users as u join posts as p on u.id = p.user_id and p.title is not null",
+		},
+		{
+			name: "join on type cast",
+			sql:  "SELECT * FROM users AS u JOIN posts AS p ON u.id::text = p.ref_id",
+			want: "select * from users as u join posts as p on u.id::text = p.ref_id",
+		},
+		{
+			name: "join on boolean test",
+			sql:  "SELECT * FROM users AS u JOIN posts AS p ON u.id = p.user_id AND p.active IS TRUE",
+			want: "select * from users as u join posts as p on u.id = p.user_id and p.active is true",
+		},
+		{
+			name: "join on coalesce",
+			sql:  "SELECT * FROM users AS u JOIN posts AS p ON coalesce(u.email, '') = p.author_email",
+			want: "select * from users as u join posts as p on coalesce(u.email, '') = p.author_email",
 		},
 	}
 
@@ -508,6 +553,29 @@ func TestJoinExprErrorsWithPgqueryNodes(t *testing.T) {
 				Quals:    &pgquery.Node{},
 			},
 			want: "unknown node in parseExpr",
+		},
+		{
+			name: "on qualified star column",
+			join: &pgquery.JoinExpr{
+				Jointype: pgquery.JoinType_JOIN_INNER,
+				Larg:     rangeVarNode("a"),
+				Rarg:     rangeVarNode("b"),
+				Quals: columnRefNode(
+					stringNode("u"),
+					&pgquery.Node{Node: &pgquery.Node_AStar{AStar: &pgquery.A_Star{}}},
+				),
+			},
+			want: "unknown column reference field in parseQualifiedColumnRef",
+		},
+		{
+			name: "on too many column reference fields",
+			join: &pgquery.JoinExpr{
+				Jointype: pgquery.JoinType_JOIN_INNER,
+				Larg:     rangeVarNode("a"),
+				Rarg:     rangeVarNode("b"),
+				Quals:    columnRefNode(stringNode("db"), stringNode("public"), stringNode("users"), stringNode("id")),
+			},
+			want: "unexpected number of column reference fields in parseQualifiedColumnRef",
 		},
 	}
 
@@ -809,6 +877,22 @@ func rangeVarNode(name string) *pgquery.Node {
 	return &pgquery.Node{
 		Node: &pgquery.Node_RangeVar{
 			RangeVar: &pgquery.RangeVar{Relname: name},
+		},
+	}
+}
+
+func stringNode(s string) *pgquery.Node {
+	return &pgquery.Node{
+		Node: &pgquery.Node_String_{
+			String_: &pgquery.String{Sval: s},
+		},
+	}
+}
+
+func columnRefNode(fields ...*pgquery.Node) *pgquery.Node {
+	return &pgquery.Node{
+		Node: &pgquery.Node_ColumnRef{
+			ColumnRef: &pgquery.ColumnRef{Fields: fields},
 		},
 	}
 }

--- a/database/postgres/tests.yml
+++ b/database/postgres/tests.yml
@@ -122,6 +122,62 @@ CreateViewWithExcept:
   compare_with_generic_parser: true
   sql: |
     CREATE VIEW set_view AS SELECT 1 AS id EXCEPT SELECT 2 AS id
+CreateViewWithJoinUsing:
+  compare_with_generic_parser: true
+  sql: |
+    CREATE VIEW join_view AS SELECT * FROM users JOIN posts USING (user_id)
+CreateViewWithJoinUsingMultipleColumns:
+  compare_with_generic_parser: true
+  sql: |
+    CREATE VIEW join_view AS SELECT * FROM users JOIN posts USING (user_id, tenant_id)
+CreateViewWithJoinOn:
+  compare_with_generic_parser: true
+  sql: |
+    CREATE VIEW join_view AS SELECT * FROM users JOIN posts ON user_id = author_id
+CreateViewWithInnerJoin:
+  compare_with_generic_parser: true
+  sql: |
+    CREATE VIEW join_view AS SELECT * FROM users INNER JOIN posts USING (user_id)
+CreateViewWithNestedJoins:
+  compare_with_generic_parser: true
+  sql: |
+    CREATE VIEW join_view AS SELECT * FROM users JOIN posts USING (user_id) JOIN comments USING (post_id)
+CreateViewWithRightNestedJoin:
+  compare_with_generic_parser: true
+  sql: |
+    CREATE VIEW join_view AS SELECT * FROM users JOIN (posts JOIN comments USING (post_id)) USING (user_id)
+CreateViewWithJoinTableAlias:
+  compare_with_generic_parser: true
+  sql: |
+    CREATE VIEW join_view AS SELECT u.* FROM users AS u JOIN posts AS p USING (user_id)
+CreateViewWithLeftJoin:
+  compare_with_generic_parser: true
+  sql: |
+    CREATE VIEW join_view AS SELECT * FROM users LEFT JOIN posts ON user_id = author_id
+CreateViewWithLeftOuterJoin:
+  compare_with_generic_parser: true
+  sql: |
+    CREATE VIEW join_view AS SELECT * FROM users LEFT OUTER JOIN posts USING (user_id)
+CreateViewWithRightJoin:
+  compare_with_generic_parser: true
+  sql: |
+    CREATE VIEW join_view AS SELECT * FROM users RIGHT JOIN posts USING (user_id)
+CreateViewWithNaturalJoin:
+  compare_with_generic_parser: true
+  sql: |
+    CREATE VIEW join_view AS SELECT * FROM users NATURAL JOIN posts
+CreateViewWithNaturalLeftJoin:
+  compare_with_generic_parser: true
+  sql: |
+    CREATE VIEW join_view AS SELECT * FROM users NATURAL LEFT JOIN posts
+CreateViewWithNaturalRightJoin:
+  compare_with_generic_parser: true
+  sql: |
+    CREATE VIEW join_view AS SELECT * FROM users NATURAL RIGHT JOIN posts
+CreateViewWithCrossJoin:
+  compare_with_generic_parser: true
+  sql: |
+    CREATE VIEW join_view AS SELECT * FROM users CROSS JOIN posts
 CreateViewWithCast:
   sql: |
     create view hoge_view as

--- a/database/postgres/tests.yml
+++ b/database/postgres/tests.yml
@@ -134,6 +134,14 @@ CreateViewWithJoinOn:
   compare_with_generic_parser: true
   sql: |
     CREATE VIEW join_view AS SELECT * FROM users JOIN posts ON user_id = author_id
+CreateViewWithJoinOnQualifiedColumns:
+  compare_with_generic_parser: true
+  sql: |
+    CREATE VIEW join_view AS SELECT * FROM users AS u JOIN posts AS p ON u.id = p.user_id
+CreateViewWithJoinOnMultipleConditions:
+  compare_with_generic_parser: true
+  sql: |
+    CREATE VIEW join_view AS SELECT * FROM users AS u JOIN posts AS p ON u.id = p.user_id AND u.tenant_id = p.tenant_id
 CreateViewWithInnerJoin:
   compare_with_generic_parser: true
   sql: |
@@ -178,6 +186,26 @@ CreateViewWithCrossJoin:
   compare_with_generic_parser: true
   sql: |
     CREATE VIEW join_view AS SELECT * FROM users CROSS JOIN posts
+CreateViewWithJoinOnFuncCall:
+  compare_with_generic_parser: true
+  sql: |
+    CREATE VIEW join_view AS SELECT * FROM users AS u JOIN posts AS p ON lower(u.email) = lower(p.email)
+CreateViewWithJoinOnNullTest:
+  compare_with_generic_parser: true
+  sql: |
+    CREATE VIEW join_view AS SELECT * FROM users AS u LEFT JOIN posts AS p ON u.id = p.user_id AND p.deleted_at IS NULL
+CreateViewWithJoinOnTypeCast:
+  compare_with_generic_parser: true
+  sql: |
+    CREATE VIEW join_view AS SELECT * FROM users AS u JOIN posts AS p ON u.id::text = p.ref_id
+CreateViewWithJoinOnBooleanTest:
+  compare_with_generic_parser: true
+  sql: |
+    CREATE VIEW join_view AS SELECT * FROM users AS u JOIN posts AS p ON u.id = p.user_id AND p.active IS TRUE
+CreateViewWithJoinOnCoalesce:
+  compare_with_generic_parser: true
+  sql: |
+    CREATE VIEW join_view AS SELECT * FROM users AS u JOIN posts AS p ON coalesce(u.email, '') = p.author_email
 CreateViewWithCast:
   sql: |
     create view hoge_view as


### PR DESCRIPTION
## What

- Extract FROM clause conversion from `parseSelectStmt` into `parseFromItem` for recursive FROM item handling, and add `JoinExpr` conversion via `parseJoinExpr`
  - `JOIN_INNER` / `JOIN_LEFT` / `JOIN_RIGHT` map to `join` / `left join` / `right join` (with `natural` variants when `is_natural` is set)
  - `JOIN_INNER` without quals/usingClause maps to `cross join` (pg_query has no dedicated CROSS type)
  - `USING (col, ...)` converts to `JoinCondition.Using`; `ON <expr>` delegates to `parseJoinQuals`
  - Right-side `JoinExpr` is wrapped in `ParenTableExpr` to preserve join associativity
  - Unsupported constructs (`JOIN_FULL`/`JOIN_SEMI`/`JOIN_ANTI`, aliased joins, `JOIN USING ... AS`) return errors, triggering generic-parser fallback in auto mode

- Refactor expression parsers (`parseBoolExpr`, `parseAExpr`, `parseFuncCall`, `parseNullTest`, `parseTypeCast`, `parseBooleanTest`, `parseCoalesceExpr`, `parseCaseExpr`) to accept a `parseOperand` callback, enabling reuse from both `parseExpr` and the new `parseJoinQuals`

- Add `parseJoinQuals` for JOIN ON conditions: unlike `parseExpr` which strips table qualifiers from column references, `parseJoinQuals` preserves them via `parseQualifiedColumnRef` (e.g., `ON u.id = p.user_id`) to avoid ambiguity

## Why (Motivate)

When the generic parser falls back to pgquery, VIEW definitions with JOIN in the FROM clause fail. `parseSelectStmt` only handles `RangeVar` and `RangeSubselect`, rejecting `JoinExpr`:

```sql
CREATE VIEW v AS SELECT * FROM (
  (SELECT a.id, a.name FROM a JOIN x USING (id))
  UNION ALL
  (SELECT b.id, b.name FROM b JOIN x USING (id))
) t;
```

In auto mode, pgquery conversion fails on `JoinExpr`, and the per-statement generic parser retry fails on the parenthesized set operation, aborting the migration with `syntax error ... near 'union'`.

Also improves coverage for `pg_get_viewdef()`-style definitions that use explicit join syntax.

## Test

- `database/postgres/tests.yml` (`compare_with_generic_parser: true`): covering JOIN USING (single/multiple columns), JOIN ON (simple/qualified/multiple conditions), INNER/LEFT/LEFT OUTER/RIGHT/NATURAL/NATURAL LEFT/NATURAL RIGHT/CROSS JOIN, nested joins (left/right), table aliases, ON with function calls/IS NULL/IS NOT NULL/type casts/boolean tests/COALESCE

- `database/postgres/parser_test.go`:
  - `TestJoinExprVariantsWithPgquery`: pgquery-mode cases including UNION ALL of join branches and right-nested parenthesized joins (no generic-parser comparison: pg_query doesn't preserve join parentheses while the generic parser uses `ParenTableExpr`)
  - `TestJoinExprErrorsWithPgquery`: FULL JOIN, aliased joins, `JOIN USING ... AS`, lateral subquery in join return conversion errors
  - `TestJoinExprErrorsWithPgqueryNodes`: error paths via direct node construction (SEMI join, invalid FROM items, bad USING/ON nodes, qualified star column, excess column ref fields)

```
PSQLDEF_PARSER=pgquery go test ./database/postgres
PSQLDEF_PARSER= go test ./database/postgres
go test ./schema
go test ./cmd/psqldef
```