### PR TITLE
psqldef: support manage.privilege as the next slice of the manage: RFC

### DIFF
--- a/cmd-psqldef.md
+++ b/cmd-psqldef.md
@@ -505,6 +505,7 @@ $ psqldef -U postgres dbname --apply \
 | `disable_ddl_transaction` | boolean | When true, all DDL statements are executed outside of transactions. Required for Aurora DSQL which does not support transactional DDL. Default is false. |
 | `legacy_ignore_quotes` | boolean | Controls identifier quoting behavior. When `true` (default), all identifiers are quoted in output. When `false`, identifiers preserve their original quoting from the source SQL. Default is `true` but will change to `false` in the next major version. See [Identifier Quoting](#identifier-quoting) for details. |
 | `manage.extension` | array | List of `{target, drop}` rules for which extensions to manage; see [Managing Extensions](#managing-extensions). |
+| `manage.privilege` | array | List of `{target, drop}` rules for which grantees' privileges to manage; see [Managing Privileges](#managing-privileges). |
 
 ### Managing Extensions
 
@@ -523,7 +524,25 @@ Rules are evaluated in order; the first match wins. `target` is a regular expres
 
 If `manage.extension` is omitted, all extensions are managed as before. An empty `manage.extension:` section manages all extensions but disables drop for all of them by default.
 
-`manage.extension` is the first part of a broader `manage:` configuration block for controlling which objects psqldef manages across all object types (tables, views, indexes, ...); see [object-management.md](object-management.md) for the full design. Other `manage:` keys are not implemented yet and are ignored with a warning.
+`manage.extension` is part of a broader `manage:` configuration block for controlling which objects psqldef manages across all object types (tables, views, indexes, ...); see [object-management.md](object-management.md) for the full design. Besides `manage.extension` and `manage.privilege`, other `manage:` keys are not implemented yet and are ignored with a warning.
+
+### Managing Privileges
+
+`manage.privilege` declares which grantees' (roles') privileges psqldef manages, replacing the deprecated `managed_roles` list, and controls REVOKE per rule:
+
+```yaml
+manage:
+  privilege:
+    - target: 'readonly_.*'
+    - target: 'app_.*'
+      drop: true  # allows REVOKE for these roles
+```
+
+Rules are evaluated in order; the first match wins. `target` is a regular expression matched against the grantee name, anchored with `^...$` (empty matches all). Grantees matching no rule are left completely untouched: their GRANTs in the desired schema are ignored, and their existing privileges are excluded from the diff and `--export`.
+
+`drop` (default `false`) controls whether REVOKE statements are emitted for that grantee — for privileges that drifted or were removed from the desired schema, and for `REVOKE GRANT OPTION FOR` downgrades. Unlike the legacy behavior where REVOKE was tied to the global `enable_drop`, the rule's `drop` decides alone: a role with `drop: true` converges even when `enable_drop` is `false` (destructive object drops stay blocked), and a role with `drop: false` only ever gains privileges, with skipped revokes shown as `-- Skipped: ...`.
+
+When `manage.privilege` is set, the deprecated `managed_roles` option is ignored (a warning is logged if both are present). An empty `manage.privilege:` section manages all grantees with REVOKE disabled by default.
 
 ## Identifier Quoting
 

--- a/cmd/psqldef/tests_manage_privilege.yml
+++ b/cmd/psqldef/tests_manage_privilege.yml
@@ -1,0 +1,196 @@
+# yaml-language-server: $schema=../../testutil/testcase.schema.json
+# Tests for manage.privilege (see object-management.md): which grantees'
+# privileges are managed, and whether REVOKE is allowed per rule.
+
+ManagePrivilegeBasicGrant:
+  manage:
+    privilege:
+      - target: readonly_user
+        drop: true
+  current: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+  desired: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    GRANT SELECT ON TABLE users TO readonly_user;
+  up: |
+    GRANT SELECT ON TABLE "public"."users" TO "readonly_user";
+  down: |
+    REVOKE SELECT ON TABLE "public"."users" FROM "readonly_user";
+
+ManagePrivilegeUnmatchedGranteeUntouched:
+  # app_user matches no rule: its desired grant is ignored and its existing
+  # drifted grant is left alone.
+  manage:
+    privilege:
+      - target: readonly_user
+        drop: true
+  current: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    GRANT INSERT ON TABLE users TO app_user;
+  desired: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    GRANT SELECT ON TABLE users TO readonly_user;
+    GRANT UPDATE ON TABLE users TO app_user;
+  up: |
+    GRANT SELECT ON TABLE "public"."users" TO "readonly_user";
+  down: |
+    REVOKE SELECT ON TABLE "public"."users" FROM "readonly_user";
+
+ManagePrivilegeRevokeAllowedDespiteEnableDropFalse:
+  # The keystone: rule-level drop permits REVOKE even though the global
+  # enable_drop is false (which still blocks object drops).
+  enable_drop: false
+  manage:
+    privilege:
+      - target: app_user
+        drop: true
+  current: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    GRANT SELECT, INSERT ON TABLE users TO app_user;
+  desired: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    GRANT SELECT ON TABLE users TO app_user;
+  up: |
+    REVOKE INSERT ON TABLE "public"."users" FROM "app_user";
+  down: |
+    GRANT INSERT ON TABLE "public"."users" TO "app_user";
+
+ManagePrivilegeRevokeForbiddenByRule:
+  # drop defaults to false: the drifted grant stays, the revoke is skipped
+  # even though enable_drop is true.
+  manage:
+    privilege:
+      - target: readonly_user
+  current: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    GRANT SELECT, INSERT ON TABLE users TO readonly_user;
+  desired: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    GRANT SELECT ON TABLE users TO readonly_user;
+  up: |
+    -- Skipped: REVOKE INSERT ON TABLE "public"."users" FROM "readonly_user";
+  down: ""
+
+ManagePrivilegeOrphanRevokeAllowed:
+  # Grantee absent from desired entirely: orphan path, revoke allowed by rule.
+  enable_drop: false
+  manage:
+    privilege:
+      - target: app_user
+        drop: true
+  current: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    GRANT SELECT ON TABLE users TO app_user;
+  desired: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+  up: |
+    REVOKE SELECT ON TABLE "public"."users" FROM "app_user";
+  down: |
+    GRANT SELECT ON TABLE "public"."users" TO "app_user";
+
+ManagePrivilegeRegexpTargetFirstMatchWins:
+  # user\d matches user1..user4 with drop, catch-all forbids drop for others.
+  enable_drop: false
+  manage:
+    privilege:
+      - target: 'user\d'
+        drop: true
+      - target: '.*'
+  current: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    GRANT SELECT ON TABLE users TO user1;
+    GRANT SELECT ON TABLE users TO readonly_user;
+  desired: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+  up: |
+    -- Skipped: REVOKE SELECT ON TABLE "public"."users" FROM "readonly_user";
+    REVOKE SELECT ON TABLE "public"."users" FROM "user1";
+  down: |
+    GRANT SELECT ON TABLE "public"."users" TO "user1";
+
+ManagePrivilegeSequenceAndColumn:
+  # Sequence and column grants work under manage.privilege, including revokes.
+  enable_drop: false
+  manage:
+    privilege:
+      - target: app_user
+        drop: true
+  current: |
+    CREATE TABLE counters (
+      id BIGINT PRIMARY KEY,
+      n SERIAL,
+      f_secret VARCHAR(100)
+    );
+    GRANT USAGE, SELECT ON SEQUENCE counters_n_seq TO app_user;
+    GRANT SELECT (id, f_secret) ON TABLE counters TO app_user;
+  desired: |
+    CREATE TABLE counters (
+      id BIGINT PRIMARY KEY,
+      n SERIAL,
+      f_secret VARCHAR(100)
+    );
+    GRANT USAGE ON SEQUENCE counters_n_seq TO app_user;
+    GRANT SELECT (id) ON TABLE counters TO app_user;
+  up: |
+    REVOKE SELECT ON SEQUENCE "public"."counters_n_seq" FROM "app_user";
+    REVOKE SELECT (f_secret, id) ON TABLE "public"."counters" FROM "app_user";
+    GRANT SELECT (id) ON TABLE "public"."counters" TO "app_user";
+  down: |
+    GRANT SELECT ON SEQUENCE "public"."counters_n_seq" TO "app_user";
+    REVOKE SELECT (id) ON TABLE "public"."counters" FROM "app_user";
+    GRANT SELECT (f_secret, id) ON TABLE "public"."counters" TO "app_user";
+
+ManagePrivilegeIdempotent:
+  manage:
+    privilege:
+      - target: readonly_user
+  current: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    GRANT SELECT ON TABLE users TO readonly_user;
+  desired: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    GRANT SELECT ON TABLE users TO readonly_user;
+  up: ""
+  down: ""

--- a/database/database.go
+++ b/database/database.go
@@ -66,6 +66,7 @@ type GeneratorConfig struct {
 	LegacyIgnoreQuotes      bool     // true = ignore quotes (legacy), false = preserve quotes
 
 	ManageExtensions *[]ManageObjectRule
+	ManagePrivileges *[]ManageObjectRule // manage.privilege rules: which grantees' privileges are managed and whether REVOKE is allowed
 
 	// MySQL-specific: value of lower_case_table_names server variable.
 	// 0 = case-sensitive (Linux default), 1 or 2 = case-insensitive (Windows/macOS).
@@ -367,6 +368,9 @@ func MergeGeneratorConfig(base, override GeneratorConfig) GeneratorConfig {
 	if override.ManageExtensions != nil {
 		result.ManageExtensions = override.ManageExtensions
 	}
+	if override.ManagePrivileges != nil {
+		result.ManagePrivileges = override.ManagePrivileges
+	}
 	if override.EnableDrop {
 		result.EnableDrop = override.EnableDrop
 	}
@@ -409,7 +413,8 @@ func parseGeneratorConfigFromBytes(buf []byte, defaults GeneratorConfig) Generat
 		log.Fatal(err)
 	}
 
-	manageExtensions := parseManageExtensions(config.Manage)
+	manageExtensions := parseManageRules(config.Manage, "extension")
+	managePrivileges := parseManageRules(config.Manage, "privilege")
 
 	var targetTables []string
 	if config.TargetTables != "" {
@@ -462,6 +467,7 @@ func parseGeneratorConfigFromBytes(buf []byte, defaults GeneratorConfig) Generat
 		BulkAlter:               config.BulkAlter,
 		LegacyIgnoreQuotes:      legacyIgnoreQuotes,
 		ManageExtensions:        manageExtensions,
+		ManagePrivileges:        managePrivileges,
 	}
 }
 
@@ -482,18 +488,27 @@ func CompileManageTarget(target string) (*regexp.Regexp, error) {
 	return regexp.Compile("^(?:" + target + ")$")
 }
 
-func parseManageExtensions(manage map[string]yaml.RawMessage) *[]ManageObjectRule {
+// manageImplementedKeys are the manage: keys with a working implementation; the other
+// recognized keys are parsed permissively and ignored with a warning.
+var manageImplementedKeys = map[string]bool{
+	"extension": true,
+	"privilege": true,
+}
+
+func parseManageRules(manage map[string]yaml.RawMessage, want string) *[]ManageObjectRule {
 	if manage == nil {
 		return nil
 	}
 
 	var result *[]ManageObjectRule
 	for key, raw := range util.CanonicalMapIter(manage) {
-		if key != "extension" {
+		if key != want {
 			if !manageKnownKeys[key] {
 				log.Fatalf("manage.%s is not a recognized manage: key (typo?)", key)
 			}
-			slog.Warn("manage key is not yet supported and will be ignored; only manage.extension is currently implemented", "key", key)
+			if !manageImplementedKeys[key] && want == "extension" { // warn once, not per implemented key
+				slog.Warn("manage key is not yet supported and will be ignored; only manage.extension and manage.privilege are currently implemented", "key", key)
+			}
 			continue
 		}
 
@@ -509,10 +524,29 @@ func parseManageExtensions(manage map[string]yaml.RawMessage) *[]ManageObjectRul
 				continue
 			}
 			if _, err := CompileManageTarget(rule.Target); err != nil {
-				log.Fatalf("manage.extension: invalid target regexp %q: %s", rule.Target, err)
+				log.Fatalf("manage.%s: invalid target regexp %q: %s", want, rule.Target, err)
 			}
 		}
 		result = &rules
 	}
 	return result
+}
+
+// MatchManageObjectRule returns the first rule whose target matches name (first match
+// wins). An empty rules list matches everything with drop disabled; an empty target
+// matches everything. The second return reports whether any rule matched.
+func MatchManageObjectRule(rules []ManageObjectRule, name string) (ManageObjectRule, bool) {
+	if len(rules) == 0 {
+		return ManageObjectRule{Drop: false}, true
+	}
+	for _, rule := range rules {
+		if rule.Target == "" {
+			return rule, true
+		}
+		re, err := CompileManageTarget(rule.Target)
+		if err == nil && re.MatchString(name) {
+			return rule, true
+		}
+	}
+	return ManageObjectRule{}, false
 }

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -50,3 +50,66 @@ func TestIsCommentedOut(t *testing.T) {
 		})
 	}
 }
