### PR TITLE
psqldef: emit the operator class before ASC/DESC on index columns

### DIFF
--- a/cmd/psqldef/tests_indices.yml
+++ b/cmd/psqldef/tests_indices.yml
@@ -231,6 +231,33 @@ AddNonDefaultOperatorClassOfSameAccessMethod:
     DROP INDEX public.idx_tags;
     CREATE INDEX idx_tags ON public.products USING gin (tags jsonb_ops);
 
+IndexWithOperatorClassAndDirection:
+  legacy_ignore_quotes: false
+  desired: |
+    CREATE TABLE products (a TEXT, b TEXT);
+    CREATE INDEX idx_ab ON products USING btree ((a || b) text_pattern_ops DESC);
+
+IndexWithOperatorClassAndDirectionOnColumn:
+  legacy_ignore_quotes: false
+  desired: |
+    CREATE TABLE products (name TEXT);
+    CREATE INDEX idx_name ON products USING btree (name text_pattern_ops DESC);
+
+AddOperatorClassToDescendingIndex:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TABLE products (name TEXT);
+    CREATE INDEX idx_name ON products USING btree (name DESC);
+  desired: |
+    CREATE TABLE products (name TEXT);
+    CREATE INDEX idx_name ON products USING btree (name text_pattern_ops DESC);
+  up: |
+    DROP INDEX public.idx_name;
+    CREATE INDEX idx_name ON public.products USING btree (name text_pattern_ops desc);
+  down: |
+    DROP INDEX public.idx_name;
+    CREATE INDEX idx_name ON public.products USING btree (name desc);
+
 RenameIndex:
   current: |
     CREATE TABLE users (

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -3279,42 +3279,44 @@ func (g *Generator) indexKeyPartNeedsParens(expr parser.Expr) bool {
 	return indexExprNeedsParens(expr)
 }
 
+// generateIndexColumnDefinition generates one key part of an index column list, with proper quoting.
+// The clauses have to keep this order: PostgreSQL accepts an operator class only before ASC/DESC.
+func (g *Generator) generateIndexColumnDefinition(indexColumn IndexColumn) string {
+	var column string
+	// For simple column references (ColName), use escapeSQLIdent to preserve quoting
+	if colName, ok := indexColumn.columnExpr.(*parser.ColName); ok {
+		column = g.escapeSQLIdent(colName.Name)
+	} else {
+		// For expressions (functional indexes), format with quote awareness
+		if !g.config.LegacyIgnoreQuotes {
+			column = g.formatExprQuoteAware(indexColumn.columnExpr)
+		} else {
+			// Legacy mode: use parser.String for backward compatibility
+			column = parser.String(indexColumn.columnExpr)
+		}
+		if g.indexKeyPartNeedsParens(indexColumn.columnExpr) {
+			column = "(" + column + ")"
+		}
+	}
+	if indexColumn.length != nil {
+		column += fmt.Sprintf("(%d)", *indexColumn.length)
+	}
+	if indexColumn.operatorClass != "" {
+		column += " " + indexColumn.operatorClass
+	}
+	if indexColumn.direction == DescScr {
+		column += fmt.Sprintf(" %s", indexColumn.direction)
+	}
+	if indexColumn.withoutOverlaps {
+		column += " WITHOUT OVERLAPS"
+	}
+	return column
+}
+
 // generateCreateIndexStatement generates a CREATE INDEX statement from an Index struct.
 // This is used to regenerate CREATE INDEX statements with proper schema-qualified table names.
 func (g *Generator) generateCreateIndexStatement(table QualifiedName, index Index) string {
-	// Build column list with proper quoting
-	columns := []string{}
-	for _, indexColumn := range index.columns {
-		var column string
-		// For simple column references (ColName), use escapeSQLIdent to preserve quoting
-		if colName, ok := indexColumn.columnExpr.(*parser.ColName); ok {
-			column = g.escapeSQLIdent(colName.Name)
-		} else {
-			// For expressions (functional indexes), format with quote awareness
-			if !g.config.LegacyIgnoreQuotes {
-				column = g.formatExprQuoteAware(indexColumn.columnExpr)
-			} else {
-				// Legacy mode: use parser.String for backward compatibility
-				column = parser.String(indexColumn.columnExpr)
-			}
-			if g.indexKeyPartNeedsParens(indexColumn.columnExpr) {
-				column = "(" + column + ")"
-			}
-		}
-		if indexColumn.length != nil {
-			column += fmt.Sprintf("(%d)", *indexColumn.length)
-		}
-		if indexColumn.direction == DescScr {
-			column += fmt.Sprintf(" %s", indexColumn.direction)
-		}
-		if indexColumn.operatorClass != "" {
-			column += " " + indexColumn.operatorClass
-		}
-		if indexColumn.withoutOverlaps {
-			column += " WITHOUT OVERLAPS"
-		}
-		columns = append(columns, column)
-	}
+	columns := util.TransformSlice(index.columns, g.generateIndexColumnDefinition)
 
 	// Start building the statement
 	// PostgreSQL syntax: CREATE [UNIQUE] INDEX [CONCURRENTLY] name ON table
@@ -3384,38 +3386,7 @@ func (g *Generator) generateAddIndex(table QualifiedName, index Index) string {
 		clusteredOption = " NONCLUSTERED"
 	}
 
-	columns := []string{}
-	for _, indexColumn := range index.columns {
-		var column string
-		// For simple column references (ColName), use escapeSQLIdent to preserve quoting
-		if colName, ok := indexColumn.columnExpr.(*parser.ColName); ok {
-			column = g.escapeSQLIdent(colName.Name)
-		} else {
-			// For expressions (functional indexes), format with quote awareness
-			if !g.config.LegacyIgnoreQuotes {
-				column = g.formatExprQuoteAware(indexColumn.columnExpr)
-			} else {
-				// Legacy mode: use parser.String for backward compatibility
-				column = parser.String(indexColumn.columnExpr)
-			}
-			if g.indexKeyPartNeedsParens(indexColumn.columnExpr) {
-				column = "(" + column + ")"
-			}
-		}
-		if indexColumn.length != nil {
-			column += fmt.Sprintf("(%d)", *indexColumn.length)
-		}
-		if indexColumn.direction == DescScr {
-			column += fmt.Sprintf(" %s", indexColumn.direction)
-		}
-		if indexColumn.operatorClass != "" {
-			column += " " + indexColumn.operatorClass
-		}
-		if indexColumn.withoutOverlaps {
-			column += " WITHOUT OVERLAPS"
-		}
-		columns = append(columns, column)
-	}
+	columns := util.TransformSlice(index.columns, g.generateIndexColumnDefinition)
 
 	optionDefinition := g.generateIndexOptionDefinition(index.options)
 


### PR DESCRIPTION
This depends on #1287; the actual changes are f4c4eadc7f6686e756f9c1b4272b92521c56aa32

---

PostgreSQL accepts an index key part as `expr [opclass] [ASC|DESC]`, but the generator emitted the direction first, producing SQL that the server rejects, e.g. `CREATE INDEX ... ((a || b) desc text_pattern_ops)`.

The two call sites rendered the column list with byte-identical code, so extract generateIndexColumnDefinition() and fix the order once.