### PR TITLE
psqldef: fix non-idempotent IN (...) in CHECK constraints and partial indexes

### DIFF
--- a/cmd/psqldef/tests_constraints.yml
+++ b/cmd/psqldef/tests_constraints.yml
@@ -858,17 +858,17 @@ ConstraintCheckInQuoteAware:
   current: |
     CREATE TABLE products (
       id serial,
-      status text
+      "Status" text
     );
   desired: |
     CREATE TABLE products (
       id serial,
-      status text CHECK (status IN ('active', 'inactive', 'pending'))
+      "Status" text CHECK ("Status" IN ('active', 'inactive', 'pending'))
     );
   up: |
-    ALTER TABLE public.products ADD CONSTRAINT products_status_check CHECK (status = ANY (ARRAY['active', 'inactive', 'pending']));
+    ALTER TABLE public.products ADD CONSTRAINT "products_Status_check" CHECK ("Status" = ANY (ARRAY['active', 'inactive', 'pending']));
   down: |
-    ALTER TABLE public.products DROP CONSTRAINT products_status_check;
+    ALTER TABLE public.products DROP CONSTRAINT "products_Status_check";
 ConstraintCheckInRemove:
   current: |
     CREATE TABLE products (

--- a/cmd/psqldef/tests_constraints.yml
+++ b/cmd/psqldef/tests_constraints.yml
@@ -811,6 +811,22 @@ ConstraintCheckInUnsorted:
       status text CHECK (status IN ('pending', 'active'))
     );
 
+ConstraintCheckInSingleValue:
+  legacy_ignore_quotes: false
+  desired: |
+    CREATE TABLE products (
+      id serial,
+      status text CHECK (status IN ('pending'))
+    );
+
+ConstraintCheckNotInSingleValue:
+  legacy_ignore_quotes: false
+  desired: |
+    CREATE TABLE products (
+      id serial,
+      status text CHECK (status NOT IN ('pending'))
+    );
+
 ConstraintCheckNotInUnsorted:
   legacy_ignore_quotes: false
   desired: |
@@ -1497,10 +1513,10 @@ ModifyTableLevelCheckMultiColumnAllAny:
     );
   up: |
     ALTER TABLE "public"."multi_check_test" DROP CONSTRAINT "valid_state_priority";
-    ALTER TABLE "public"."multi_check_test" ADD CONSTRAINT "valid_state_priority" CHECK (state = ANY (ARRAY['active', 'pending', 'waiting']) and priority >= ALL (ARRAY[1, 2]) or state = ALL (ARRAY['inactive']) and priority = ANY (ARRAY[0]));
+    ALTER TABLE "public"."multi_check_test" ADD CONSTRAINT "valid_state_priority" CHECK (state = ANY (ARRAY['active', 'pending', 'waiting']) and priority >= ALL (ARRAY[1, 2]) or state = 'inactive' and priority = 0);
   down: |
     ALTER TABLE "public"."multi_check_test" DROP CONSTRAINT "valid_state_priority";
-    ALTER TABLE "public"."multi_check_test" ADD CONSTRAINT "valid_state_priority" CHECK (state = ANY (ARRAY['active', 'pending']) and priority >= ALL (ARRAY[1, 2]) or state = ALL (ARRAY['inactive']) and priority = ANY (ARRAY[0]));
+    ALTER TABLE "public"."multi_check_test" ADD CONSTRAINT "valid_state_priority" CHECK (state = ANY (ARRAY['active', 'pending']) and priority >= ALL (ARRAY[1, 2]) or state = 'inactive' and priority = 0);
 CheckConstraintWithTypeCastInArray:
   desired: |
     CREATE TABLE test_check_typecast (

--- a/cmd/psqldef/tests_constraints.yml
+++ b/cmd/psqldef/tests_constraints.yml
@@ -104,10 +104,10 @@ AllAnySomeCheckConstraintsModifySome:
     );
   up: |
     ALTER TABLE "public"."test_all_any" DROP CONSTRAINT "test_all_any_some_text_check";
-    ALTER TABLE "public"."test_all_any" ADD CONSTRAINT "test_all_any_some_text_check" CHECK (some_text = ANY (ARRAY['changed', 'modified', 'updated']));
+    ALTER TABLE "public"."test_all_any" ADD CONSTRAINT "test_all_any_some_text_check" CHECK (some_text = ANY (ARRAY['updated', 'modified', 'changed']));
   down: |
     ALTER TABLE "public"."test_all_any" DROP CONSTRAINT "test_all_any_some_text_check";
-    ALTER TABLE "public"."test_all_any" ADD CONSTRAINT "test_all_any_some_text_check" CHECK (some_text = ANY (ARRAY['allowed', 'valid']));
+    ALTER TABLE "public"."test_all_any" ADD CONSTRAINT "test_all_any_some_text_check" CHECK (some_text = ANY (ARRAY['valid', 'allowed']));
 AllAnySomeCheckConstraintsRemove:
   current: |
     CREATE TABLE test_all_any (
@@ -133,7 +133,7 @@ AllAnySomeCheckConstraintsRemove:
   down: |
     ALTER TABLE "public"."test_all_any" ADD CONSTRAINT "test_all_any_state_check" CHECK (state = ANY (ARRAY['active', 'pending']));
     ALTER TABLE "public"."test_all_any" ADD CONSTRAINT "test_all_any_all_positive_check" CHECK (all_positive = ALL (ARRAY[2, 3, 4]));
-    ALTER TABLE "public"."test_all_any" ADD CONSTRAINT "test_all_any_some_text_check" CHECK (some_text = ANY (ARRAY['changed', 'modified', 'updated']));
+    ALTER TABLE "public"."test_all_any" ADD CONSTRAINT "test_all_any_some_text_check" CHECK (some_text = ANY (ARRAY['updated', 'modified', 'changed']));
     ALTER TABLE "public"."test_all_any" ADD CONSTRAINT "test_all_any_score_check" CHECK (score > ALL (ARRAY[0, 10, 20]));
 SomeConstraintModificationsCreate:
   desired: |
@@ -157,12 +157,12 @@ SomeConstraintModificationsModify:
     );
   up: |
     ALTER TABLE "public"."test_some_modify" DROP CONSTRAINT "test_some_modify_status_check";
-    ALTER TABLE "public"."test_some_modify" ADD CONSTRAINT "test_some_modify_status_check" CHECK (status = ANY (ARRAY['active', 'archived', 'completed']));
+    ALTER TABLE "public"."test_some_modify" ADD CONSTRAINT "test_some_modify_status_check" CHECK (status = ANY (ARRAY['active', 'completed', 'archived']));
     ALTER TABLE "public"."test_some_modify" DROP CONSTRAINT "test_some_modify_category_check";
     ALTER TABLE "public"."test_some_modify" ADD CONSTRAINT "test_some_modify_category_check" CHECK (category = ANY (ARRAY['X', 'Y', 'Z']));
   down: |
     ALTER TABLE "public"."test_some_modify" DROP CONSTRAINT "test_some_modify_status_check";
-    ALTER TABLE "public"."test_some_modify" ADD CONSTRAINT "test_some_modify_status_check" CHECK (status = ANY (ARRAY['active', 'draft', 'pending']));
+    ALTER TABLE "public"."test_some_modify" ADD CONSTRAINT "test_some_modify_status_check" CHECK (status = ANY (ARRAY['active', 'pending', 'draft']));
     ALTER TABLE "public"."test_some_modify" DROP CONSTRAINT "test_some_modify_category_check";
     ALTER TABLE "public"."test_some_modify" ADD CONSTRAINT "test_some_modify_category_check" CHECK (category = ANY (ARRAY['A', 'B', 'C']));
 SomeConstraintModificationsSomeToAny:
@@ -193,12 +193,12 @@ SomeConstraintModificationsSomeToAll:
     );
   up: |
     ALTER TABLE "public"."test_some_modify" DROP CONSTRAINT "test_some_modify_status_check";
-    ALTER TABLE "public"."test_some_modify" ADD CONSTRAINT "test_some_modify_status_check" CHECK (status = ALL (ARRAY['active', 'archived', 'completed']));
+    ALTER TABLE "public"."test_some_modify" ADD CONSTRAINT "test_some_modify_status_check" CHECK (status = ALL (ARRAY['active', 'completed', 'archived']));
     ALTER TABLE "public"."test_some_modify" DROP CONSTRAINT "test_some_modify_category_check";
     ALTER TABLE "public"."test_some_modify" ADD CONSTRAINT "test_some_modify_category_check" CHECK (category = ALL (ARRAY['X', 'Y', 'Z']));
   down: |
     ALTER TABLE "public"."test_some_modify" DROP CONSTRAINT "test_some_modify_status_check";
-    ALTER TABLE "public"."test_some_modify" ADD CONSTRAINT "test_some_modify_status_check" CHECK (status = ANY (ARRAY['active', 'archived', 'completed']));
+    ALTER TABLE "public"."test_some_modify" ADD CONSTRAINT "test_some_modify_status_check" CHECK (status = ANY (ARRAY['active', 'completed', 'archived']));
     ALTER TABLE "public"."test_some_modify" DROP CONSTRAINT "test_some_modify_category_check";
     ALTER TABLE "public"."test_some_modify" ADD CONSTRAINT "test_some_modify_category_check" CHECK (category = ANY (ARRAY['X', 'Y', 'Z']));
 PosixRegexCheckConstraint:
@@ -849,10 +849,10 @@ ConstraintCheckInUnsortedModify:
     );
   up: |
     ALTER TABLE public.products DROP CONSTRAINT products_status_check;
-    ALTER TABLE public.products ADD CONSTRAINT products_status_check CHECK (status = ANY (ARRAY['active', 'pending', 'waiting']));
+    ALTER TABLE public.products ADD CONSTRAINT products_status_check CHECK (status = ANY (ARRAY['pending', 'active', 'waiting']));
   down: |
     ALTER TABLE public.products DROP CONSTRAINT products_status_check;
-    ALTER TABLE public.products ADD CONSTRAINT products_status_check CHECK (status = ANY (ARRAY['active', 'pending']));
+    ALTER TABLE public.products ADD CONSTRAINT products_status_check CHECK (status = ANY (ARRAY['pending', 'active']));
 ConstraintCheckInQuoteAware:
   legacy_ignore_quotes: false
   current: |