+
+func TestParseGeneratorConfigManagePrivilege(t *testing.T) {
+	// No manage: section → nil (feature off).
+	config := ParseGeneratorConfigString("managed_roles: [app_user]", GeneratorConfig{})
+	assert.Nil(t, config.ManagePrivileges)
+
+	// Rules are parsed with target and drop; drop defaults to false.
+	config = ParseGeneratorConfigString("manage: {privilege: [{target: 'readonly_.*'}, {target: 'app_.*', drop: true}]}", GeneratorConfig{})
+	if assert.NotNil(t, config.ManagePrivileges) {
+		rules := *config.ManagePrivileges
+		assert.Equal(t, 2, len(rules))
+		assert.Equal(t, "readonly_.*", rules[0].Target)
+		assert.False(t, rules[0].Drop)
+		assert.Equal(t, "app_.*", rules[1].Target)
+		assert.True(t, rules[1].Drop)
+	}
+
+	// An empty privilege section is distinct from an absent one: it manages
+	// all grantees with REVOKE disabled.
+	config = ParseGeneratorConfigString("manage: {privilege: []}", GeneratorConfig{})
+	if assert.NotNil(t, config.ManagePrivileges) {
+		assert.Equal(t, 0, len(*config.ManagePrivileges))
+	}
+
+	// A known but unimplemented manage: key is ignored without affecting
+	// the privilege rules.
+	config = ParseGeneratorConfigString("manage: {table: [{target: foo}], privilege: [{target: bar}]}", GeneratorConfig{})
+	if assert.NotNil(t, config.ManagePrivileges) {
+		assert.Equal(t, 1, len(*config.ManagePrivileges))
+	}
+}
+
+func TestMatchManageObjectRule(t *testing.T) {
+	// Empty rules list matches everything with drop disabled.
+	rule, ok := MatchManageObjectRule([]ManageObjectRule{}, "any_role")
+	assert.True(t, ok)
+	assert.False(t, rule.Drop)
+
+	rules := []ManageObjectRule{
+		{Target: "readonly_.*", Drop: false},
+		{Target: "read.*", Drop: true},
+		{Target: "", Drop: true},
+	}
+
+	// First match wins even when later rules also match.
+	rule, ok = MatchManageObjectRule(rules, "readonly_user")
+	assert.True(t, ok)
+	assert.False(t, rule.Drop)
+
+	// Target is anchored: a substring match is not enough to hit rule 1.
+	rule, ok = MatchManageObjectRule(rules, "app_reader")
+	assert.True(t, ok) // falls through to the empty target
+	assert.True(t, rule.Drop)
+
+	// An empty target matches everything.
+	rule, ok = MatchManageObjectRule(rules[2:], "whatever")
+	assert.True(t, ok)
+	assert.True(t, rule.Drop)
+
+	// No rule matches → not managed.
+	_, ok = MatchManageObjectRule(rules[:2], "unrelated")
+	assert.False(t, ok)
+}

