### PR TITLE
psqldef: detect operator class changes on index columns

### DIFF
--- a/cmd/psqldef/tests_indices.yml
+++ b/cmd/psqldef/tests_indices.yml
@@ -183,6 +183,54 @@ IndexOnIdentifierNamedTextPatternOps:
     CREATE TABLE text_pattern_ops (text_pattern_ops TEXT);
     CREATE INDEX idx_tpo ON text_pattern_ops USING btree (text_pattern_ops text_pattern_ops);
 
+AddOperatorClassToExistingIndex:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TABLE products (name TEXT);
+    CREATE INDEX idx_name ON products USING btree (name);
+  desired: |
+    CREATE TABLE products (name TEXT);
+    CREATE INDEX idx_name ON products USING btree (name text_pattern_ops);
+  up: |
+    DROP INDEX public.idx_name;
+    CREATE INDEX idx_name ON public.products USING btree (name text_pattern_ops);
+  down: |
+    DROP INDEX public.idx_name;
+    CREATE INDEX idx_name ON public.products USING btree (name);
+
+IndexWithExplicitDefaultOperatorClass:
+  legacy_ignore_quotes: false
+  desired: |
+    CREATE TABLE products (name TEXT);
+    CREATE INDEX idx_name ON products USING btree (name text_ops);
+
+IndexWithExplicitDefaultOperatorClassWithoutUsing:
+  legacy_ignore_quotes: false
+  desired: |
+    CREATE TABLE products (name TEXT);
+    CREATE INDEX idx_name ON products (name text_ops);
+
+IndexWithExplicitDefaultGinOperatorClass:
+  legacy_ignore_quotes: false
+  desired: |
+    CREATE TABLE products (tags TEXT[]);
+    CREATE INDEX idx_tags ON products USING gin (tags array_ops);
+
+AddNonDefaultOperatorClassOfSameAccessMethod:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TABLE products (tags JSONB);
+    CREATE INDEX idx_tags ON products USING gin (tags jsonb_ops);
+  desired: |
+    CREATE TABLE products (tags JSONB);
+    CREATE INDEX idx_tags ON products USING gin (tags jsonb_path_ops);
+  up: |
+    DROP INDEX public.idx_tags;
+    CREATE INDEX idx_tags ON public.products USING gin (tags jsonb_path_ops);
+  down: |
+    DROP INDEX public.idx_tags;
+    CREATE INDEX idx_tags ON public.products USING gin (tags jsonb_ops);
+
 RenameIndex:
   current: |
     CREATE TABLE users (

--- a/database/database.go
+++ b/database/database.go
@@ -72,6 +72,15 @@ type GeneratorConfig struct {
 	// 0 = case-sensitive (Linux default), 1 or 2 = case-insensitive (Windows/macOS).
 	// Default is 0 (case-sensitive) for offline mode compatibility.
 	MysqlLowerCaseTableNames int
+
+	// PostgreSQL-specific: the default operator class of every access method, keyed by
+	// "<access method>.<operator class>" in lower case, e.g. "btree.text_ops".
+	// The database omits the default operator class from the DDL it exports, so one written
+	// explicitly in the desired DDL has to compare equal to an omitted one.
+	// Nil in offline mode, where an explicit operator class is compared as-is.
+	// Every copy of the config shares one map that ExportDDLs() refills, so read it only after
+	// exporting: the schema being applied may install an extension that registers operator classes.
+	PostgresDefaultOperatorClasses map[string]bool
 }
 
 type ManageObjectRule struct {

--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -4,6 +4,8 @@ import (
 	"cmp"
 	"database/sql"
 	"fmt"
+	"log/slog"
+	"maps"
 	"net/url"
 	"os"
 	"regexp"
@@ -28,11 +30,12 @@ var (
 const indent = "    "
 
 type PostgresDatabase struct {
-	config          database.Config
-	generatorConfig database.GeneratorConfig
-	db              *sql.DB
-	defaultSchema   *string
-	hasConperiod    *bool // cached: whether pg_constraint has conperiod column (PG18+)
+	config           database.Config
+	generatorConfig  database.GeneratorConfig
+	db               *sql.DB
+	defaultSchema    *string
+	hasConperiod     *bool           // cached: whether pg_constraint has conperiod column (PG18+)
+	defaultOpclasses map[string]bool // cached: see defaultOperatorClasses()
 }
 
 func NewDatabase(config database.Config) (database.Database, error) {
@@ -49,10 +52,50 @@ func NewDatabase(config database.Config) (database.Database, error) {
 }
 
 func (d *PostgresDatabase) SetGeneratorConfig(config database.GeneratorConfig) {
+	if d.defaultOpclasses == nil {
+		d.defaultOpclasses = map[string]bool{}
+	}
+	config.PostgresDefaultOperatorClasses = d.defaultOpclasses
 	d.generatorConfig = config
 	// Sync TargetSchema to d.config for backward compatibility
 	// (other methods read from d.config.TargetSchema)
 	d.config.TargetSchema = config.TargetSchema
+}
+
+// refreshDefaultOperatorClasses reloads the default operator class of every access method, keyed by
+// "<access method>.<operator class>". pg_get_indexdef() omits an operator class from its output when
+// it's the default one, so the generator needs this to tell an omitted operator class apart from a
+// removed one.
+//
+// The map is the very one handed out to every GeneratorConfig copy, so it's refilled in place:
+// an extension that the schema itself installs (pgvector, say) registers operator classes that
+// weren't in the catalog when the config was built.
+func (d *PostgresDatabase) refreshDefaultOperatorClasses() {
+	if d.defaultOpclasses == nil {
+		return
+	}
+	rows, err := d.db.Query(`
+		SELECT am.amname, opc.opcname
+		FROM pg_opclass opc
+		JOIN pg_am am ON am.oid = opc.opcmethod
+		WHERE opc.opcdefault
+	`)
+	if err != nil {
+		slog.Debug("Failed to get default operator classes", "error", err)
+		return
+	}
+	defer rows.Close()
+	opclasses := map[string]bool{}
+	for rows.Next() {
+		var accessMethod, opclass string
+		if err := rows.Scan(&accessMethod, &opclass); err != nil {
+			slog.Debug("Failed to scan default operator classes", "error", err)
+			return
+		}
+		opclasses[strings.ToLower(accessMethod)+"."+strings.ToLower(opclass)] = true
+	}
+	clear(d.defaultOpclasses)
+	maps.Copy(d.defaultOpclasses, opclasses)
 }
 
 func (d *PostgresDatabase) GetGeneratorConfig() database.GeneratorConfig {
@@ -92,6 +135,10 @@ func (d *PostgresDatabase) GetConfig() database.Config {
 }
 
 func (d *PostgresDatabase) ExportDDLs() (string, error) {
+	// The generator compares the exported DDLs right after this, so the catalog is read here to
+	// pick up operator classes registered since the generator config was built.
+	d.refreshDefaultOperatorClasses()
+
 	var ddls []string
 
 	schemaDDLs, err := d.schemas()

--- a/schema/ast.go
+++ b/schema/ast.go
@@ -279,6 +279,18 @@ type Index struct {
 	renamedFrom       Ident // Previous index name if renamed via @renamed annotation
 }
 
+// AccessMethod returns the index access method, e.g. "btree" or "gin". A DDL without a USING
+// clause leaves indexType holding the kind of the index instead, which means the default method.
+func (i Index) AccessMethod() string {
+	indexType := strings.ToLower(i.indexType)
+	switch indexType {
+	case "", "index", "key", "primary key", "unique":
+		return "btree"
+	default:
+		return indexType
+	}
+}
+
 type IndexColumn struct {
 	columnExpr    parser.Expr // never nil as it's always initialized in the parser
 	length        *int

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -5791,6 +5791,28 @@ func (g *Generator) areSamePrimaryKeyColumns(indexA Index, indexB Index) bool {
 	return true
 }
 
+// areSameOperatorClasses reports whether two index columns use the same operator class.
+// Operator classes are unquoted identifiers, so they're compared case-insensitively. The database
+// omits the default operator class from the DDL it exports, so a default written explicitly in the
+// desired DDL has to compare equal to an omitted one.
+func (g *Generator) areSameOperatorClasses(indexA Index, indexB Index, columnIndex int) bool {
+	operatorClassA := indexA.columns[columnIndex].operatorClass
+	operatorClassB := indexB.columns[columnIndex].operatorClass
+	if strings.EqualFold(operatorClassA, operatorClassB) {
+		return true
+	}
+	if operatorClassA != "" && operatorClassB != "" {
+		return false
+	}
+	// Exactly one side specifies an operator class here. It matches the omitted one only if the
+	// access method defaults to it.
+	specified, index := operatorClassA, indexA
+	if specified == "" {
+		specified, index = operatorClassB, indexB
+	}
+	return g.config.PostgresDefaultOperatorClasses[index.AccessMethod()+"."+strings.ToLower(specified)]
+}
+
 func (g *Generator) areSameIndexes(indexA Index, indexB Index) bool {
 	if indexA.unique != indexB.unique {
 		return false
@@ -5820,6 +5842,9 @@ func (g *Generator) areSameIndexes(indexA Index, indexB Index) bool {
 			return false
 		}
 		if indexA.columns[i].withoutOverlaps != indexB.columns[i].withoutOverlaps {
+			return false
+		}
+		if !g.areSameOperatorClasses(indexA, indexB, i) {
 			return false
 		}
 	}

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -410,6 +410,7 @@ func (l *stringLogger) String() string {
 // This mimics the behavior of running psqldef/mysqldef/etc from the command line
 func ApplyWithOutput(db database.Database, mode schema.GeneratorMode, sqlParser database.Parser, desiredDDLs string, config database.GeneratorConfig) (string, error) {
 	db.SetGeneratorConfig(config)
+	config = db.GetGeneratorConfig()
 
 	currentDDLs, err := db.ExportDDLs()
 	if err != nil {


### PR DESCRIPTION
This depends on #1286; ~the actual changes are 700376b5d4620cacd48dfcfd5fb07e5893c1d5e3~

---

areSameIndexes() never compared operatorClass, so adding, removing or changing an operator class on an index produced no DDL at all.

Comparing it naively regresses the opposite case: pg_get_indexdef() omits the default operator class from its output, so one written explicitly in the desired DDL (e.g. `name text_ops`) would never match the exported one and the index would be dropped and recreated on every run. Telling a default apart from a non-default one needs pg_opclass, which the schema package must not read, so PostgresDatabase passes the defaults through GeneratorConfig, the same way MySQL passes lower_case_table_names.

Every GeneratorConfig copy shares one map that ExportDDLs() refills, rather than a snapshot taken up front, because the schema being applied may install an extension that registers operator classes of its own -- pgvector's ivfflat defaults to vector_l2_ops, for instance.

ApplyWithOutput() did not read the config back after SetGeneratorConfig() even though it mimics the CLI, which also kept MysqlLowerCaseTableNames from reaching the generator in that path.