### PR TITLE
fix(psqldef): deterministic, dependency-safe view/matview order in --export

### DIFF
--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -818,6 +818,82 @@ func TestPsqldefExportConcurrency(t *testing.T) {
 	assert.Equal(t, outputDefault, outputConcurrencyNoLimit)
 }
 
+// TestPsqldefExportViewOrder guards --export ordering of enum types, views, and
+// materialized views. Without a stable ORDER BY the objects follow the unstable
+// pg_class scan order and a committed schema.sql churns on every dump. Views/matviews
+// are additionally ordered topologically (a dependent after the object it selects from)
+// so the dump is valid to load in order (e.g. psql -f), with a name tie-break within a
+// dependency level. Objects are created out of order (reverse-alphabetical, and a
+// dependent whose name sorts before its dependency) to catch both regressions.
+func TestPsqldefExportViewOrder(t *testing.T) {
+	resetTestDatabase()
+
+	mustPgExec(testDatabaseName, tu.StripHeredoc(`
+		CREATE TYPE z_enum AS ENUM ('x');
+		CREATE TYPE a_enum AS ENUM ('y');
+		CREATE TABLE items (id bigint NOT NULL);
+		CREATE VIEW v_charlie AS SELECT id FROM items;
+		CREATE VIEW v_bravo AS SELECT id FROM items;
+		CREATE VIEW v_alpha AS SELECT id FROM items;
+		CREATE VIEW zz_base AS SELECT id FROM items;
+		CREATE VIEW aa_derived AS SELECT id FROM zz_base;
+		CREATE MATERIALIZED VIEW mv_charlie AS SELECT id FROM items;
+		CREATE MATERIALIZED VIEW mv_bravo AS SELECT id FROM items;
+		CREATE MATERIALIZED VIEW mv_alpha AS SELECT id FROM items;
+		CREATE MATERIALIZED VIEW zz_mbase AS SELECT id FROM items;
+		CREATE MATERIALIZED VIEW aa_mderived AS SELECT id FROM zz_mbase;
+	`))
+
+	output := tu.MustExecute(t, "./psqldef", psqldefArgs(testDatabaseName, "--export")...)
+
+	// enum types sort by name
+	assertObjectsInOrder(t, output,
+		"CREATE TYPE public.a_enum",
+		"CREATE TYPE public.z_enum",
+	)
+	// independent views sort by name (determinism)
+	assertObjectsInOrder(t, output,
+		"CREATE VIEW public.v_alpha",
+		"CREATE VIEW public.v_bravo",
+		"CREATE VIEW public.v_charlie",
+	)
+	// a view is emitted after the view it depends on, even though its name sorts first
+	assertObjectsInOrder(t, output,
+		"CREATE VIEW public.zz_base",
+		"CREATE VIEW public.aa_derived",
+	)
+	assertObjectsInOrder(t, output,
+		"CREATE MATERIALIZED VIEW public.mv_alpha",
+		"CREATE MATERIALIZED VIEW public.mv_bravo",
+		"CREATE MATERIALIZED VIEW public.mv_charlie",
+	)
+	assertObjectsInOrder(t, output,
+		"CREATE MATERIALIZED VIEW public.zz_mbase",
+		"CREATE MATERIALIZED VIEW public.aa_mderived",
+	)
+}
+
+// assertObjectsInOrder asserts each needle is present in output and that they appear in
+// the given order. Quotes are stripped first so the assertion holds under both the
+// always-quote (legacy_ignore_quotes) and quote-aware identifier modes.
+func assertObjectsInOrder(t *testing.T, output string, needles ...string) {
+	t.Helper()
+	unquoted := strings.ReplaceAll(output, `"`, "")
+	prev := -1
+	for _, needle := range needles {
+		idx := strings.Index(unquoted, needle)
+		if idx < 0 {
+			t.Errorf("expected export to contain %q, got:\n%s", needle, output)
+			return
+		}
+		if idx < prev {
+			t.Errorf("expected %q to appear after the previous object; export is not name-sorted:\n%s", needle, output)
+			return
+		}
+		prev = idx
+	}
+}
+
 func TestPsqldefSkipView(t *testing.T) {
 	resetTestDatabase()
 

--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -286,13 +286,37 @@ func (d *PostgresDatabase) views() ([]string, error) {
 		return []string{}, nil
 	}
 
+	// Order views so a view is emitted after the views it selects from (topological
+	// order), with a name tie-break within each dependency level. This keeps the dump
+	// deterministic AND valid to load in order (e.g. psql -f), independent of the
+	// unstable pg_class scan order. depth = longest chain of view-on-view dependencies.
 	rows, err := d.db.Query(`
-		select n.nspname as table_schema, c.relname as table_name, pg_get_viewdef(c.oid) as definition,
-		       obj_description(c.oid, 'pg_class') as view_comment
-		from pg_catalog.pg_class c inner join pg_catalog.pg_namespace n on c.relnamespace = n.oid
-		where n.nspname not in ('information_schema', 'pg_catalog', 'sys')
-		and c.relkind = 'v'
-		and not exists (select 1 from pg_catalog.pg_depend d where c.oid = d.objid and d.classid = (select oid from pg_catalog.pg_class where relname = 'pg_class') and d.deptype = 'e')
+		with recursive
+		target as (
+			select c.oid, n.nspname, c.relname
+			from pg_catalog.pg_class c inner join pg_catalog.pg_namespace n on c.relnamespace = n.oid
+			where n.nspname not in ('information_schema', 'pg_catalog', 'sys')
+			and c.relkind = 'v'
+			and not exists (select 1 from pg_catalog.pg_depend d where c.oid = d.objid and d.classid = (select oid from pg_catalog.pg_class where relname = 'pg_class') and d.deptype = 'e')
+		),
+		view_edges as (
+			select distinct r.ev_class as dependent, d.refobjid as dependency
+			from pg_catalog.pg_depend d
+			inner join pg_catalog.pg_rewrite r on r.oid = d.objid
+			where d.classid = 'pg_rewrite'::regclass and d.refclassid = 'pg_class'::regclass
+			and d.deptype = 'n' and r.ev_class <> d.refobjid
+			and r.ev_class in (select oid from target) and d.refobjid in (select oid from target)
+		),
+		view_depth as (
+			select t.oid, 0 as depth from target t where not exists (select 1 from view_edges e where e.dependent = t.oid)
+			union all
+			select e.dependent, vd.depth + 1 from view_edges e inner join view_depth vd on e.dependency = vd.oid
+		),
+		view_rank as (select oid, max(depth) as depth from view_depth group by oid)
+		select t.nspname as table_schema, t.relname as table_name, pg_get_viewdef(t.oid) as definition,
+		       obj_description(t.oid, 'pg_class') as view_comment
+		from target t inner join view_rank vr on vr.oid = t.oid
+		order by vr.depth, t.nspname, t.relname
 	`)
 	if err != nil {
 		return nil, err
@@ -333,11 +357,34 @@ func (d *PostgresDatabase) materializedViews() ([]string, error) {
 		return []string{}, nil
 	}
 
+	// Order materialized views topologically (a matview after the matviews it selects
+	// from), name tie-break within a level. Deterministic and valid to load in order,
+	// independent of pg_class scan order. See views() for the same pattern.
 	rows, err := d.db.Query(`
-		select n.nspname as schemaname, c.relname as matviewname, pg_get_viewdef(c.oid) as definition
-		from pg_catalog.pg_class c inner join pg_catalog.pg_namespace n on c.relnamespace = n.oid
-		where c.relkind = 'm'
-		and not exists (select 1 from pg_catalog.pg_depend d where c.oid = d.objid and d.classid = (select oid from pg_catalog.pg_class where relname = 'pg_class') and d.deptype = 'e')
+		with recursive
+		target as (
+			select c.oid, n.nspname, c.relname
+			from pg_catalog.pg_class c inner join pg_catalog.pg_namespace n on c.relnamespace = n.oid
+			where c.relkind = 'm'
+			and not exists (select 1 from pg_catalog.pg_depend d where c.oid = d.objid and d.classid = (select oid from pg_catalog.pg_class where relname = 'pg_class') and d.deptype = 'e')
+		),
+		matview_edges as (
+			select distinct r.ev_class as dependent, d.refobjid as dependency
+			from pg_catalog.pg_depend d
+			inner join pg_catalog.pg_rewrite r on r.oid = d.objid
+			where d.classid = 'pg_rewrite'::regclass and d.refclassid = 'pg_class'::regclass
+			and d.deptype = 'n' and r.ev_class <> d.refobjid
+			and r.ev_class in (select oid from target) and d.refobjid in (select oid from target)
+		),
+		matview_depth as (
+			select t.oid, 0 as depth from target t where not exists (select 1 from matview_edges e where e.dependent = t.oid)
+			union all
+			select e.dependent, md.depth + 1 from matview_edges e inner join matview_depth md on e.dependency = md.oid
+		),
+		matview_rank as (select oid, max(depth) as depth from matview_depth group by oid)
+		select t.nspname as schemaname, t.relname as matviewname, pg_get_viewdef(t.oid) as definition
+		from target t inner join matview_rank mr on mr.oid = t.oid
+		order by mr.depth, t.nspname, t.relname
 	`)
 	if err != nil {
 		return nil, err
@@ -381,7 +428,8 @@ func (d *PostgresDatabase) schemas() ([]string, error) {
 		SELECT schema_name
 		FROM information_schema.schemata
 		WHERE schema_name NOT LIKE 'pg_%%'
-		AND schema_name not in ('information_schema', 'public', 'sys');
+		AND schema_name not in ('information_schema', 'public', 'sys')
+		ORDER BY schema_name;
 	`)
 	if err != nil {
 		return nil, err
@@ -410,7 +458,8 @@ func (d *PostgresDatabase) extensions() ([]string, error) {
 
 	rows, err := d.db.Query(`
 		SELECT extname FROM pg_extension
-		WHERE extname != 'plpgsql';
+		WHERE extname != 'plpgsql'
+		ORDER BY extname;
 	`)
 	if err != nil {
 		return nil, err
@@ -444,7 +493,8 @@ func (d *PostgresDatabase) types() ([]string, error) {
 		JOIN pg_type t ON e.enumtypid = t.oid
 		INNER JOIN pg_catalog.pg_namespace n ON t.typnamespace = n.oid
 		WHERE NOT EXISTS (SELECT 1 FROM pg_depend d WHERE d.objid = t.oid AND d.classid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'pg_type') AND d.deptype = 'e')
-		GROUP BY n.nspname, t.typname, t.oid;
+		GROUP BY n.nspname, t.typname, t.oid
+		ORDER BY n.nspname, t.typname;
 	`)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Problem

`psqldef --export` emitted `VIEW`s and `MATERIALIZED VIEW`s in `pg_class` **scan (physical) order** because `views()` and `materializedViews()` had no `ORDER BY` (tables and most other objects already sort by `nspname, relname`). That order is not stable: a `DROP`+`CREATE` during a migration, autovacuum on `pg_class`, or a primary/replica physical difference relocates the row. So a committed `schema.sql` generated by `--export` changes across runs with **no real schema change**, producing recurring "chore: update schema.sql" commits (a matview and its unique index kept moving together in the diff, since the index is emitted right after its matview).

Repro (before this change):

```
CREATE 3 matviews + 2 views  ->  psqldef --export        (order A)
DROP + CREATE two of them    ->  psqldef --export again  (order B)   # A != B
```

## Fix

Order views and materialized views **topologically** — each object is emitted after the view(s)/matview(s) it selects from — with a `nspname, relname` **tie-break within each dependency level**. A recursive CTE derives view→view edges from `pg_rewrite`/`pg_depend` and computes each object's depth (longest dependency chain); the result is ordered by `(depth, schema, name)`.

This is both:
- **deterministic** — stable across `pg_class` churn, so `schema.sql` stops flip-flopping; and
- **dependency-safe** — the dump loads in order via a plain `psql -f schema.sql` (a naive alphabetical sort would place `a_report` before its dependency `z_base` and fail). `psqldef --apply` already re-sorts, so the export→apply workflow was safe either way, but the dump is now correct for direct execution too.

Also adds the missing `ORDER BY` to the sibling export queries that had the same determinism gap:
- `types()` — had `GROUP BY` but no `ORDER BY` (enum types could reorder)
- `schemas()`
- `extensions()`

## Testing

- New `TestPsqldefExportViewOrder` guards enum-type name order, independent view/matview name order, and topological order (a dependent whose name sorts *before* its dependency still comes after it). It fails on the unfixed code and passes here.
- Verified manually on PostgreSQL 13/14/18: order is stable across DROP+CREATE churn, and a direct `psql -f` of the dump succeeds.
- `go test ./cmd/psqldef` passes; `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