--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -183,8 +183,30 @@ func (d *PostgresDatabase) ExportDDLs() (string, error) {
 // are emitted as standalone GRANTs rather than attached to an object's DDL.
 // Extension-owned sequences are excluded, mirroring how psqldef skips
 // extension-owned objects elsewhere.
+
+// managedGranteeArgs returns the SQL role-filter array for privilege export.
+// In legacy managed_roles mode it returns the role list (SQL-side filtering);
+// with manage.privilege it returns NULL so every grantee is fetched and
+// filtered in Go via the regexp rules (isExportedGrantee).
+func (d *PostgresDatabase) managedGranteeArgs() interface{} {
+	if d.generatorConfig.ManagePrivileges != nil {
+		return pq.Array([]string(nil))
+	}
+	return pq.Array(d.generatorConfig.ManagedRoles)
+}
+
+// isExportedGrantee reports whether a fetched grantee's privileges belong in
+// the export under manage.privilege; in legacy mode SQL already filtered.
+func (d *PostgresDatabase) isExportedGrantee(grantee string) bool {
+	if d.generatorConfig.ManagePrivileges == nil {
+		return true
+	}
+	_, matched := database.MatchManageObjectRule(*d.generatorConfig.ManagePrivileges, grantee)
+	return matched
+}
+
 func (d *PostgresDatabase) sequencePrivileges() ([]string, error) {
-	if len(d.generatorConfig.ManagedRoles) == 0 {
+	if d.generatorConfig.ManagePrivileges == nil && len(d.generatorConfig.ManagedRoles) == 0 {
 		return nil, nil
 	}
 
@@ -200,7 +222,7 @@ func (d *PostgresDatabase) sequencePrivileges() ([]string, error) {
 		WHERE c.relkind = 'S'
 		AND n.nspname NOT IN ('pg_catalog', 'information_schema')
 		AND acl.grantee <> c.relowner
-		AND (CASE WHEN acl.grantee = 0 THEN 'PUBLIC' ELSE pg_get_userbyid(acl.grantee) END) = ANY($1::text[])
+		AND ($1::text[] IS NULL OR (CASE WHEN acl.grantee = 0 THEN 'PUBLIC' ELSE pg_get_userbyid(acl.grantee) END) = ANY($1::text[]))
 		AND NOT EXISTS (
 			SELECT 1 FROM pg_depend dep
 			WHERE dep.classid = 'pg_class'::regclass AND dep.objid = c.oid AND dep.deptype = 'e'
@@ -209,7 +231,7 @@ func (d *PostgresDatabase) sequencePrivileges() ([]string, error) {
 		ORDER BY seq_name, grantee, acl.is_grantable
 	`
 
-	rows, err := d.db.Query(query, pq.Array(d.generatorConfig.ManagedRoles))
+	rows, err := d.db.Query(query, d.managedGranteeArgs())
 	if err != nil {
 		return nil, fmt.Errorf("failed to query sequence privileges: %w", err)
 	}
@@ -221,6 +243,9 @@ func (d *PostgresDatabase) sequencePrivileges() ([]string, error) {
 		var isGrantable bool
 		if err := rows.Scan(&seqName, &grantee, &isGrantable, &privileges); err != nil {
 			return nil, fmt.Errorf("failed to scan sequence privilege row: %w", err)
+		}
+		if !d.isExportedGrantee(grantee) {
+			continue
 		}
 
 		escapedGrantee := grantee
@@ -1960,7 +1985,7 @@ func (d *PostgresDatabase) getCommentsForTables(tableNames []string) (map[string
 
 func (d *PostgresDatabase) getPrivilegeDefsForTables(tableNames []string) (map[string][]string, error) {
 	// If no roles are specified to include, don't query privileges at all
-	if len(d.generatorConfig.ManagedRoles) == 0 {
+	if d.generatorConfig.ManagePrivileges == nil && len(d.generatorConfig.ManagedRoles) == 0 {
 		return map[string][]string{}, nil
 	}
 
@@ -1972,7 +1997,7 @@ func (d *PostgresDatabase) getPrivilegeDefsForTables(tableNames []string) (map[s
 			string_agg(privilege_type, ', ' ORDER BY privilege_type) as privileges
 		FROM information_schema.table_privileges
 		WHERE table_schema || '.' || table_name = ANY($1::text[])
-		AND grantee = ANY($2::text[])
+		AND ($2::text[] IS NULL OR grantee = ANY($2::text[]))
 		AND grantee != (
 			SELECT tableowner FROM pg_tables
 			WHERE schemaname = table_schema AND tablename = table_name
@@ -1981,7 +2006,7 @@ func (d *PostgresDatabase) getPrivilegeDefsForTables(tableNames []string) (map[s
 		ORDER BY table_schema, table_name, grantee, is_grantable
 	`
 
-	rows, err := d.db.Query(query, pq.Array(tableNames), pq.Array(d.generatorConfig.ManagedRoles))
+	rows, err := d.db.Query(query, pq.Array(tableNames), d.managedGranteeArgs())
 	if err != nil {
 		return nil, fmt.Errorf("failed to query privileges: %w", err)
 	}
@@ -1992,6 +2017,9 @@ func (d *PostgresDatabase) getPrivilegeDefsForTables(tableNames []string) (map[s
 		var tableName, grantee, isGrantable, privileges string
 		if err := rows.Scan(&tableName, &grantee, &isGrantable, &privileges); err != nil {
 			return nil, fmt.Errorf("failed to scan privilege row: %w", err)
+		}
+		if !d.isExportedGrantee(grantee) {
+			continue
 		}
 
 		escapedGrantee := grantee
@@ -2026,12 +2054,12 @@ func (d *PostgresDatabase) getPrivilegeDefsForTables(tableNames []string) (map[s
 		LATERAL aclexplode(at.attacl) AS acl
 		WHERE n.nspname || '.' || c.relname = ANY($1::text[])
 		AND acl.grantee <> c.relowner
-		AND (CASE WHEN acl.grantee = 0 THEN 'PUBLIC' ELSE pg_get_userbyid(acl.grantee) END) = ANY($2::text[])
+		AND ($2::text[] IS NULL OR (CASE WHEN acl.grantee = 0 THEN 'PUBLIC' ELSE pg_get_userbyid(acl.grantee) END) = ANY($2::text[]))
 		GROUP BY n.nspname, c.relname, acl.grantee, acl.is_grantable, acl.privilege_type
 		ORDER BY qualified_table_name, grantee, acl.privilege_type, acl.is_grantable
 	`
 
-	colRows, err := d.db.Query(columnQuery, pq.Array(tableNames), pq.Array(d.generatorConfig.ManagedRoles))
+	colRows, err := d.db.Query(columnQuery, pq.Array(tableNames), d.managedGranteeArgs())
 	if err != nil {
 		return nil, fmt.Errorf("failed to query column privileges: %w", err)
 	}
@@ -2042,6 +2070,9 @@ func (d *PostgresDatabase) getPrivilegeDefsForTables(tableNames []string) (map[s
 		var isGrantable bool
 		if err := colRows.Scan(&tableName, &grantee, &isGrantable, &privilegeType, &columns); err != nil {
 			return nil, fmt.Errorf("failed to scan column privilege row: %w", err)
+		}
+		if !d.isExportedGrantee(grantee) {
+			continue
 		}
 
 		escapedGrantee := grantee

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -739,8 +739,10 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 		for _, currentPriv := range g.currentPrivileges {
 			// Check each grantee individually for orphaned privileges
 			for _, grantee := range currentPriv.grantees {
-				// Skip if managed roles is empty (means "manage no roles") or grantee is not in managed roles
-				if len(g.config.ManagedRoles) == 0 || !slices.Contains(g.config.ManagedRoles, grantee) {
+				// Skip grantees whose privileges are not managed (manage.privilege
+				// rules when present, else the legacy managed_roles list; an empty
+				// managed_roles means "manage no roles")
+				if !isManagedGrantee(g.config, grantee) {
 					continue
 				}
 
@@ -766,7 +768,7 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 						grantObjectKeyword(currentPriv.objectType),
 						g.escapeQualifiedName(currentPriv.tableName),
 						escapedGrantee)
-					ddls = append(ddls, revoke)
+					ddls = append(ddls, gateRevokeDDL(g.config, grantee, revoke))
 				}
 			}
 		}
@@ -788,9 +790,11 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 		}
 	}
 
-	// Comment out DROP/REVOKE statements when enable_drop is false
+	// Comment out DROP/REVOKE statements when enable_drop is false. With
+	// manage.privilege, REVOKE gating is already decided per grantee at
+	// emission time, so REVOKE lines are left alone here.
 	if !g.config.EnableDrop {
-		ddls = commentOutDropStatements(ddls)
+		ddls = commentOutDropStatements(ddls, g.config.ManagePrivileges != nil)
 	}
 
 	return ddls, nil
@@ -800,9 +804,13 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 // This makes the output testable and visible in --dry-run output.
 // Every line is commented out so that a multi-line statement can never leak
 // executable SQL after the first line.
-func commentOutDropStatements(ddls []string) []string {
+func commentOutDropStatements(ddls []string, preserveRevokes bool) []string {
 	result := make([]string, len(ddls))
 	for i, ddl := range ddls {
+		if preserveRevokes && strings.HasPrefix(ddl, "REVOKE ") {
+			result[i] = ddl
+			continue
+		}
 		if !strings.HasPrefix(ddl, "-- Skipped: ") && isDropStatement(ddl) {
 			result[i] = "-- Skipped: " + strings.ReplaceAll(ddl, "\n", "\n-- ")
 		} else {
@@ -4287,7 +4295,7 @@ func (g *Generator) generateDDLsForGrantPrivilege(desired *GrantPrivilege) ([]st
 			grantObjectKeyword(desired.objectType),
 			g.escapeQualifiedName(desired.tableName),
 			escapedGrantee)
-		ddls = append(ddls, revoke)
+		ddls = append(ddls, gateRevokeDDL(g.config, grantee, revoke))
 	}
 
 	for grantee, privileges := range util.CanonicalMapIter(revokeGrantOptionByGrantee) {
@@ -4300,7 +4308,7 @@ func (g *Generator) generateDDLsForGrantPrivilege(desired *GrantPrivilege) ([]st
 			grantObjectKeyword(desired.objectType),
 			g.escapeQualifiedName(desired.tableName),
 			escapedGrantee)
-		ddls = append(ddls, revoke)
+		ddls = append(ddls, gateRevokeDDL(g.config, grantee, revoke))
 	}
 
 	var privilegeKeys []string
@@ -4338,10 +4346,10 @@ func (g *Generator) generateDDLsForGrantPrivilege(desired *GrantPrivilege) ([]st
 }
 
 func (g *Generator) generateDDLsForRevokePrivilege(desired *RevokePrivilege) ([]string, error) {
-	if len(g.config.ManagedRoles) > 0 && len(desired.grantees) > 0 {
+	if (g.config.ManagePrivileges != nil || len(g.config.ManagedRoles) > 0) && len(desired.grantees) > 0 {
 		hasIncludedGrantee := false
 		for _, grantee := range desired.grantees {
-			if slices.Contains(g.config.ManagedRoles, grantee) {
+			if isManagedGrantee(g.config, grantee) {
 				hasIncludedGrantee = true
 				break
 			}
@@ -4356,11 +4364,11 @@ func (g *Generator) generateDDLsForRevokePrivilege(desired *RevokePrivilege) ([]
 		return nil, err
 	}
 
-	revoke := fmt.Sprintf("REVOKE %s ON %s %s FROM %s",
+	revoke := gateRevokeDDL(g.config, desired.grantees[0], fmt.Sprintf("REVOKE %s ON %s %s FROM %s",
 		formatPrivilegesForGrant(desired.privileges),
 		grantObjectKeyword(desired.objectType),
 		g.escapeQualifiedName(desired.tableName),
-		escapedGrantee)
+		escapedGrantee))
 
 	if desired.cascadeOption {
 		revoke += " CASCADE"
@@ -6306,8 +6314,12 @@ func FilterViews(ddls []DDL, config database.GeneratorConfig) []DDL {
 }
 
 func FilterPrivileges(ddls []DDL, config database.GeneratorConfig) []DDL {
+	if config.ManagePrivileges != nil && len(config.ManagedRoles) > 0 {
+		slog.Warn("both manage.privilege and managed_roles are set; managed_roles is ignored (deprecated by the manage: RFC)")
+	}
+
 	// If no roles specified, exclude all privileges
-	if len(config.ManagedRoles) == 0 {
+	if config.ManagePrivileges == nil && len(config.ManagedRoles) == 0 {
 		filtered := []DDL{}
 		for _, ddl := range ddls {
 			switch ddl.(type) {
@@ -6335,7 +6347,7 @@ func FilterPrivileges(ddls []DDL, config database.GeneratorConfig) []DDL {
 			// Filter grantees to only include those in config
 			includedGrantees := []string{}
 			for _, grantee := range stmt.grantees {
-				if slices.Contains(config.ManagedRoles, grantee) {
+				if isManagedGrantee(config, grantee) {
 					includedGrantees = append(includedGrantees, grantee)
 				}
 			}
@@ -6365,7 +6377,7 @@ func FilterPrivileges(ddls []DDL, config database.GeneratorConfig) []DDL {
 		case *RevokePrivilege:
 			// Process each grantee separately and consolidate
 			for _, grantee := range stmt.grantees {
-				if slices.Contains(config.ManagedRoles, grantee) {
+				if isManagedGrantee(config, grantee) {
 					key := fmt.Sprintf("%s:%s:%s", stmt.objectType, stmt.tableName.RawString(), grantee)
 					if existing, ok := revokesByTableAndGrantee[key]; ok {
 						// Merge privileges
@@ -6452,19 +6464,36 @@ func FilterExtensions(ddls []DDL, config database.GeneratorConfig) []DDL {
 }
 
 func matchManageObjectRule(rules []database.ManageObjectRule, name string) (database.ManageObjectRule, bool) {
-	if len(rules) == 0 {
-		return database.ManageObjectRule{Drop: false}, true
+	return database.MatchManageObjectRule(rules, name)
+}
+
+// isManagedGrantee reports whether privileges for grantee are managed: by
+// manage.privilege rules when present, else by the legacy managed_roles list.
+func isManagedGrantee(config database.GeneratorConfig, grantee string) bool {
+	if config.ManagePrivileges != nil {
+		_, matched := database.MatchManageObjectRule(*config.ManagePrivileges, grantee)
+		return matched
 	}
-	for _, rule := range rules {
-		if rule.Target == "" {
-			return rule, true
-		}
-		re, err := database.CompileManageTarget(rule.Target)
-		if err == nil && re.MatchString(name) {
-			return rule, true
-		}
+	return slices.Contains(config.ManagedRoles, grantee)
+}
+
+// granteeRevokeAllowed reports whether REVOKE statements may be emitted for
+// grantee under manage.privilege. Only meaningful when ManagePrivileges is set;
+// the per-rule drop flag then decides, independent of the global enable_drop
+// (which the manage: RFC deprecates).
+func granteeRevokeAllowed(config database.GeneratorConfig, grantee string) bool {
+	rule, matched := database.MatchManageObjectRule(*config.ManagePrivileges, grantee)
+	return matched && rule.Drop
+}
+
+// gateRevokeDDL wraps a REVOKE statement in a skip comment when manage.privilege
+// forbids revokes for grantee; in legacy mode it returns the DDL unchanged (the
+// global enable_drop pass handles it).
+func gateRevokeDDL(config database.GeneratorConfig, grantee, ddl string) string {
+	if config.ManagePrivileges != nil && !granteeRevokeAllowed(config, grantee) {
+		return "-- Skipped: " + ddl
 	}
-	return database.ManageObjectRule{}, false
+	return ddl
 }
 
 // generateDropTableDDLsWithDependencies generates DROP TABLE statements in the correct order

--- a/schema/generator_test.go
+++ b/schema/generator_test.go
@@ -551,17 +551,23 @@ func TestCommentOutDropStatements(t *testing.T) {
 	// Single-line drops keep the existing format.
 	assert.Equal(t,
 		[]string{`-- Skipped: DROP TABLE "public"."users"`},
-		commentOutDropStatements([]string{`DROP TABLE "public"."users"`}),
+		commentOutDropStatements([]string{`DROP TABLE "public"."users"`}, false),
 	)
 	// Non-drop statements pass through unchanged.
 	assert.Equal(t,
 		[]string{"CREATE TABLE users (id bigint)"},
-		commentOutDropStatements([]string{"CREATE TABLE users (id bigint)"}),
+		commentOutDropStatements([]string{"CREATE TABLE users (id bigint)"}, false),
+	)
+	// preserveRevokes keeps REVOKE statements executable (used when a
+	// manage.privilege rule allows dropping privileges for a role).
+	assert.Equal(t,
+		[]string{`REVOKE SELECT ON TABLE users FROM app_user`},
+		commentOutDropStatements([]string{`REVOKE SELECT ON TABLE users FROM app_user`}, true),
 	)
 	// Every line of a multi-line statement is commented out so no executable
 	// SQL can leak after the first line.
 	assert.Equal(t,
 		[]string{"-- Skipped: DROP TABLE users;\n-- DROP TABLE orders;"},
-		commentOutDropStatements([]string{"DROP TABLE users;\nDROP TABLE orders;"}),
+		commentOutDropStatements([]string{"DROP TABLE users;\nDROP TABLE orders;"}, false),
 	)
 }

--- a/testutil/testcase.schema.json
+++ b/testutil/testcase.schema.json
@@ -65,7 +65,7 @@
         },
         "manage": {
           "type": "object",
-          "description": "manage: config block (see object-management.md). Only manage.extension is implemented.",
+          "description": "manage: config block (see object-management.md). Only manage.extension and manage.privilege are implemented.",
           "properties": {
             "extension": {
               "type": "array",
@@ -80,6 +80,25 @@
                   "drop": {
                     "type": "boolean",
                     "description": "Whether DROP EXTENSION is allowed for extensions matched by this rule.",
+                    "default": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "privilege": {
+              "type": "array",
+              "description": "Rules for which grantees' privileges to manage. Only grantees matching a rule's target are managed; unmatched grantees are left untouched. An empty array manages all grantees with REVOKE disabled by default.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "target": {
+                    "type": "string",
+                    "description": "Regexp pattern matched against the grantee (role) name, anchored with ^...$. Empty matches all."
+                  },
+                  "drop": {
+                    "type": "boolean",
+                    "description": "Whether REVOKE is allowed for grantees matched by this rule (independent of enable_drop).",
                     "default": false
                   }
                 },

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -45,6 +45,7 @@ type TestCase struct {
 	} `yaml:"config"`
 	Manage struct {
 		Extension *[]database.ManageObjectRule `yaml:"extension"`
+		Privilege *[]database.ManageObjectRule `yaml:"privilege"`
 	} `yaml:"manage"`
 }
 
@@ -181,13 +182,19 @@ func RunTest(t *testing.T, db database.Database, test TestCase, mode schema.Gene
 		legacyIgnoreQuotes = *test.LegacyIgnoreQuotes
 	}
 
-	if test.Manage.Extension != nil {
-		for _, rule := range *test.Manage.Extension {
+	for name, rules := range map[string]*[]database.ManageObjectRule{
+		"extension": test.Manage.Extension,
+		"privilege": test.Manage.Privilege,
+	} {
+		if rules == nil {
+			continue
+		}
+		for _, rule := range *rules {
 			if rule.Target == "" {
 				continue
 			}
 			if _, err := database.CompileManageTarget(rule.Target); err != nil {
-				t.Fatalf("manage.extension: invalid target regexp %q: %s", rule.Target, err)
+				t.Fatalf("manage.%s: invalid target regexp %q: %s", name, rule.Target, err)
 			}
 		}
 	}
@@ -195,6 +202,7 @@ func RunTest(t *testing.T, db database.Database, test TestCase, mode schema.Gene
 	config := database.GeneratorConfig{
 		ManagedRoles:            test.ManagedRoles,
 		ManageExtensions:        test.Manage.Extension,
+		ManagePrivileges:        test.Manage.Privilege,
 		EnableDrop:              *test.EnableDrop,
 		CreateIndexConcurrently: test.Config.CreateIndexConcurrently,
 		DisableDdlTransaction:   test.Config.DisableDdlTransaction,


### PR DESCRIPTION
## Summary

`manage.privilege` declares which grantees' (roles') privileges psqldef
manages, replacing the deprecated `managed_roles` list with the manage: RFC's
rule shape (#1072, following the slice pattern of #1284):

```yaml
manage:
  privilege:
    - target: 'readonly_.*'
    - target: 'app_.*'
      drop: true  # allows REVOKE
```

The per-rule `drop` flag decouples privilege convergence from destructive
object drops: a role with `drop: true` can have drifted privileges revoked
even while `enable_drop` is `false` (DROP TABLE etc. stay blocked), which the
all-or-nothing `enable_drop` could not express.

## Changes

- config: parse `manage.privilege` rules ({target, drop}, first match wins,
  target as an anchored regexp), sharing `ManageObjectRule` and the manage:
  key handling introduced for `manage.extension`
- filtering: grantees matching no rule are left completely untouched — their
  GRANTs in the desired schema are ignored and their existing privileges are
  excluded from the diff and `--export` (fetched without the SQL role filter
  and matched in Go against the rules)
- revoke gating: the rule's `drop` decides REVOKE / REVOKE GRANT OPTION FOR
  emission per grantee; skipped revokes appear as `-- Skipped: ...`
- precedence: when `manage.privilege` is set, the deprecated `managed_roles`
  is ignored (warning when both are present); an empty section manages all
  grantees with REVOKE disabled
- docs (cmd-psqldef.md) and round-trip tests (grant/revoke-allowed/
  revoke-forbidden/orphan/regexp targets/sequence+column/idempotency)

## Verification

- New round-trip tests in tests_manage_privilege.yml, including revoke
  allowed under enable_drop: false and unmatched-grantee isolation
- Full psqldef suites on PostgreSQL 13 and 18 (PSQLDEF_PARSER=generic),
  test-core, mysqldef (8.0), sqlite3def, vet, and `make parser` determinism
  all pass locally; existing managed_roles behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
