### PR TITLE
psqldef: scope generic-parser syntax errors to the offending statement

### DIFF
--- a/cmd/psqldef/tests_indices.yml
+++ b/cmd/psqldef/tests_indices.yml
@@ -601,6 +601,13 @@ PartialIndexWithWhereNotInUnsorted:
     CREATE INDEX idx_non_cancelled ON orders (id)
     WHERE status NOT IN ('deleted', 'cancelled');
 
+PartialIndexWithArrayCastAnyPgDumpStyle:
+  legacy_ignore_quotes: false
+  desired: |
+    CREATE TABLE orders (id integer, status character varying(16));
+    CREATE UNIQUE INDEX uk_orders_status ON orders (id)
+    WHERE ((status)::text = ANY ((ARRAY['active'::character varying, 'pending'::character varying])::text[]));
+
 IndexWithNullsNotDistinct:
   legacy_ignore_quotes: false
   min_version: "15"

--- a/database/parser.go
+++ b/database/parser.go
@@ -58,6 +58,7 @@ func (p GenericParser) splitDDLs(str string) ([]string, error) {
 		// So we just attempt parsing until it succeeds. I'll let the parser do it in the future.
 		var ddl string
 		var err error
+		var firstErr error
 		i := 1
 		for {
 			ddl = strings.Join(ddls[0:i], ";")
@@ -67,6 +68,9 @@ func (p GenericParser) splitDDLs(str string) ([]string, error) {
 				break
 			}
 			_, err = parser.ParseDDL(ddl, p.mode)
+			if i == 1 {
+				firstErr = err
+			}
 			if err == nil || i == len(ddls) {
 				break
 			}
@@ -74,6 +78,11 @@ func (p GenericParser) splitDDLs(str string) ([]string, error) {
 		}
 
 		if err != nil {
+			// err is from the chunk joined all the way to EOF; firstErr keeps the
+			// error scoped to the offending statement instead of the whole rest of the file.
+			if firstErr != nil {
+				return result, firstErr
+			}
 			return result, err
 		}
 		if ddl != "" {

--- a/database/parser_test.go
+++ b/database/parser_test.go
@@ -1,0 +1,48 @@
+package database
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sqldef/sqldef/v3/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseErrorScopedToOffendingStatement(t *testing.T) {
+	sql := `CREATE TABLE foo (
+    id bigint NOT NULL
+) WITH (some_bogus_totally_unsupported_syntax = true);
+
+CREATE TABLE bar (
+    id bigint NOT NULL
+);
+
+CREATE TABLE baz (
+    id bigint NOT NULL
+);
+`
+	p := NewParser(parser.ParserModePostgres)
+	_, err := p.Parse(sql)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "some_bogus_totally_unsupported_syntax")
+	assert.NotContains(t, err.Error(), "CREATE TABLE bar")
+	assert.NotContains(t, err.Error(), "CREATE TABLE baz")
+	assert.Less(t, len(err.Error()), 500, "error message should be scoped to the offending statement, not the rest of the input")
+}
+
+func TestParseResyncAcrossEmbeddedSemicolons(t *testing.T) {
+	sql := `CREATE TABLE foo (
+    id bigint NOT NULL
+);
+
+CREATE TABLE bar (
+    id bigint NOT NULL
+);
+`
+	p := NewParser(parser.ParserModePostgres)
+	stmts, err := p.Parse(sql)
+	assert.NoError(t, err)
+	assert.Len(t, stmts, 2)
+	assert.True(t, strings.Contains(stmts[0].DDL, "foo"))
+	assert.True(t, strings.Contains(stmts[1].DDL, "bar"))
+}


### PR DESCRIPTION
## Summary

A user-filed bug report (private repro, summarized below) surfaced two issues in psqldef's generic PostgreSQL parser when handling `CREATE UNIQUE INDEX ... WHERE (("status")::text = ANY ((ARRAY[...])::text[]))` — the exact partial-index predicate shape `pg_dump`/`pg_get_indexdef` emits for an `IN (...)`-style partial index on a `character varying` column:

1. The generic parser rejected this predicate form, forcing a fallback to the `pgquery` parser on every dry-run against schemas containing it.
2. When the generic parser genuinely fails on a statement, the WARN log's `error=` field embedded the failing statement **concatenated with the entire remainder of the input SQL** (unbounded, scales with schema.sql size) — hundreds of KB on an 800-line schema.

### Investigation

- Issue (1) turned out to already be fixed on `master` by f9a9fba (shipped in v3.11.10, included in the current v3.11.14 release) — the reporter was likely on an older pinned build. Added a regression test (`PartialIndexWithArrayCastAnyPgDumpStyle`) to lock this in.
- Issue (2) is still present. `GenericParser.splitDDLs`'s resync loop — which rejoins `";"`-delimited chunks to handle statements with embedded semicolons (e.g. function bodies) — keeps growing its parse attempt across the rest of the file when a statement is genuinely unparseable, and returns the error from that maximal, ballooned attempt.

## Fix

- `database/parser.go`: capture the error from the *first* (single-chunk) parse attempt, and return that instead of the final ballooned-join error when no resync attempt ever succeeds. This scopes the error message to the actual offending statement instead of swallowing the rest of the file. Legitimate multi-chunk resync (e.g. semicolons inside a function body) is unaffected, since that path still succeeds and never falls into this branch.

## Test plan

- [x] `go build ./...`
- [x] `go test ./database/...` (against a live Postgres)
- [x] `go test ./cmd/psqldef/...` (against a live Postgres, `PSQLDEF_PARSER=generic`)
- [x] `go test ./cmd/mysqldef/...`, `go test ./cmd/sqlite3def/...`
- [x] `make format`, `make lint`, `make build`
- [x] New unit tests `TestParseErrorScopedToOffendingStatement` / `TestParseResyncAcrossEmbeddedSemicolons` in `database/parser_test.go`
- [x] New YAML regression test `PartialIndexWithArrayCastAnyPgDumpStyle` in `cmd/psqldef/tests_indices.yml`
- [x] Manually verified against the built binary: the WARN log for a genuinely-unparseable statement now cites only that statement, not trailing `CREATE TABLE` statements in the same file

🤖 Generated with [Claude Code](https://claude.com/claude-code)