@@ -1513,10 +1513,10 @@ ModifyTableLevelCheckMultiColumnAllAny:
     );
   up: |
     ALTER TABLE "public"."multi_check_test" DROP CONSTRAINT "valid_state_priority";
-    ALTER TABLE "public"."multi_check_test" ADD CONSTRAINT "valid_state_priority" CHECK (state = ANY (ARRAY['active', 'pending', 'waiting']) and priority >= ALL (ARRAY[1, 2]) or state = 'inactive' and priority = 0);
+    ALTER TABLE "public"."multi_check_test" ADD CONSTRAINT "valid_state_priority" CHECK (state = ANY (ARRAY['active', 'pending', 'waiting']) and priority >= ALL (ARRAY[1, 2]) or state = ALL (ARRAY['inactive']) and priority = ANY (ARRAY[0]));
   down: |
     ALTER TABLE "public"."multi_check_test" DROP CONSTRAINT "valid_state_priority";
-    ALTER TABLE "public"."multi_check_test" ADD CONSTRAINT "valid_state_priority" CHECK (state = ANY (ARRAY['active', 'pending']) and priority >= ALL (ARRAY[1, 2]) or state = 'inactive' and priority = 0);
+    ALTER TABLE "public"."multi_check_test" ADD CONSTRAINT "valid_state_priority" CHECK (state = ANY (ARRAY['active', 'pending']) and priority >= ALL (ARRAY[1, 2]) or state = ALL (ARRAY['inactive']) and priority = ANY (ARRAY[0]));
 CheckConstraintWithTypeCastInArray:
   desired: |
     CREATE TABLE test_check_typecast (

--- a/cmd/psqldef/tests_constraints.yml
+++ b/cmd/psqldef/tests_constraints.yml
@@ -811,6 +811,22 @@ ConstraintCheckInUnsorted:
       status text CHECK (status IN ('pending', 'active'))
     );
 
+ConstraintCheckNotInAdd:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TABLE products (
+      id serial,
+      status text
+    );
+  desired: |
+    CREATE TABLE products (
+      id serial,
+      status text CHECK (status NOT IN ('deleted', 'cancelled'))
+    );
+  up: |
+    ALTER TABLE public.products ADD CONSTRAINT products_status_check CHECK (status <> ALL (ARRAY['deleted', 'cancelled']));
+  down: |
+    ALTER TABLE public.products DROP CONSTRAINT products_status_check;
 ConstraintCheckInSingleValue:
   legacy_ignore_quotes: false
   desired: |

--- a/cmd/psqldef/tests_constraints.yml
+++ b/cmd/psqldef/tests_constraints.yml
@@ -104,10 +104,10 @@ AllAnySomeCheckConstraintsModifySome:
     );
   up: |
     ALTER TABLE "public"."test_all_any" DROP CONSTRAINT "test_all_any_some_text_check";
-    ALTER TABLE "public"."test_all_any" ADD CONSTRAINT "test_all_any_some_text_check" CHECK (some_text = ANY (ARRAY['updated', 'modified', 'changed']));
+    ALTER TABLE "public"."test_all_any" ADD CONSTRAINT "test_all_any_some_text_check" CHECK (some_text = ANY (ARRAY['changed', 'modified', 'updated']));
   down: |
     ALTER TABLE "public"."test_all_any" DROP CONSTRAINT "test_all_any_some_text_check";
-    ALTER TABLE "public"."test_all_any" ADD CONSTRAINT "test_all_any_some_text_check" CHECK (some_text = ANY (ARRAY['valid', 'allowed']));
+    ALTER TABLE "public"."test_all_any" ADD CONSTRAINT "test_all_any_some_text_check" CHECK (some_text = ANY (ARRAY['allowed', 'valid']));
 AllAnySomeCheckConstraintsRemove:
   current: |
     CREATE TABLE test_all_any (
@@ -133,7 +133,7 @@ AllAnySomeCheckConstraintsRemove:
   down: |
     ALTER TABLE "public"."test_all_any" ADD CONSTRAINT "test_all_any_state_check" CHECK (state = ANY (ARRAY['active', 'pending']));
     ALTER TABLE "public"."test_all_any" ADD CONSTRAINT "test_all_any_all_positive_check" CHECK (all_positive = ALL (ARRAY[2, 3, 4]));
-    ALTER TABLE "public"."test_all_any" ADD CONSTRAINT "test_all_any_some_text_check" CHECK (some_text = ANY (ARRAY['updated', 'modified', 'changed']));
+    ALTER TABLE "public"."test_all_any" ADD CONSTRAINT "test_all_any_some_text_check" CHECK (some_text = ANY (ARRAY['changed', 'modified', 'updated']));
     ALTER TABLE "public"."test_all_any" ADD CONSTRAINT "test_all_any_score_check" CHECK (score > ALL (ARRAY[0, 10, 20]));
 SomeConstraintModificationsCreate:
   desired: |
@@ -157,12 +157,12 @@ SomeConstraintModificationsModify:
     );
   up: |
     ALTER TABLE "public"."test_some_modify" DROP CONSTRAINT "test_some_modify_status_check";
-    ALTER TABLE "public"."test_some_modify" ADD CONSTRAINT "test_some_modify_status_check" CHECK (status = ANY (ARRAY['active', 'completed', 'archived']));
+    ALTER TABLE "public"."test_some_modify" ADD CONSTRAINT "test_some_modify_status_check" CHECK (status = ANY (ARRAY['active', 'archived', 'completed']));
     ALTER TABLE "public"."test_some_modify" DROP CONSTRAINT "test_some_modify_category_check";
     ALTER TABLE "public"."test_some_modify" ADD CONSTRAINT "test_some_modify_category_check" CHECK (category = ANY (ARRAY['X', 'Y', 'Z']));
   down: |
     ALTER TABLE "public"."test_some_modify" DROP CONSTRAINT "test_some_modify_status_check";
-    ALTER TABLE "public"."test_some_modify" ADD CONSTRAINT "test_some_modify_status_check" CHECK (status = ANY (ARRAY['active', 'pending', 'draft']));
+    ALTER TABLE "public"."test_some_modify" ADD CONSTRAINT "test_some_modify_status_check" CHECK (status = ANY (ARRAY['active', 'draft', 'pending']));
     ALTER TABLE "public"."test_some_modify" DROP CONSTRAINT "test_some_modify_category_check";
     ALTER TABLE "public"."test_some_modify" ADD CONSTRAINT "test_some_modify_category_check" CHECK (category = ANY (ARRAY['A', 'B', 'C']));
 SomeConstraintModificationsSomeToAny:
@@ -193,12 +193,12 @@ SomeConstraintModificationsSomeToAll:
     );
   up: |
     ALTER TABLE "public"."test_some_modify" DROP CONSTRAINT "test_some_modify_status_check";
-    ALTER TABLE "public"."test_some_modify" ADD CONSTRAINT "test_some_modify_status_check" CHECK (status = ALL (ARRAY['active', 'completed', 'archived']));
+    ALTER TABLE "public"."test_some_modify" ADD CONSTRAINT "test_some_modify_status_check" CHECK (status = ALL (ARRAY['active', 'archived', 'completed']));
     ALTER TABLE "public"."test_some_modify" DROP CONSTRAINT "test_some_modify_category_check";
     ALTER TABLE "public"."test_some_modify" ADD CONSTRAINT "test_some_modify_category_check" CHECK (category = ALL (ARRAY['X', 'Y', 'Z']));
   down: |
     ALTER TABLE "public"."test_some_modify" DROP CONSTRAINT "test_some_modify_status_check";
-    ALTER TABLE "public"."test_some_modify" ADD CONSTRAINT "test_some_modify_status_check" CHECK (status = ANY (ARRAY['active', 'completed', 'archived']));
+    ALTER TABLE "public"."test_some_modify" ADD CONSTRAINT "test_some_modify_status_check" CHECK (status = ANY (ARRAY['active', 'archived', 'completed']));
     ALTER TABLE "public"."test_some_modify" DROP CONSTRAINT "test_some_modify_category_check";
     ALTER TABLE "public"."test_some_modify" ADD CONSTRAINT "test_some_modify_category_check" CHECK (category = ANY (ARRAY['X', 'Y', 'Z']));
 PosixRegexCheckConstraint:
@@ -803,6 +803,32 @@ ConstraintCheckInAdd:
     ALTER TABLE "public"."products" ADD CONSTRAINT "products_status_check" CHECK (status = ANY (ARRAY['active', 'inactive', 'pending']));
   down: |
     ALTER TABLE "public"."products" DROP CONSTRAINT "products_status_check";
+ConstraintCheckInUnsorted:
+  legacy_ignore_quotes: false
+  desired: |
+    CREATE TABLE products (
+      id serial,
+      status text CHECK (status IN ('pending', 'active'))
+    );
+
+ConstraintCheckInUnsortedModify:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TABLE products (
+      id serial,
+      status text CHECK (status IN ('pending', 'active'))
+    );
+  desired: |
+    CREATE TABLE products (
+      id serial,
+      status text CHECK (status IN ('pending', 'active', 'waiting'))
+    );
+  up: |
+    ALTER TABLE public.products DROP CONSTRAINT products_status_check;
+    ALTER TABLE public.products ADD CONSTRAINT products_status_check CHECK (status = ANY (ARRAY['active', 'pending', 'waiting']));
+  down: |
+    ALTER TABLE public.products DROP CONSTRAINT products_status_check;
+    ALTER TABLE public.products ADD CONSTRAINT products_status_check CHECK (status = ANY (ARRAY['active', 'pending']));
 ConstraintCheckInQuoteAware:
   legacy_ignore_quotes: false
   current: |

--- a/cmd/psqldef/tests_constraints.yml
+++ b/cmd/psqldef/tests_constraints.yml
@@ -803,6 +803,22 @@ ConstraintCheckInAdd:
     ALTER TABLE "public"."products" ADD CONSTRAINT "products_status_check" CHECK (status = ANY (ARRAY['active', 'inactive', 'pending']));
   down: |
     ALTER TABLE "public"."products" DROP CONSTRAINT "products_status_check";
