### PR TITLE
psqldef: Fix unnamed composite unique names

### DIFF
--- a/cmd/psqldef/tests_constraints.yml
+++ b/cmd/psqldef/tests_constraints.yml
@@ -920,11 +920,24 @@ ConstraintCheckInMultipleColumnsWithUnique:
   up: |
     ALTER TABLE "public"."orders" ADD CONSTRAINT "orders_priority_check" CHECK (priority = ANY (ARRAY[1, 2, 3]));
     ALTER TABLE "public"."orders" ADD CONSTRAINT "orders_category_check" CHECK (category = ANY (ARRAY[10, 20, 30, 40]));
-    ALTER TABLE "public"."orders" ADD CONSTRAINT "priority" UNIQUE ("priority", "category");
+    ALTER TABLE "public"."orders" ADD CONSTRAINT "orders_priority_category_key" UNIQUE ("priority", "category");
   down: |
     ALTER TABLE "public"."orders" DROP CONSTRAINT "orders_priority_check";
     ALTER TABLE "public"."orders" DROP CONSTRAINT "orders_category_check";
-    ALTER TABLE "public"."orders" DROP CONSTRAINT "priority";
+    ALTER TABLE "public"."orders" DROP CONSTRAINT "orders_priority_category_key";
+UnnamedCompositeUniqueConstraints:
+  legacy_ignore_quotes: false
+  desired: |
+    CREATE TABLE t2 (
+      a integer,
+      b integer,
+      UNIQUE (a, b)
+    );
+    CREATE TABLE t3 (
+      a integer,
+      c integer,
+      UNIQUE (a, c)
+    );
 CreateTableWithCheckConstraints:
   current: |
     CREATE TABLE "public"."domains" (

--- a/schema/parser.go
+++ b/schema/parser.go
@@ -602,12 +602,13 @@ func parseTable(mode GeneratorMode, stmt *parser.DDL, defaultSchema string, rawD
 			if tableName == "" {
 				tableName = stmt.NewName.Name.Name
 			}
-			columnName := indexColumns[0].ColumnName()
-
-			if mode == GeneratorModePostgres && indexDef.Info.Unique && len(indexColumns) == 1 {
-				nameIdent = buildPostgresConstraintNameIdent(tableName, columnName, "key")
+			if mode == GeneratorModePostgres && indexDef.Info.Unique {
+				columnNames := util.TransformSlice(indexColumns, func(column IndexColumn) string {
+					return column.ColumnName()
+				})
+				nameIdent = buildPostgresConstraintNameIdent(tableName, strings.Join(columnNames, "_"), "key")
 			} else {
-				// For MySQL or multi-column constraints, use just the column name
+				columnName := indexColumns[0].ColumnName()
 				// Auto-generated names are unquoted
 				nameIdent.Name = columnName
 				nameIdent.Quoted = false


### PR DESCRIPTION
## Summary

- Normalize unnamed PostgreSQL composite `UNIQUE` constraints using every target column in declaration order
- Reuse the existing PostgreSQL identifier quoting and 63-byte truncation behavior
- Update the existing composite constraint DDL expectations and add an idempotency regression test

## Background

PostgreSQL derives the default name of an unnamed composite unique constraint from all constrained columns, such as `orders_priority_category_key`. sqldef only applied the PostgreSQL naming convention to single-column unique constraints and fell back to the first column name for composite constraints.

As a result, the desired schema and the schema exported after application used different constraint names, which could produce unnecessary `ADD CONSTRAINT` and `DROP CONSTRAINT` statements on subsequent runs.

This fixes the behavior described in Discussion #1290.

## Impact

Unnamed PostgreSQL composite unique constraints now remain idempotent after they are applied. Explicitly named constraints and the MySQL, SQLite, and SQL Server naming paths are unchanged.

## Validation

- Targeted PostgreSQL integration tests with `PSQLDEF_PARSER=generic`
- `make format`
- `make build`
- `make test-all-flavors`
- `make lint`
