### PR TITLE
fix: classify destructive DDLs by leading keyword, not whole-text substrings

### DIFF
--- a/cmd/psqldef/tests_enable_drop.yml
+++ b/cmd/psqldef/tests_enable_drop.yml
@@ -250,11 +250,8 @@ GrantOverlappingRevokeSkipped:
     -- Skipped: REVOKE INSERT, SELECT ON TABLE "public"."users" FROM "user2";
     -- Skipped: REVOKE DELETE, UPDATE ON TABLE "public"."users" FROM "user3";
 
-# Regression test: a CREATE FUNCTION whose body contains destructive-sounding
-# substrings ("DROP TABLE", "REVOKE ") must not be misclassified as a drop
-# statement. Previously it was commented out on its first line only, leaking
-# the remaining lines as raw SQL and aborting the whole transaction on apply
-# (e.g. AWS DMS's awsdms_intercept_ddl event trigger function).
+# Regression: additive statements mentioning "DROP TABLE"/"REVOKE" in payloads
+# (function body, comment text, literals) must not be skipped as destructive.
 CreateFunctionBodyMentioningDropNotSkipped:
   enable_drop: false
   legacy_ignore_quotes: false
@@ -280,9 +277,6 @@ CreateFunctionBodyMentioningDropNotSkipped:
   down: |
     -- Skipped: DROP FUNCTION public.intercept_ddl;
 
-# Regression test: a COMMENT whose text contains destructive-sounding
-# substrings must not be misclassified as a drop statement. Previously it was
-# commented out and silently never applied.
 CommentMentioningDropNotSkipped:
   enable_drop: false
   legacy_ignore_quotes: false
@@ -295,3 +289,22 @@ CommentMentioningDropNotSkipped:
     COMMENT ON TABLE public.audit_log IS 'rows written when a DROP TABLE happens';
   down: |
     COMMENT ON TABLE public.audit_log IS NULL;
+
+CheckConstraintLiteralMentioningDropNotSkipped:
+  enable_drop: false
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TABLE audit (
+      id bigint,
+      note text
+    );
+  desired: |
+    CREATE TABLE audit (
+      id bigint,
+      note text,
+      CONSTRAINT note_ck CHECK (note <> 'DROP TABLE')
+    );
+  up: |
+    ALTER TABLE public.audit ADD CONSTRAINT note_ck CHECK (note <> 'DROP TABLE');
+  down: |
+    ALTER TABLE public.audit DROP CONSTRAINT note_ck;

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -812,42 +812,29 @@ func commentOutDropStatements(ddls []string) []string {
 	return result
 }
 