+ConstraintCheckInQuoteAware:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TABLE products (
+      id serial,
+      status text
+    );
+  desired: |
+    CREATE TABLE products (
+      id serial,
+      status text CHECK (status IN ('active', 'inactive', 'pending'))
+    );
+  up: |
+    ALTER TABLE public.products ADD CONSTRAINT products_status_check CHECK (status = ANY (ARRAY['active', 'inactive', 'pending']));
+  down: |
+    ALTER TABLE public.products DROP CONSTRAINT products_status_check;
 ConstraintCheckInRemove:
   current: |
     CREATE TABLE products (

--- a/cmd/psqldef/tests_constraints.yml
+++ b/cmd/psqldef/tests_constraints.yml
@@ -811,6 +811,14 @@ ConstraintCheckInUnsorted:
       status text CHECK (status IN ('pending', 'active'))
     );
 
+ConstraintCheckNotInUnsorted:
+  legacy_ignore_quotes: false
+  desired: |
+    CREATE TABLE products (
+      id serial,
+      status text CHECK (status NOT IN ('deleted', 'cancelled'))
+    );
+
 ConstraintCheckInUnsortedModify:
   legacy_ignore_quotes: false
   current: |

--- a/cmd/psqldef/tests_indices.yml
+++ b/cmd/psqldef/tests_indices.yml
@@ -601,6 +601,20 @@ PartialIndexWithWhereNotInUnsorted:
     CREATE INDEX idx_non_cancelled ON orders (id)
     WHERE status NOT IN ('deleted', 'cancelled');
 
+PartialIndexWithWhereInSingleValue:
+  legacy_ignore_quotes: false
+  desired: |
+    CREATE TABLE orders (id integer, status text);
+    CREATE INDEX idx_orders_pending ON orders (id)
+    WHERE status IN ('pending');
+
+PartialIndexWithWhereNotInSingleValue:
+  legacy_ignore_quotes: false
+  desired: |
+    CREATE TABLE orders (id integer, status text);
+    CREATE INDEX idx_orders_not_pending ON orders (id)
+    WHERE status NOT IN ('pending');
+
 PartialIndexWithArrayCastAnyPgDumpStyle:
   legacy_ignore_quotes: false
   desired: |

--- a/parser/node.go
+++ b/parser/node.go
@@ -2064,6 +2064,16 @@ const (
 	OverlapsStr          = "overlaps"
 )
 
+// NeedsAnyAllParens reports whether the right operand of an ALL/ANY/SOME comparison has
+// to be wrapped in parentheses. ParenExpr and Subquery already print their own.
+func NeedsAnyAllParens(right Expr) bool {
+	switch right.(type) {
+	case *ParenExpr, *Subquery:
+		return false
+	}
+	return true
+}
+
 // Format formats the node.
 func (node *ComparisonExpr) Format(buf *nodeBuffer) {
 	buf.Printf("%v %s ", node.Left, node.Operator)
@@ -2073,17 +2083,8 @@ func (node *ComparisonExpr) Format(buf *nodeBuffer) {
 		buf.Printf("ANY ")
 	}
 
-	// For ALL/ANY/SOME, wrap the right expression in parentheses if it's not already a ParenExpr or Subquery
-	if node.All || node.Any {
-		if _, isParenExpr := node.Right.(*ParenExpr); !isParenExpr {
-			if _, isSubquery := node.Right.(*Subquery); !isSubquery {
-				buf.Printf("(%v)", node.Right)
-			} else {
-				buf.Printf("%v", node.Right)
-			}
-		} else {
-			buf.Printf("%v", node.Right)
-		}
+	if (node.All || node.Any) && NeedsAnyAllParens(node.Right) {
+		buf.Printf("(%v)", node.Right)
 	} else {
 		buf.Printf("%v", node.Right)
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1670,3 +1670,37 @@ func TestForeignKeyMatchGrammar(t *testing.T) {
 		}
 	})
 }