-// isDropStatement checks if a DDL statement is a DROP or REVOKE statement.
-// Note: DROP CONSTRAINT and DROP CHECK are NOT included because they are
-// required for non-destructive schema changes (e.g., changing defaults).
+// isDropStatement checks if a DDL statement is a destructive DROP or REVOKE
+// statement. All DDLs passed here are synthesized by the generator itself, so
+// destructive ones can be recognized by their leading keyword (plus the
+// destructive clauses embedded in ALTER TABLE). Substring-matching the whole
+// text would misfire on additive statements whose payload merely mentions a
+// destructive word: a function body inspecting tg_tag (e.g. AWS DMS's
+// awsdms_intercept_ddl event trigger function), a comment text, or a string
+// literal in a CHECK/DEFAULT clause.
+// Note: ALTER TABLE ... DROP CONSTRAINT/CHECK/DEFAULT/FOREIGN KEY/PRIMARY KEY
+// are NOT treated as destructive because they are required for non-destructive
+// schema changes (e.g., changing defaults or recreating constraints).
 func isDropStatement(ddl string) bool {
-	// CREATE (including CREATE OR REPLACE) and COMMENT statements are additive,
-	// never destructive drops, even when their payload contains substrings like
-	// "DROP TABLE" or "REVOKE ": e.g. a function body inspecting tg_tag (such as
-	// AWS DMS's awsdms_intercept_ddl event trigger function), or a comment text
-	// mentioning those words. Without this guard they would be skipped as
-	// destructive: a single-line statement silently never applies, and a
-	// multi-line one leaks its remaining lines as raw SQL (see
-	// commentOutDropStatements), aborting the transaction.
-	head := strings.ToUpper(strings.TrimSpace(ddl))
-	if strings.HasPrefix(head, "CREATE ") || strings.HasPrefix(head, "COMMENT ") {
-		return false
+	if strings.HasPrefix(ddl, "DROP ") || strings.HasPrefix(ddl, "REVOKE ") {
+		return true
 	}
-	return strings.Contains(ddl, "DROP TABLE") ||
-		strings.Contains(ddl, "DROP SCHEMA") ||
-		strings.Contains(ddl, "DROP COLUMN") ||
-		strings.Contains(ddl, "DROP ROLE") ||
-		strings.Contains(ddl, "DROP USER") ||
-		strings.Contains(ddl, "DROP FUNCTION") ||
-		strings.Contains(ddl, "DROP PROCEDURE") ||
-		strings.Contains(ddl, "DROP TRIGGER") ||
-		strings.Contains(ddl, "DROP VIEW") ||
-		strings.Contains(ddl, "DROP MATERIALIZED VIEW") ||
-		strings.Contains(ddl, "DROP INDEX") ||
-		strings.Contains(ddl, "DROP SEQUENCE") ||
-		strings.Contains(ddl, "DROP TYPE") ||
-		strings.Contains(ddl, "DROP DOMAIN") ||
-		strings.Contains(ddl, "DROP EXTENSION") ||
-		strings.Contains(ddl, "DROP POLICY") ||
-		strings.Contains(ddl, "DROP PARTITION") ||
-		strings.Contains(ddl, "DISABLE ROW LEVEL SECURITY") ||
-		strings.Contains(ddl, "NO FORCE ROW LEVEL SECURITY") ||
-		strings.Contains(ddl, "REVOKE ")
+	if strings.HasPrefix(ddl, "ALTER ") {
+		return strings.Contains(ddl, " DROP COLUMN ") ||
+			strings.Contains(ddl, " DROP INDEX ") ||
+			strings.Contains(ddl, " DROP PARTITION ") ||
+			strings.Contains(ddl, " DISABLE ROW LEVEL SECURITY") ||
+			strings.Contains(ddl, " NO FORCE ROW LEVEL SECURITY")
+	}
+	return false
 }
 
 // alterTablePrefix returns "ALTER TABLE <escaped-table-name> ", the prefix the

--- a/schema/generator_test.go
+++ b/schema/generator_test.go
@@ -529,22 +529,35 @@ func TestCheckConstraintMSSQLInVsOrNormalization(t *testing.T) {
 }
 
 func TestIsDropStatement(t *testing.T) {
-	// Destructive statements are detected.
+	// Destructive statements are detected by their leading keyword.
 	assert.True(t, isDropStatement(`DROP TABLE "public"."users"`))
 	assert.True(t, isDropStatement("DROP FUNCTION public.add_one"))
-	assert.True(t, isDropStatement(`ALTER TABLE "public"."users" DROP COLUMN "name"`))
+	assert.True(t, isDropStatement("DROP EVENT `cleanup`"))
 	assert.True(t, isDropStatement(`REVOKE SELECT ON TABLE users FROM app_user`))
-	assert.True(t, isDropStatement(`ALTER TABLE public.users DISABLE ROW LEVEL SECURITY`))
 
-	// CREATE statements are additive even when their body mentions destructive
-	// keywords (e.g. an event trigger function inspecting tg_tag).
+	// Destructive clauses embedded in ALTER TABLE are detected.
+	assert.True(t, isDropStatement(`ALTER TABLE "public"."users" DROP COLUMN "name"`))
+	assert.True(t, isDropStatement("ALTER TABLE `users` DROP INDEX `idx_name`"))
+	assert.True(t, isDropStatement("ALTER TABLE `logs` DROP PARTITION p2024"))
+	assert.True(t, isDropStatement(`ALTER TABLE public.users DISABLE ROW LEVEL SECURITY`))
+	assert.True(t, isDropStatement(`ALTER TABLE public.users NO FORCE ROW LEVEL SECURITY`))
+
+	// Non-destructive ALTER clauses stay allowed (needed for non-destructive
+	// schema changes).
+	assert.False(t, isDropStatement(`ALTER TABLE users DROP CONSTRAINT users_check`))
+	assert.False(t, isDropStatement(`ALTER TABLE users ALTER COLUMN c DROP DEFAULT`))
+	assert.False(t, isDropStatement("ALTER TABLE `users` DROP FOREIGN KEY `fk_users`"))
+
+	// Additive statements are never destructive, even when their payload
+	// mentions destructive keywords (function bodies, comment text, literals).
 	assert.False(t, isDropStatement("CREATE FUNCTION intercept_ddl() RETURNS event_trigger AS $$\nBEGIN\n  IF tg_tag = 'DROP TABLE' THEN RAISE NOTICE 'x'; END IF;\nEND;\n$$ LANGUAGE plpgsql;"))
 	assert.False(t, isDropStatement("CREATE OR REPLACE FUNCTION f() RETURNS void AS $$\n-- REVOKE and DROP TABLE only appear in this comment\nBEGIN END;\n$$ LANGUAGE plpgsql;"))
-
-	// COMMENT statements are additive even when the comment text mentions
-	// destructive keywords.
 	assert.False(t, isDropStatement(`COMMENT ON TABLE "public"."audit_log" IS 'rows written when a DROP TABLE happens'`))
 	assert.False(t, isDropStatement(`COMMENT ON COLUMN "public"."users"."flags" IS 'set after REVOKE runs'`))
+	assert.False(t, isDropStatement(`ALTER TABLE audit ADD CONSTRAINT note_ck CHECK (note <> 'DROP TABLE')`))
+	assert.False(t, isDropStatement(`ALTER TABLE users ALTER COLUMN c SET DEFAULT 'DROP TABLE'`))
+	assert.False(t, isDropStatement("ALTER EVENT `cleanup` ON SCHEDULE EVERY 1 DAY DO\nDELETE FROM logs WHERE note = 'DROP TABLE'"))
+	assert.False(t, isDropStatement("-- audit helper\nCREATE FUNCTION f() RETURNS void AS $$ SELECT 'DROP TABLE' $$ LANGUAGE sql;"))
 }
 
 func TestCommentOutDropStatements(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to #1294, which raced with a force-push and merged its initial revision. The whole-text substring matching that revision kept in `isDropStatement` still misfires in both directions:

- **False positive → silent non-convergence**: an `ALTER` statement carrying a string literal, e.g. `ADD CONSTRAINT ... CHECK (note <> 'DROP TABLE')` or `SET DEFAULT 'DROP TABLE'`, is commented out as destructive on every run, so the schema never converges and no error is reported.
- **False negative → destructive statement executes**: the generator emits `DROP EVENT` (MySQL), which is absent from the substring list, so the event is dropped **even with `enable_drop: false`**.

## Fix

Every DDL reaching this check is synthesized by the generator itself, so destructive statements can be recognized positively by their leading keyword:

- `DROP `/`REVOKE `-headed statements are drops (this also covers the previously missed `DROP EVENT`);
- `ALTER `-headed statements are drops only for the destructive embedded clauses the old list targeted (` DROP COLUMN `, ` DROP INDEX `, ` DROP PARTITION `, RLS disabling);
- everything else — including CREATE/COMMENT with arbitrary payloads, in any formatting — is not a drop.

`ALTER TABLE ... DROP CONSTRAINT/DEFAULT/FOREIGN KEY/PRIMARY KEY` remain allowed, as before, since non-destructive schema changes need them. This also removes the substring entries for statements the generator never emits (`DROP ROLE`, `DROP USER`, etc.), which the `DROP ` prefix now covers uniformly anyway.

## Verification

- Unit tests cover leading-keyword detection (incl. `DROP EVENT`), the embedded ALTER clauses, the allowed ALTER forms, and payload-bearing additive statements (function bodies, comment text, CHECK/DEFAULT literals, comment-prefixed and unusually formatted statements).
- New `tests_enable_drop.yml` case: a CHECK constraint whose literal mentions `DROP TABLE` now applies and converges.
- Full psqldef suites on PostgreSQL 13 & 18 (`PSQLDEF_PARSER=generic`), test-core, mysqldef (8.0), sqlite3def, and vet all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