+
+func TestAnyAllOperandParens(t *testing.T) {
+	// An ANY/ALL operand gets parentheses of its own unless it already carries them,
+	// which is the case for both node types the parser can produce here. Without the
+	// exemption these would come out double-wrapped as ANY ((...)).
+	testCases := []struct {
+		name     string
+		sql      string
+		expected string
+	}{
+		{
+			name:     "array operand is not double-wrapped",
+			sql:      "CREATE TABLE t (status text CHECK (status = ANY (ARRAY['active', 'pending'])))",
+			expected: "status = ANY(ARRAY['active', 'pending'])",
+		},
+		{
+			name:     "subquery operand is not double-wrapped",
+			sql:      "CREATE VIEW v AS SELECT a FROM t WHERE a <> ALL (SELECT b FROM u)",
+			expected: "a != ALL (select b from u)",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			stmt, err := ParseDDL(tc.sql, ParserModePostgres)
+			if err != nil {
+				t.Fatalf("parse failed: %v", err)
+			}
+			if got := String(stmt); !strings.Contains(got, tc.expected) {
+				t.Errorf("String() = %q, want it to contain %q", got, tc.expected)
+			}
+		})
+	}
+}

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -5284,21 +5284,15 @@ func (g *Generator) formatExprQuoteAware(expr parser.Expr) string {
 		return "(" + g.formatExprQuoteAware(e.Expr) + ")"
 	case *parser.ComparisonExpr:
 		result := g.formatExprQuoteAware(e.Left) + " " + e.Operator + " "
-		if !e.All && !e.Any {
-			return result + g.formatExprQuoteAware(e.Right)
-		}
-		// ANY/ALL requires its right operand to be parenthesized, and ParenExpr/Subquery
-		// already carry their own parentheses.
 		if e.All {
 			result += "ALL "
-		} else {
+		} else if e.Any {
 			result += "ANY "
 		}
-		switch e.Right.(type) {
-		case *parser.ParenExpr, *parser.Subquery:
-			return result + g.formatExprQuoteAware(e.Right)
+		if (e.All || e.Any) && parser.NeedsAnyAllParens(e.Right) {
+			return result + "(" + g.formatExprQuoteAware(e.Right) + ")"
 		}
-		return result + "(" + g.formatExprQuoteAware(e.Right) + ")"
+		return result + g.formatExprQuoteAware(e.Right)
 	case *parser.AndExpr:
 		return g.formatExprQuoteAware(e.Left) + " AND " + g.formatExprQuoteAware(e.Right)
 	case *parser.OrExpr:

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -5283,7 +5283,22 @@ func (g *Generator) formatExprQuoteAware(expr parser.Expr) string {
 	case *parser.ParenExpr:
 		return "(" + g.formatExprQuoteAware(e.Expr) + ")"
 	case *parser.ComparisonExpr:
-		return g.formatExprQuoteAware(e.Left) + " " + e.Operator + " " + g.formatExprQuoteAware(e.Right)
+		result := g.formatExprQuoteAware(e.Left) + " " + e.Operator + " "
+		if !e.All && !e.Any {
+			return result + g.formatExprQuoteAware(e.Right)
+		}
+		// ANY/ALL requires its right operand to be parenthesized, and ParenExpr/Subquery
+		// already carry their own parentheses.
+		if e.All {
+			result += "ALL "
+		} else {
+			result += "ANY "
+		}
+		switch e.Right.(type) {
+		case *parser.ParenExpr, *parser.Subquery:
+			return result + g.formatExprQuoteAware(e.Right)
+		}
+		return result + "(" + g.formatExprQuoteAware(e.Right) + ")"
 	case *parser.AndExpr:
 		return g.formatExprQuoteAware(e.Left) + " AND " + g.formatExprQuoteAware(e.Right)
 	case *parser.OrExpr:

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -5252,7 +5252,7 @@ func (g *Generator) buildForeignKeyDDL(tableName QualifiedName, fk *ForeignKey) 
 // For PostgreSQL, this converts IN (a,b,c) to = ANY (ARRAY[a,b,c])
 func (g *Generator) normalizeCheckExprString(expr parser.Expr) string {
 	if g.mode == GeneratorModePostgres {
-		normalized := normalizeCheckExpr(expr, g.mode)
+		normalized := normalizeCheckExprForOutput(expr, g.mode)
 		// Unwrap outermost parentheses for consistent output (comparison does this too)
 		normalized = unwrapOutermostParenExpr(normalized)
 		// In quote-aware mode, use formatExprQuoteAware to preserve quoting in column names

--- a/schema/normalize.go
+++ b/schema/normalize.go
@@ -423,21 +423,19 @@ func normalizeCheckExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 		if op == "in" || op == "not in" {
 			if tuple, ok := right.(parser.ValTuple); ok {
 				if mode == GeneratorModePostgres {
-					// PostgreSQL normalizes IN (values) to = ANY (ARRAY[values])
-
+					// PostgreSQL normalizes IN (values) to = ANY (ARRAY[values]) and NOT IN to <> ALL (ARRAY[values]).
 					elements := sortAndDeduplicateValues(tuple)
 					normalizedElements := util.TransformSlice(elements, func(elem parser.Expr) parser.Expr {
 						return normalizeCheckExpr(elem, mode)
 					})
 					right = &parser.ArrayConstructor{Elements: normalizedElements}
 
-					// Change operator and set ANY flag
 					if op == "in" {
 						op = "="
 						anyFlag = true
 					} else { // "not in"
-						op = "!="
-						anyFlag = true
+						op = "<>"
+						allFlag = true
 					}
 				} else {
 					// For other databases, keep IN but sort the tuple for consistent comparison

--- a/schema/normalize.go
+++ b/schema/normalize.go
@@ -450,17 +450,13 @@ func normalizeCheckExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 			}
 		}
 
-		// For ANY/ALL expressions, normalize the array elements
-		if (anyFlag || allFlag) && !e.Any && !e.All {
-			// This means we just set the flag above from IN conversion
-			// Already handled
-		} else if anyFlag || allFlag {
-			// Normalize existing ANY/ALL expressions (strip casts, preserve order)
+		// For existing ANY/ALL expressions, normalize and sort the array elements.
+		if anyFlag || allFlag {
 			if arrayConst, ok := right.(*parser.ArrayConstructor); ok {
 				normalizedElements := util.TransformSlice(arrayConst.Elements, func(elem parser.Expr) parser.Expr {
 					return normalizeCheckExpr(elem, mode)
 				})
-				right = &parser.ArrayConstructor{Elements: normalizedElements}
+				right = &parser.ArrayConstructor{Elements: sortAndDeduplicateValues(normalizedElements)}
 			}
 		}
 

--- a/schema/normalize.go
+++ b/schema/normalize.go
@@ -457,6 +457,7 @@ func normalizeCheckExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 				right = &parser.ArrayConstructor{Elements: sortAndDeduplicateValues(normalizedElements)}
 			}
 		}
+		right, anyFlag, allFlag = foldSingleElementArrayComparison(right, anyFlag, allFlag)
 
 		return &parser.ComparisonExpr{
 			Operator: op,
@@ -980,6 +981,7 @@ func normalizeExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 				right = &parser.ArrayConstructor{Elements: sortAndDeduplicateValues(normalizedElements)}
 			}
 		}
+		right, anyFlag, allFlag = foldSingleElementArrayComparison(right, anyFlag, allFlag)
 
 		return &parser.ComparisonExpr{
 			Operator: op,
@@ -1612,6 +1614,21 @@ func sortPrivilegesByCanonicalOrder(privileges []string) {
 		}
 		return 1
 	})
+}
+
+// foldSingleElementArrayComparison rewrites "x <op> ANY/ALL (ARRAY[v])" into "x <op> v".
+// PostgreSQL folds a single-element IN into a scalar comparison (IN ('a') becomes = 'a')
+// but keeps the array for an explicitly written ANY/ALL, so both spellings have to be
+// folded to compare equal. A single element makes ANY and ALL collapse to the same
+// comparison whatever the operator is, so this holds beyond = and <>.
+func foldSingleElementArrayComparison(right parser.Expr, anyFlag, allFlag bool) (parser.Expr, bool, bool) {
+	if !anyFlag && !allFlag {
+		return right, anyFlag, allFlag
+	}
+	if arrayConst, ok := right.(*parser.ArrayConstructor); ok && len(arrayConst.Elements) == 1 {
+		return arrayConst.Elements[0], false, false
+	}
+	return right, anyFlag, allFlag
 }
 
 // sortAndDeduplicateValues sorts and deduplicates a slice of expressions based on their string representation.

--- a/schema/normalize.go
+++ b/schema/normalize.go
@@ -380,93 +380,7 @@ func normalizeCheckExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 	case *parser.NotExpr:
 		return &parser.NotExpr{Expr: normalizeCheckExpr(e.Expr, mode)}
 	case *parser.ComparisonExpr:
-		left := normalizeCheckExpr(e.Left, mode)
-		right := normalizeCheckExpr(e.Right, mode)
-		op := normalizeOperator(e.Operator, mode)
-		anyFlag := e.Any
-		allFlag := e.All
-
-		// The generic parser may parse "= ANY(ARRAY[...])" as a FuncExpr on the right side
-		// We need to normalize this to set the Any/All flags properly
-		if funcExpr, ok := right.(*parser.FuncExpr); ok {
-			funcName := strings.ToLower(funcExpr.Name.Name)
-			switch funcName {
-			case "any", "some":
-				// Convert "column = ANY(array)" to ComparisonExpr with Any=true
-				if len(funcExpr.Exprs) == 1 {
-					if aliased, ok := funcExpr.Exprs[0].(*parser.AliasedExpr); ok {
-						right = normalizeCheckExpr(aliased.Expr, mode)
-						anyFlag = true
-					}
-				}
-			case "all":
-				// Convert "column = ALL(array)" to ComparisonExpr with All=true
-				if len(funcExpr.Exprs) == 1 {
-					if aliased, ok := funcExpr.Exprs[0].(*parser.AliasedExpr); ok {
-						right = normalizeCheckExpr(aliased.Expr, mode)
-						allFlag = true
-					}
-				}
-			}
-		}
-
-		// Unwrap ParenExpr from right side for ANY/ALL to ensure consistent formatting
-		// The parser may create ParenExpr(ArrayConstructor) which formats as ANY(ARRAY
-		// We want to normalize to ArrayConstructor directly which formats as ANY (ARRAY
-		if anyFlag || allFlag {
-			if parenExpr, ok := right.(*parser.ParenExpr); ok {
-				right = parenExpr.Expr
-			}
-		}
-
-		// Handle IN clauses based on mode
-		if op == "in" || op == "not in" {
-			if tuple, ok := right.(parser.ValTuple); ok {
-				if mode == GeneratorModePostgres {
-					// PostgreSQL normalizes IN (values) to = ANY (ARRAY[values]) and NOT IN to <> ALL (ARRAY[values]).
-					elements := sortAndDeduplicateValues(tuple)
-					normalizedElements := util.TransformSlice(elements, func(elem parser.Expr) parser.Expr {
-						return normalizeCheckExpr(elem, mode)
-					})
-					right = &parser.ArrayConstructor{Elements: normalizedElements}
-
-					if op == "in" {
-						op = "="
-						anyFlag = true
-					} else { // "not in"
-						op = "<>"
-						allFlag = true
-					}
-				} else {
-					// For other databases, keep IN but sort the tuple for consistent comparison
-					sortedElements := sortAndDeduplicateValues(tuple)
-					normalizedElements := util.TransformSlice(sortedElements, func(elem parser.Expr) parser.Expr {
-						return normalizeCheckExpr(elem, mode)
-					})
-					right = parser.ValTuple(normalizedElements)
-				}
-			}
-		}
-
-		// For existing ANY/ALL expressions, normalize and sort the array elements.
-		if anyFlag || allFlag {
-			if arrayConst, ok := right.(*parser.ArrayConstructor); ok {
-				normalizedElements := util.TransformSlice(arrayConst.Elements, func(elem parser.Expr) parser.Expr {
-					return normalizeCheckExpr(elem, mode)
-				})
-				right = &parser.ArrayConstructor{Elements: sortAndDeduplicateValues(normalizedElements)}
-			}
-		}
-		right, anyFlag, allFlag = foldSingleElementArrayComparison(right, anyFlag, allFlag)
-
-		return &parser.ComparisonExpr{
-			Operator: op,
-			Left:     left,
-			Right:    right,
-			Escape:   normalizeCheckExpr(e.Escape, mode),
-			All:      allFlag,
-			Any:      anyFlag,
-		}
+		return normalizeComparisonExpr(e, mode, normalizeCheckExpr)
 	case *parser.BinaryExpr:
 		return &parser.BinaryExpr{
 			Operator: e.Operator,
@@ -908,89 +822,7 @@ func normalizeExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 			Expr: normalizedInner,
 		}
 	case *parser.ComparisonExpr:
-		left := normalizeExpr(e.Left, mode)
-		right := normalizeExpr(e.Right, mode)
-		op := normalizeOperator(e.Operator, mode)
-		anyFlag := e.Any
-		allFlag := e.All
-
-		// The generic parser may parse "= ANY(ARRAY[...])" as a FuncExpr on the right side.
-		// Normalize this to set the Any/All flags properly.
-		if funcExpr, ok := right.(*parser.FuncExpr); ok {
-			funcName := strings.ToLower(funcExpr.Name.Name)
-			switch funcName {
-			case "any", "some":
-				if len(funcExpr.Exprs) == 1 {
-					if aliased, ok := funcExpr.Exprs[0].(*parser.AliasedExpr); ok {
-						right = normalizeExpr(aliased.Expr, mode)
-						anyFlag = true
-					}
-				}
-			case "all":
-				if len(funcExpr.Exprs) == 1 {
-					if aliased, ok := funcExpr.Exprs[0].(*parser.AliasedExpr); ok {
-						right = normalizeExpr(aliased.Expr, mode)
-						allFlag = true
-					}
-				}
-			}
-		}
-
-		// Unwrap ParenExpr from right side for ANY/ALL to ensure consistent formatting.
-		if anyFlag || allFlag {
-			if parenExpr, ok := right.(*parser.ParenExpr); ok {
-				right = parenExpr.Expr
-			}
-		}
-
-		// Handle IN clauses based on mode.
-		if op == "in" || op == "not in" {
-			if tuple, ok := right.(parser.ValTuple); ok {
-				if mode == GeneratorModePostgres {
-					// PostgreSQL normalizes IN (values) to = ANY (ARRAY[values]) and NOT IN to <> ALL (ARRAY[values]).
-					elements := sortAndDeduplicateValues(tuple)
-					normalizedElements := util.TransformSlice(elements, func(elem parser.Expr) parser.Expr {
-						return normalizeExpr(elem, mode)
-					})
-					right = &parser.ArrayConstructor{Elements: normalizedElements}
-					if op == "in" {
-						op = "="
-						anyFlag = true
-					} else {
-						// PostgreSQL normalizes NOT IN (values) to <> ALL (ARRAY[values]).
-						op = "<>"
-						allFlag = true
-					}
-				} else {
-					// For other databases, keep IN but sort the tuple for consistent comparison.
-					sortedElements := sortAndDeduplicateValues(tuple)
-					normalizedElements := util.TransformSlice(sortedElements, func(elem parser.Expr) parser.Expr {
-						return normalizeExpr(elem, mode)
-					})
-					right = parser.ValTuple(normalizedElements)
-				}
-			}
-		}
-
-		// For existing ANY/ALL expressions, normalize and sort the array elements.
-		if anyFlag || allFlag {
-			if arrayConst, ok := right.(*parser.ArrayConstructor); ok {
-				normalizedElements := util.TransformSlice(arrayConst.Elements, func(elem parser.Expr) parser.Expr {
-					return normalizeExpr(elem, mode)
-				})
-				right = &parser.ArrayConstructor{Elements: sortAndDeduplicateValues(normalizedElements)}
-			}
-		}
-		right, anyFlag, allFlag = foldSingleElementArrayComparison(right, anyFlag, allFlag)
-
-		return &parser.ComparisonExpr{
-			Operator: op,
-			Left:     left,
-			Right:    right,
-			Escape:   normalizeExpr(e.Escape, mode),
-			All:      allFlag,
-			Any:      anyFlag,
-		}
+		return normalizeComparisonExpr(e, mode, normalizeExpr)
 	case *parser.AndExpr:
 		return &parser.AndExpr{
 			Left:  normalizeExpr(e.Left, mode),
@@ -1616,19 +1448,105 @@ func sortPrivilegesByCanonicalOrder(privileges []string) {
 	})
 }
 
-// foldSingleElementArrayComparison rewrites "x <op> ANY/ALL (ARRAY[v])" into "x <op> v".
-// PostgreSQL folds a single-element IN into a scalar comparison (IN ('a') becomes = 'a')
-// but keeps the array for an explicitly written ANY/ALL, so both spellings have to be
-// folded to compare equal. A single element makes ANY and ALL collapse to the same
-// comparison whatever the operator is, so this holds beyond = and <>.
-func foldSingleElementArrayComparison(right parser.Expr, anyFlag, allFlag bool) (parser.Expr, bool, bool) {
-	if !anyFlag && !allFlag {
-		return right, anyFlag, allFlag
+// normalizeComparisonExpr normalizes a comparison towards the form PostgreSQL stores:
+// IN becomes = ANY (ARRAY[...]), NOT IN becomes <> ALL (ARRAY[...]), ANY/ALL array
+// elements are sorted and deduplicated, and a single-element array collapses to a
+// scalar comparison. Other modes keep IN but sort its values.
+//
+// recur is the caller's own normalizer: CHECK constraints and value expressions share
+// this comparison handling but normalize their operands differently. Keeping it in one
+// place is deliberate — the two used to carry copies of this logic, and fixes to one
+// repeatedly failed to reach the other (see #1182).
+func normalizeComparisonExpr(e *parser.ComparisonExpr, mode GeneratorMode, recur func(parser.Expr, GeneratorMode) parser.Expr) parser.Expr {
+	left := recur(e.Left, mode)
+	right := recur(e.Right, mode)
+	op := normalizeOperator(e.Operator, mode)
+	anyFlag := e.Any
+	allFlag := e.All
+
+	// The generic parser may parse "= ANY(ARRAY[...])" as a FuncExpr on the right side.
+	// Normalize this to set the Any/All flags properly.
+	if funcExpr, ok := right.(*parser.FuncExpr); ok {
+		funcName := strings.ToLower(funcExpr.Name.Name)
+		switch funcName {
+		case "any", "some":
+			if len(funcExpr.Exprs) == 1 {
+				if aliased, ok := funcExpr.Exprs[0].(*parser.AliasedExpr); ok {
+					right = recur(aliased.Expr, mode)
+					anyFlag = true
+				}
+			}
+		case "all":
+			if len(funcExpr.Exprs) == 1 {
+				if aliased, ok := funcExpr.Exprs[0].(*parser.AliasedExpr); ok {
+					right = recur(aliased.Expr, mode)
+					allFlag = true
+				}
+			}
+		}
 	}
-	if arrayConst, ok := right.(*parser.ArrayConstructor); ok && len(arrayConst.Elements) == 1 {
-		return arrayConst.Elements[0], false, false
+
+	// Unwrap ParenExpr from right side for ANY/ALL to ensure consistent formatting.
+	// The parser may create ParenExpr(ArrayConstructor), which formats as ANY(ARRAY
+	// instead of ANY (ARRAY.
+	if anyFlag || allFlag {
+		if parenExpr, ok := right.(*parser.ParenExpr); ok {
+			right = parenExpr.Expr
+		}
 	}
-	return right, anyFlag, allFlag
+
+	// Handle IN clauses based on mode.
+	if op == "in" || op == "not in" {
+		if tuple, ok := right.(parser.ValTuple); ok {
+			if mode == GeneratorModePostgres {
+				// Elements are normalized and sorted by the ANY/ALL block below.
+				right = &parser.ArrayConstructor{Elements: parser.Exprs(tuple)}
+				if op == "in" {
+					op = "="
+					anyFlag = true
+				} else { // "not in"
+					op = "<>"
+					allFlag = true
+				}
+			} else {
+				// For other databases, keep IN but sort the tuple for consistent comparison.
+				normalizedElements := util.TransformSlice(tuple, func(elem parser.Expr) parser.Expr {
+					return recur(elem, mode)
+				})
+				right = parser.ValTuple(sortAndDeduplicateValues(normalizedElements))
+			}
+		}
+	}
+
+	// Normalize and sort the array elements of ANY/ALL expressions, whether they were
+	// written as such or converted from IN above. Element order does not affect ANY/ALL.
+	if anyFlag || allFlag {
+		if arrayConst, ok := right.(*parser.ArrayConstructor); ok {
+			normalizedElements := util.TransformSlice(arrayConst.Elements, func(elem parser.Expr) parser.Expr {
+				return recur(elem, mode)
+			})
+			right = &parser.ArrayConstructor{Elements: sortAndDeduplicateValues(normalizedElements)}
+		}
+
+		// PostgreSQL folds a single-element IN into a scalar comparison (IN ('a') becomes
+		// = 'a') but keeps the array for an explicitly written ANY/ALL, so both spellings
+		// have to be folded to compare equal. A single element makes ANY and ALL collapse
+		// to the same comparison whatever the operator is, so this holds beyond = and <>.
+		if arrayConst, ok := right.(*parser.ArrayConstructor); ok && len(arrayConst.Elements) == 1 {
+			right = arrayConst.Elements[0]
+			anyFlag = false
+			allFlag = false
+		}
+	}
+
+	return &parser.ComparisonExpr{
+		Operator: op,
+		Left:     left,
+		Right:    right,
+		Escape:   recur(e.Escape, mode),
+		All:      allFlag,
+		Any:      anyFlag,
+	}
 }
 
 // sortAndDeduplicateValues sorts and deduplicates a slice of expressions based on their string representation.

--- a/schema/normalize.go
+++ b/schema/normalize.go
@@ -264,9 +264,26 @@ func isFoldableValueCastTypeName(typeStr string) bool {
 	return false
 }
 
-// normalizeCheckExpr normalizes a CHECK constraint expression AST for comparison
-// mode parameter controls PostgreSQL-specific normalization (IN to ANY conversion)
+// normalizeCheckExpr normalizes a CHECK constraint expression AST for comparison.
+// mode parameter controls PostgreSQL-specific normalization (IN to ANY conversion).
 func normalizeCheckExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
+	return normalizeCheckExprWith(expr, mode, true)
+}
+
+// normalizeCheckExprForOutput normalizes a CHECK constraint expression for DDL generation.
+// Unlike normalizeCheckExpr it leaves ANY/ALL array elements in the order they were written:
+// comparison canonicalizes both sides anyway, so reordering here would only rewrite the
+// author's schema, discarding an order that often carries meaning (a status lifecycle, say).
+func normalizeCheckExprForOutput(expr parser.Expr, mode GeneratorMode) parser.Expr {
+	return normalizeCheckExprWith(expr, mode, false)
+}
+
+// canonicalizeArrays sorts and deduplicates ANY/ALL array elements, which is wanted when
+// comparing but not when generating DDL.
+func normalizeCheckExprWith(expr parser.Expr, mode GeneratorMode, canonicalizeArrays bool) parser.Expr {
+	recur := func(expr parser.Expr, mode GeneratorMode) parser.Expr {
+		return normalizeCheckExprWith(expr, mode, canonicalizeArrays)
+	}
 	if expr == nil {
 		return nil
 	}
@@ -292,7 +309,7 @@ func normalizeCheckExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 
 			// Always remove text casts
 			if typeStr == "text" || typeStr == "character varying" {
-				return normalizeCheckExpr(e.Expr, mode)
+				return recur(e.Expr, mode)
 			}
 
 			normalizedTypeStr := normalizeTypeName(typeStr, mode)
@@ -300,7 +317,7 @@ func normalizeCheckExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 			// Remove date/timestamp casts from string literals
 			// PostgreSQL simplifies '2020-01-01'::date to '2020-01-01' in CHECK constraints
 			if normalizedTypeStr == "date" || normalizedTypeStr == "timestamp" {
-				return normalizeCheckExpr(e.Expr, mode)
+				return recur(e.Expr, mode)
 			}
 
 			// Remove redundant array typecasts on ARRAY constructors
@@ -310,7 +327,7 @@ func normalizeCheckExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 			// e.g., ARRAY['a'::varchar]::text[] -> ARRAY['a'::varchar] (after stripping ::text[])
 			//       ARRAY['a'::varchar::text]   -> ARRAY['a'::varchar] (after stripping ::text on element)
 			// Empty arrays (ARRAY[]) need the typecast or PostgreSQL can't determine the type.
-			normalizedExpr := normalizeCheckExpr(e.Expr, mode)
+			normalizedExpr := recur(e.Expr, mode)
 			if arrayConstructor, isArrayConstructor := normalizedExpr.(*parser.ArrayConstructor); isArrayConstructor {
 				if strings.HasSuffix(typeStr, "[]") && len(arrayConstructor.Elements) > 0 {
 					// Non-empty array with array typecast: strip the redundant typecast
@@ -325,11 +342,11 @@ func normalizeCheckExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 			}
 		}
 		return &parser.CastExpr{
-			Expr: normalizeCheckExpr(e.Expr, mode),
+			Expr: recur(e.Expr, mode),
 			Type: e.Type,
 		}
 	case *parser.ParenExpr:
-		normalized := normalizeCheckExpr(e.Expr, mode)
+		normalized := recur(e.Expr, mode)
 		if paren, ok := normalized.(*parser.ParenExpr); ok {
 			return paren
 		}
@@ -343,8 +360,8 @@ func normalizeCheckExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 		return &parser.ParenExpr{Expr: normalized}
 	case *parser.AndExpr:
 		// Normalize operands and unwrap unnecessary parentheses around them
-		left := normalizeCheckExpr(e.Left, mode)
-		right := normalizeCheckExpr(e.Right, mode)
+		left := recur(e.Left, mode)
+		right := recur(e.Right, mode)
 		// MySQL adds parentheses around each operand in AND chains, so unwrap them
 		left = unwrapOutermostParenExpr(left)
 		right = unwrapOutermostParenExpr(right)
@@ -354,8 +371,8 @@ func normalizeCheckExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 		}
 	case *parser.OrExpr:
 		// Normalize operands and unwrap unnecessary parentheses around them
-		left := normalizeCheckExpr(e.Left, mode)
-		right := normalizeCheckExpr(e.Right, mode)
+		left := recur(e.Left, mode)
+		right := recur(e.Right, mode)
 		// MySQL adds parentheses around each operand in OR chains, so unwrap them
 		// Always safe to unwrap in OR chains since OR has the lowest precedence
 		left = unwrapOutermostParenExpr(left)
@@ -374,34 +391,34 @@ func normalizeCheckExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 		}
 	case *parser.ConcatExpr:
 		return &parser.ConcatExpr{
-			Left:  normalizeCheckExpr(e.Left, mode),
-			Right: normalizeCheckExpr(e.Right, mode),
+			Left:  recur(e.Left, mode),
+			Right: recur(e.Right, mode),
 		}
 	case *parser.NotExpr:
-		return &parser.NotExpr{Expr: normalizeCheckExpr(e.Expr, mode)}
+		return &parser.NotExpr{Expr: recur(e.Expr, mode)}
 	case *parser.ComparisonExpr:
-		return normalizeComparisonExpr(e, mode, normalizeCheckExpr)
+		return normalizeComparisonExpr(e, mode, recur, canonicalizeArrays)
 	case *parser.BinaryExpr:
 		return &parser.BinaryExpr{
 			Operator: e.Operator,
-			Left:     normalizeCheckExpr(e.Left, mode),
-			Right:    normalizeCheckExpr(e.Right, mode),
+			Left:     recur(e.Left, mode),
+			Right:    recur(e.Right, mode),
 		}
 	case *parser.UnaryExpr:
 		return &parser.UnaryExpr{
 			Operator: e.Operator,
-			Expr:     normalizeCheckExpr(e.Expr, mode),
+			Expr:     recur(e.Expr, mode),
 		}
 	case *parser.AtTimeZoneExpr:
 		return &parser.AtTimeZoneExpr{
-			Expr: normalizeCheckExpr(e.Expr, mode),
-			Zone: normalizeCheckExpr(e.Zone, mode),
+			Expr: recur(e.Expr, mode),
+			Zone: recur(e.Zone, mode),
 		}
 	case *parser.FuncExpr:
 		normalizedExprs := util.TransformSlice(e.Exprs, func(arg parser.SelectExpr) parser.SelectExpr {
 			if aliased, ok := arg.(*parser.AliasedExpr); ok {
 				return &parser.AliasedExpr{
-					Expr: normalizeCheckExpr(aliased.Expr, mode),
+					Expr: recur(aliased.Expr, mode),
 					As:   aliased.As,
 				}
 			}
@@ -421,21 +438,21 @@ func normalizeCheckExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 		}
 	case *parser.ArrayConstructor:
 		normalizedElements := util.TransformSlice(e.Elements, func(elem parser.Expr) parser.Expr {
-			return normalizeCheckExpr(elem, mode)
+			return recur(elem, mode)
 		})
 		return &parser.ArrayConstructor{Elements: normalizedElements}
 	case *parser.IsExpr:
 		return &parser.IsExpr{
 			Operator: e.Operator,
-			Expr:     normalizeCheckExpr(e.Expr, mode),
+			Expr:     recur(e.Expr, mode),
 		}
 	case *parser.RangeCond:
 		// PostgreSQL normalizes BETWEEN to >= AND <=
 		// e.g., "score BETWEEN 0 AND 100" becomes "score >= 0 AND score <= 100"
 		if mode == GeneratorModePostgres {
-			left := normalizeCheckExpr(e.Left, mode)
-			from := normalizeCheckExpr(e.From, mode)
-			to := normalizeCheckExpr(e.To, mode)
+			left := recur(e.Left, mode)
+			from := recur(e.From, mode)
+			to := recur(e.To, mode)
 
 			if e.Operator == parser.BetweenStr {
 				// x BETWEEN a AND b -> x >= a AND x <= b
@@ -453,13 +470,13 @@ func normalizeCheckExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 		}
 		return &parser.RangeCond{
 			Operator: e.Operator,
-			Left:     normalizeCheckExpr(e.Left, mode),
-			From:     normalizeCheckExpr(e.From, mode),
-			To:       normalizeCheckExpr(e.To, mode),
+			Left:     recur(e.Left, mode),
+			From:     recur(e.From, mode),
+			To:       recur(e.To, mode),
 		}
 	case parser.ValTuple:
 		normalizedTuple := util.TransformSlice(e, func(elem parser.Expr) parser.Expr {
-			return normalizeCheckExpr(elem, mode)
+			return recur(elem, mode)
 		})
 		return parser.ValTuple(normalizedTuple)
 	case *parser.ColName:
@@ -481,7 +498,7 @@ func normalizeCheckExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 		}
 		// Strip the prefix for temporal/json/uuid: pg_get_constraintdef emits typed
 		// literals but user SQL writes bare ones; dropping it on both sides compares equal.
-		return normalizeCheckExpr(e.Value, mode)
+		return recur(e.Value, mode)
 	default:
 		// For all other expression types (literals, etc.), return as-is
 		return expr
@@ -822,7 +839,7 @@ func normalizeExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 			Expr: normalizedInner,
 		}
 	case *parser.ComparisonExpr:
-		return normalizeComparisonExpr(e, mode, normalizeExpr)
+		return normalizeComparisonExpr(e, mode, normalizeExpr, true)
 	case *parser.AndExpr:
 		return &parser.AndExpr{
 			Left:  normalizeExpr(e.Left, mode),
@@ -1449,15 +1466,18 @@ func sortPrivilegesByCanonicalOrder(privileges []string) {
 }
 
 // normalizeComparisonExpr normalizes a comparison towards the form PostgreSQL stores:
-// IN becomes = ANY (ARRAY[...]), NOT IN becomes <> ALL (ARRAY[...]), ANY/ALL array
-// elements are sorted and deduplicated, and a single-element array collapses to a
-// scalar comparison. Other modes keep IN but sort its values.
+// IN becomes = ANY (ARRAY[...]) and NOT IN becomes <> ALL (ARRAY[...]).
+//
+// canonicalizeArrays additionally sorts and deduplicates ANY/ALL array elements and
+// collapses a single-element array to a scalar comparison. That is what makes the two
+// spellings PostgreSQL may store compare equal, so it is on when comparing and off when
+// generating DDL, where it would only rewrite the order the author wrote.
 //
 // recur is the caller's own normalizer: CHECK constraints and value expressions share
 // this comparison handling but normalize their operands differently. Keeping it in one
 // place is deliberate — the two used to carry copies of this logic, and fixes to one
 // repeatedly failed to reach the other (see #1182).
-func normalizeComparisonExpr(e *parser.ComparisonExpr, mode GeneratorMode, recur func(parser.Expr, GeneratorMode) parser.Expr) parser.Expr {
+func normalizeComparisonExpr(e *parser.ComparisonExpr, mode GeneratorMode, recur func(parser.Expr, GeneratorMode) parser.Expr, canonicalizeArrays bool) parser.Expr {
 	left := recur(e.Left, mode)
 	right := recur(e.Right, mode)
 	op := normalizeOperator(e.Operator, mode)
@@ -1499,7 +1519,7 @@ func normalizeComparisonExpr(e *parser.ComparisonExpr, mode GeneratorMode, recur
 	if op == "in" || op == "not in" {
 		if tuple, ok := right.(parser.ValTuple); ok {
 			if mode == GeneratorModePostgres {
-				// Elements are normalized and sorted by the ANY/ALL block below.
+				// Elements are normalized by the ANY/ALL block below.
 				right = &parser.ArrayConstructor{Elements: parser.Exprs(tuple)}
 				if op == "in" {
 					op = "="
@@ -1509,30 +1529,38 @@ func normalizeComparisonExpr(e *parser.ComparisonExpr, mode GeneratorMode, recur
 					allFlag = true
 				}
 			} else {
-				// For other databases, keep IN but sort the tuple for consistent comparison.
+				// For other databases, keep IN.
 				normalizedElements := util.TransformSlice(tuple, func(elem parser.Expr) parser.Expr {
 					return recur(elem, mode)
 				})
-				right = parser.ValTuple(sortAndDeduplicateValues(normalizedElements))
+				if canonicalizeArrays {
+					normalizedElements = sortAndDeduplicateValues(normalizedElements)
+				}
+				right = parser.ValTuple(normalizedElements)
 			}
 		}
 	}
 
-	// Normalize and sort the array elements of ANY/ALL expressions, whether they were
-	// written as such or converted from IN above. Element order does not affect ANY/ALL.
+	// Normalize the array elements of ANY/ALL expressions, whether they were written as
+	// such or converted from IN above.
 	if anyFlag || allFlag {
 		if arrayConst, ok := right.(*parser.ArrayConstructor); ok {
 			normalizedElements := util.TransformSlice(arrayConst.Elements, func(elem parser.Expr) parser.Expr {
 				return recur(elem, mode)
 			})
-			right = &parser.ArrayConstructor{Elements: sortAndDeduplicateValues(normalizedElements)}
+			// Element order does not affect ANY/ALL, and PostgreSQL keeps whichever order
+			// was written, so sorting is what lets the two sides compare equal.
+			if canonicalizeArrays {
+				normalizedElements = sortAndDeduplicateValues(normalizedElements)
+			}
+			right = &parser.ArrayConstructor{Elements: normalizedElements}
 		}
 
 		// PostgreSQL folds a single-element IN into a scalar comparison (IN ('a') becomes
 		// = 'a') but keeps the array for an explicitly written ANY/ALL, so both spellings
 		// have to be folded to compare equal. A single element makes ANY and ALL collapse
 		// to the same comparison whatever the operator is, so this holds beyond = and <>.
-		if arrayConst, ok := right.(*parser.ArrayConstructor); ok && len(arrayConst.Elements) == 1 {
+		if arrayConst, ok := right.(*parser.ArrayConstructor); ok && canonicalizeArrays && len(arrayConst.Elements) == 1 {
 			right = arrayConst.Elements[0]
 			anyFlag = false
 			allFlag = false

--- a/schema/normalize_any_array_test.go
+++ b/schema/normalize_any_array_test.go
@@ -163,9 +163,9 @@ func TestNormalizeCheckExprStringQuoteAwareKeepsAnyAll(t *testing.T) {
 			expected: "status <> ALL (ARRAY['deleted', 'cancelled'])",
 		},
 		// FIXME: the generic parser rejects a column reference inside ARRAY[...], which
-		// PostgreSQL accepts. Until it parses, ARRAY elements are literals as far as
-		// formatExprQuoteAware is concerned, so falling back to parser.String for them
-		// loses no quoting.
+		// PostgreSQL accepts, so this cannot be exercised yet. Once it parses, this case
+		// fails: formatExprQuoteAware has no ArrayConstructor branch and falls back to
+		// parser.String, which drops the quotes and silently references another column.
 		// {
 		// 	name:     "quoted column name inside the array is preserved",
 		// 	sql:      `CREATE TABLE t ("Status" text, "Fallback" text, CHECK ("Status" = ANY (ARRAY["Fallback", 'pending'])))`,

--- a/schema/normalize_any_array_test.go
+++ b/schema/normalize_any_array_test.go
@@ -40,6 +40,34 @@ func TestNormalizeCheckExprSortsAnyAllArray(t *testing.T) {
 	}
 }
 
+func TestNormalizeCheckExprNormalizesNotInToAllComparison(t *testing.T) {
+	tests := []struct {
+		name     string
+		sql      string
+		expected string
+	}{
+		{
+			name:     "NOT IN",
+			sql:      `CREATE TABLE t (status text, CHECK (status NOT IN ('deleted', 'cancelled')))`,
+			expected: "status <> ALL (ARRAY['cancelled', 'deleted'])",
+		},
+		{
+			name:     "ALL as stored by PostgreSQL",
+			sql:      `CREATE TABLE t (status text, CHECK (status <> ALL (ARRAY['deleted'::text, 'cancelled'::text])))`,
+			expected: "status <> ALL (ARRAY['cancelled', 'deleted'])",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parser.String(normalizeCheckExpr(extractCheckExpr(t, tt.sql), GeneratorModePostgres))
+			if got != tt.expected {
+				t.Errorf("normalizeCheckExpr() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestNormalizeCheckExprStringQuoteAwareKeepsAnyAll(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/schema/normalize_any_array_test.go
+++ b/schema/normalize_any_array_test.go
@@ -1,0 +1,50 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/sqldef/sqldef/v3/database"
+)
+
+func TestNormalizeCheckExprStringQuoteAwareKeepsAnyAll(t *testing.T) {
+	tests := []struct {
+		name     string
+		sql      string
+		expected string
+	}{
+		{
+			name:     "IN is converted to ANY",
+			sql:      `CREATE TABLE t (status text, CHECK (status IN ('active', 'pending')))`,
+			expected: "status = ANY (ARRAY['active', 'pending'])",
+		},
+		{
+			name:     "explicit ANY is preserved",
+			sql:      `CREATE TABLE t (status text, CHECK (status = ANY (ARRAY['active', 'pending'])))`,
+			expected: "status = ANY (ARRAY['active', 'pending'])",
+		},
+		{
+			name:     "explicit ALL is preserved",
+			sql:      `CREATE TABLE t (status text, CHECK (status <> ALL (ARRAY['active', 'pending'])))`,
+			expected: "status <> ALL (ARRAY['active', 'pending'])",
+		},
+		{
+			name:     "quoted column name is preserved",
+			sql:      `CREATE TABLE t ("Status" text, CHECK ("Status" IN ('active', 'pending')))`,
+			expected: `"Status" = ANY (ARRAY['active', 'pending'])`,
+		},
+	}
+
+	g := &Generator{
+		mode:   GeneratorModePostgres,
+		config: database.GeneratorConfig{LegacyIgnoreQuotes: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := g.normalizeCheckExprString(extractCheckExpr(t, tt.sql))
+			if got != tt.expected {
+				t.Errorf("normalizeCheckExprString() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}

--- a/schema/normalize_any_array_test.go
+++ b/schema/normalize_any_array_test.go
@@ -157,6 +157,20 @@ func TestNormalizeCheckExprStringQuoteAwareKeepsAnyAll(t *testing.T) {
 			sql:      `CREATE TABLE t (status text, CHECK (status IN ('pending')))`,
 			expected: "status = ANY (ARRAY['pending'])",
 		},
+		{
+			name:     "NOT IN is converted to ALL",
+			sql:      `CREATE TABLE t (status text, CHECK (status NOT IN ('deleted', 'cancelled')))`,
+			expected: "status <> ALL (ARRAY['deleted', 'cancelled'])",
+		},
+		// FIXME: the generic parser rejects a column reference inside ARRAY[...], which
+		// PostgreSQL accepts. Until it parses, ARRAY elements are literals as far as
+		// formatExprQuoteAware is concerned, so falling back to parser.String for them
+		// loses no quoting.
+		// {
+		// 	name:     "quoted column name inside the array is preserved",
+		// 	sql:      `CREATE TABLE t ("Status" text, "Fallback" text, CHECK ("Status" = ANY (ARRAY["Fallback", 'pending'])))`,
+		// 	expected: `"Status" = ANY (ARRAY["Fallback", 'pending'])`,
+		// },
 	}
 
 	g := &Generator{

--- a/schema/normalize_any_array_test.go
+++ b/schema/normalize_any_array_test.go
@@ -4,7 +4,41 @@ import (
 	"testing"
 
 	"github.com/sqldef/sqldef/v3/database"
+	"github.com/sqldef/sqldef/v3/parser"
 )
+
+func TestNormalizeCheckExprSortsAnyAllArray(t *testing.T) {
+	tests := []struct {
+		name     string
+		sql      string
+		expected string
+	}{
+		{
+			name:     "unsorted IN",
+			sql:      `CREATE TABLE t (status text, CHECK (status IN ('pending', 'active')))`,
+			expected: "status = ANY (ARRAY['active', 'pending'])",
+		},
+		{
+			name:     "unsorted ANY as stored by PostgreSQL",
+			sql:      `CREATE TABLE t (status text, CHECK (status = ANY (ARRAY['pending'::text, 'active'::text])))`,
+			expected: "status = ANY (ARRAY['active', 'pending'])",
+		},
+		{
+			name:     "unsorted ALL as stored by PostgreSQL",
+			sql:      `CREATE TABLE t (status text, CHECK (status <> ALL (ARRAY['deleted'::text, 'cancelled'::text])))`,
+			expected: "status <> ALL (ARRAY['cancelled', 'deleted'])",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parser.String(normalizeCheckExpr(extractCheckExpr(t, tt.sql), GeneratorModePostgres))
+			if got != tt.expected {
+				t.Errorf("normalizeCheckExpr() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
 
 func TestNormalizeCheckExprStringQuoteAwareKeepsAnyAll(t *testing.T) {
 	tests := []struct {

--- a/schema/normalize_any_array_test.go
+++ b/schema/normalize_any_array_test.go
@@ -24,9 +24,10 @@ func TestNormalizeCheckExprSortsAnyAllArray(t *testing.T) {
 			expected: "status = ANY (ARRAY['active', 'pending'])",
 		},
 		{
-			name:     "unsorted ALL as stored by PostgreSQL",
-			sql:      `CREATE TABLE t (status text, CHECK (status <> ALL (ARRAY['deleted'::text, 'cancelled'::text])))`,
-			expected: "status <> ALL (ARRAY['cancelled', 'deleted'])",
+			// Element order is irrelevant for every ANY/ALL operator, not just = and <>.
+			name:     "unsorted ALL with a non-equality operator",
+			sql:      `CREATE TABLE t (priority int, CHECK (priority >= ALL (ARRAY[2, 1])))`,
+			expected: "priority >= ALL (ARRAY[1, 2])",
 		},
 	}
 
@@ -98,7 +99,7 @@ func TestNormalizeSingleElementArrayComparison(t *testing.T) {
 		},
 		{
 			name:     "multiple elements are left as an array",
-			sql:      `CREATE TABLE t (status text, CHECK (status IN ('pending', 'active')))`,
+			sql:      `CREATE TABLE t (status text, CHECK (status = ANY (ARRAY['active'::text, 'pending'::text])))`,
 			expected: "status = ANY (ARRAY['active', 'pending'])",
 		},
 	}

--- a/schema/normalize_any_array_test.go
+++ b/schema/normalize_any_array_test.go
@@ -145,6 +145,18 @@ func TestNormalizeCheckExprStringQuoteAwareKeepsAnyAll(t *testing.T) {
 			sql:      `CREATE TABLE t ("Status" text, CHECK ("Status" IN ('active', 'pending')))`,
 			expected: `"Status" = ANY (ARRAY['active', 'pending'])`,
 		},
+		{
+			// Generated DDL keeps the authored order even though comparison sorts it,
+			// so applying a change does not rewrite an order that carries meaning.
+			name:     "authored element order is kept",
+			sql:      `CREATE TABLE t (status text, CHECK (status IN ('pending', 'active')))`,
+			expected: "status = ANY (ARRAY['pending', 'active'])",
+		},
+		{
+			name:     "single element is not folded",
+			sql:      `CREATE TABLE t (status text, CHECK (status IN ('pending')))`,
+			expected: "status = ANY (ARRAY['pending'])",
+		},
 	}
 
 	g := &Generator{

--- a/schema/normalize_any_array_test.go
+++ b/schema/normalize_any_array_test.go
@@ -68,6 +68,56 @@ func TestNormalizeCheckExprNormalizesNotInToAllComparison(t *testing.T) {
 	}
 }
 
+// PostgreSQL folds IN ('a') into = 'a' but keeps ARRAY[...] for an explicitly written
+// ANY/ALL, so both spellings must normalize to the same scalar comparison.
+func TestNormalizeSingleElementArrayComparison(t *testing.T) {
+	tests := []struct {
+		name     string
+		sql      string
+		expected string
+	}{
+		{
+			name:     "single element IN",
+			sql:      `CREATE TABLE t (status text, CHECK (status IN ('pending')))`,
+			expected: "status = 'pending'",
+		},
+		{
+			name:     "single element ANY",
+			sql:      `CREATE TABLE t (status text, CHECK (status = ANY (ARRAY['pending'::text])))`,
+			expected: "status = 'pending'",
+		},
+		{
+			name:     "single element NOT IN",
+			sql:      `CREATE TABLE t (status text, CHECK (status NOT IN ('pending')))`,
+			expected: "status <> 'pending'",
+		},
+		{
+			name:     "single element ALL",
+			sql:      `CREATE TABLE t (status text, CHECK (status <> ALL (ARRAY['pending'::text])))`,
+			expected: "status <> 'pending'",
+		},
+		{
+			name:     "multiple elements are left as an array",
+			sql:      `CREATE TABLE t (status text, CHECK (status IN ('pending', 'active')))`,
+			expected: "status = ANY (ARRAY['active', 'pending'])",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expr := extractCheckExpr(t, tt.sql)
+
+			// normalizeCheckExpr covers CHECK constraints, normalizeExpr partial index WHERE clauses.
+			if got := parser.String(normalizeCheckExpr(expr, GeneratorModePostgres)); got != tt.expected {
+				t.Errorf("normalizeCheckExpr() = %q, want %q", got, tt.expected)
+			}
+			if got := parser.String(normalizeExpr(expr, GeneratorModePostgres)); got != tt.expected {
+				t.Errorf("normalizeExpr() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestNormalizeCheckExprStringQuoteAwareKeepsAnyAll(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Why

Running psqldef against a database initialized by `psql` (e.g. via
`docker-entrypoint-initdb.d`) regenerates the same DDL on every run even though
the schema already matches:

```console
$ psql -U postgres -d repro -f schema.sql
$ psqldef ... --file schema.sql --dry-run repro
-- dry run --
BEGIN;
ALTER TABLE "public"."multi_value" DROP CONSTRAINT "multi_value_status_check";
ALTER TABLE "public"."multi_value" ADD CONSTRAINT "multi_value_status_check" CHECK (status = ANY (ARRAY['pending', 'active']));
ALTER TABLE "public"."single_value" DROP CONSTRAINT "single_value_status_check";
ALTER TABLE "public"."single_value" ADD CONSTRAINT "single_value_status_check" CHECK (status = ANY (ARRAY['pending']));
-- Skipped: DROP INDEX "public"."idx_orders_single";
CREATE INDEX idx_orders_single ON orders (id) WHERE status IN ('pending');
COMMIT;
```

`ADD CONSTRAINT ... CHECK` revalidates every existing row, so on a large table
this is a meaningful lock on each run. For partial indexes it is worse than
noise: without `--enable-drop` the `DROP INDEX` is skipped while the
`CREATE INDEX` is still emitted, so psqldef **always exits 1** with
`relation "idx_orders_single" already exists`.

This is the CHECK-constraint counterpart of #1182, which fixed the same class of
bug in `normalizeExpr` (partial indexes) but not in `normalizeCheckExpr`.

### Root causes

PostgreSQL stores these expressions in forms psqldef did not normalize to:

| written | stored by PostgreSQL |
|---|---|
| `CHECK (status IN ('pending','active'))` | `status = ANY (ARRAY['pending'::text, 'active'::text])` — in the written order |
| `CHECK (status NOT IN ('deleted','cancelled'))` | `status <> ALL (ARRAY['deleted'::text, 'cancelled'::text])` |
| `CHECK (status IN ('pending'))` | `status = 'pending'::text` — folded to a scalar |
| `CHECK (state = ALL (ARRAY['inactive']))` | `state = ALL (ARRAY['inactive'::text])` — *not* folded |
| `WHERE status IN ('pending')` | `status = 'pending'::text` — folded to a scalar |

Since a single-element list can be stored either way, comparison has to fold both
spellings to the same shape.

1. `normalizeCheckExpr` sorted array elements only when converting `IN`, leaving an
   existing `ANY/ALL (ARRAY[...])` unsorted. `normalizeExpr` has sorted both since #1182.
2. Neither normalizer folded a single-element array, so the two spellings above never
   compared equal.
3. `normalizeCheckExpr` turned `NOT IN` into `!= ANY`, which never matched
   PostgreSQL's `<> ALL` — see the breaking change below.
4. Found while writing the tests: with `legacy_ignore_quotes: false`,
   `formatExprQuoteAware` dropped the `Any`/`All` flags, so a CHECK written as
   `IN (...)` was emitted as `col = ARRAY[...]` and rejected by PostgreSQL with
   `operator does not exist: text = text[]`. No existing test covered quote-aware
   mode together with `ANY`/`ALL`.

## What

- Sort existing `ANY/ALL` array elements when comparing CHECK constraints, matching #1182.
- Fold a single-element `ANY/ALL (ARRAY[v])` to `<op> v` when comparing, in both normalizers.
- Normalize CHECK `NOT IN` to `<> ALL` instead of `!= ANY`.
- Keep `ANY`/`ALL` when formatting a comparison in quote-aware mode.
- Apply the sorting and folding to comparison only when generating CHECK DDL, so it
  keeps the array order the author wrote.
- Extract the shared comparison normalization so the two normalizers cannot drift
  again, and extract `parser.NeedsAnyAllParens` for the same reason.

## ⚠️ Breaking change: CHECK `NOT IN` now enforces what was written

`normalizeCheckExpr` converted `NOT IN (a, b)` to `!= ANY (ARRAY[a, b])`, and that
DDL was what psqldef actually applied. The two are not equivalent: `!= ANY` holds
when the value differs from *any* element, so a constraint over two or more distinct
values was always true — effectively vacuous.

```console
$ psql -c "INSERT INTO items VALUES ('spam')"   -- CHECK (kind NOT IN ('spam', 'deleted'))
INSERT 0 1
```

psqldef now emits `<> ALL (ARRAY[a, b])`. If a table was previously "protected" by
such a constraint and holds rows that violate what was written, the next apply will
fail on `ADD CONSTRAINT`. That surfaces pre-existing bad data rather than continuing
to apply a constraint that never enforced anything.

Two limits worth noting: a table created by psqldef was never affected, because
`CREATE TABLE` emits the statement as written and PostgreSQL stores the correct
`<> ALL`; and a single-element `NOT IN` was already correct, since `!= ANY (ARRAY[a])`
is equivalent to `!= a`. Only `ADD CONSTRAINT` on an existing table, with two or more
values, produced the vacuous constraint.

## Notes for reviewers

- **Sorting does not ask users to sort their schema files, and does not reorder them.**
  It runs on the desired and the current side alike, so a `CHECK (status IN (...))`
  written in any order compares equal to what PostgreSQL stores. It deliberately does
  *not* run on the DDL generation path: reordering there would rewrite an order that
  often carries meaning (a status lifecycle, say), and it would buy nothing, since
  `--export` still shows whatever order the database holds for constraints psqldef has
  not rewritten. Existing test expectations are unchanged as a result.
  This split is applied to `normalizeCheckExpr` only. `normalizeExpr` also reaches DDL
  generation through `DEFAULT` and `ALTER DOMAIN SET DEFAULT`, where a single-element
  ANY/ALL comparison would now be folded — a degenerate shape for a default value, and
  the result stays equivalent SQL, so it did not seem worth a second split.
- **Sorting is applied regardless of the operator** (`>= ALL (ARRAY[1, 2])` included).
  Element order does not affect `ANY`/`ALL` for any operator, and `normalizeExpr`
  already behaved this way; leaving only one of the two order-preserving is what
  produced this bug class twice.
- **Not fixed here**: `formatExprQuoteAware` is a hand-written quote-aware parallel of
  `parser.String`, and cause 4 was a missed update to it. It has a second gap of the same
  kind: no `ArrayConstructor` branch, so a column reference inside `ARRAY[...]` loses its
  quotes and would silently refer to a different, case-folded column. That is unreachable
  today because the generic parser rejects a column reference inside `ARRAY[...]` in the
  first place, so both halves belong together in a separate PR; a commented-out case in
  `normalize_any_array_test.go` marks the spot. Replacing `formatExprQuoteAware` outright,
  by threading an identifier formatter through `nodeBuffer`, would delete ~110 lines and
  remove the whole class of drift, but it touches parser infrastructure shared by all four
  dialects — better again as its own PR.
- **Also not fixed here**: the general problem that a skipped `DROP INDEX` still emits
  its `CREATE INDEX` (the commented-out `ChangeIndexUniquenessWithEnableDropFalse` TODO
  in `tests_constraints.yml`). This PR removes the diff that triggered it for
  single-element `IN`, not the underlying behavior.

## Testing

`make test` (1820 tests), MariaDB, TiDB, pgvector, `make format`, `make lint` all pass.
Every commit passes on its own.

New tests, all with `legacy_ignore_quotes: false`:

- `schema/normalize_any_array_test.go` — sorting, `NOT IN` → `<> ALL`, single-element
  folding (both normalizers), quote-aware `ANY`/`ALL` output, and that generated DDL
  keeps the authored order.
- `cmd/psqldef/tests_constraints.yml` — `ConstraintCheckInUnsorted`,
  `ConstraintCheckNotInUnsorted`, `ConstraintCheckInSingleValue`,
  `ConstraintCheckNotInSingleValue`, `ConstraintCheckInQuoteAware`,
  `ConstraintCheckNotInAdd` (pins the emitted `<> ALL` DDL, which is the behavior the
  breaking change above turns on), and `ConstraintCheckInUnsortedModify` (pins that
  changing the values still produces DROP + ADD).
- `cmd/psqldef/tests_indices.yml` — `PartialIndexWithWhereInSingleValue`,
  `PartialIndexWithWhereNotInSingleValue`.

Each new test was confirmed to fail without its fix. Manually verified against
PostgreSQL 18 that the reproduction becomes `-- Nothing is modified --` in both legacy
and quote-aware mode, and that `--apply` without `--enable-drop` exits 0.
