### PR TITLE
psqldef: support manage.function as the next slice of the manage: RFC

### DIFF
--- a/cmd-psqldef.md
+++ b/cmd-psqldef.md
@@ -505,6 +505,7 @@ $ psqldef -U postgres dbname --apply \
 | `disable_ddl_transaction` | boolean | When true, all DDL statements are executed outside of transactions. Required for Aurora DSQL which does not support transactional DDL. Default is false. |
 | `legacy_ignore_quotes` | boolean | Controls identifier quoting behavior. When `true` (default), all identifiers are quoted in output. When `false`, identifiers preserve their original quoting from the source SQL. Default is `true` but will change to `false` in the next major version. See [Identifier Quoting](#identifier-quoting) for details. |
 | `manage.extension` | array | List of `{target, drop}` rules for which extensions to manage; see [Managing Extensions](#managing-extensions). |
+| `manage.function` | array | List of `{target, drop}` rules for which functions to manage; see [Managing Functions](#managing-functions). |
 | `manage.privilege` | array | List of `{target, drop}` rules for which grantees' privileges to manage; see [Managing Privileges](#managing-privileges). |
 
 ### Managing Extensions
@@ -524,7 +525,25 @@ Rules are evaluated in order; the first match wins. `target` is a regular expres
 
 If `manage.extension` is omitted, all extensions are managed as before. An empty `manage.extension:` section manages all extensions but disables drop for all of them by default.
 
-`manage.extension` is part of a broader `manage:` configuration block for controlling which objects psqldef manages across all object types (tables, views, indexes, ...); see [object-management.md](object-management.md) for the full design. Besides `manage.extension` and `manage.privilege`, other `manage:` keys are not implemented yet and are ignored with a warning.
+`manage.extension` is part of a broader `manage:` configuration block for controlling which objects psqldef manages across all object types (tables, views, indexes, ...); see [object-management.md](object-management.md) for the full design. Besides `manage.extension`, `manage.function` and `manage.privilege`, other `manage:` keys are not implemented yet and are ignored with a warning.
+
+### Managing Functions
+
+`manage.function` restricts function management to those matching a rule, leaving everything else untouched. This is useful when some functions are maintained outside of psqldef (for example an `awsdms_intercept_ddl` event-trigger function installed by AWS DMS, or functions applied by a separate tool):
+
+```yaml
+manage:
+  function:
+    - target: 'app_.*'
+    - target: 'tmp_.*'
+      drop: true  # allows DROP FUNCTION for these functions
+```
+
+Rules are evaluated in order; the first match wins. `target` is a regular expression matched against the function name, anchored with `^...$` (empty matches all). `manage.function` is scoped to the default schema: functions in other schemas match no rule and are left untouched (schema-qualified rules are not implemented yet). Functions matching no rule are left completely untouched: their definitions in the desired schema are ignored, and their existing definitions are excluded from the diff and `--export`.
+
+`drop` (default `false`) controls whether `DROP FUNCTION` is emitted for a managed function that is missing from the desired schema. As with `manage.privilege`, the rule's `drop` decides alone, independent of the global `enable_drop`: a function matched by a `drop: true` rule can be dropped even when `enable_drop` is `false`, while otherwise the drop is commented out as `-- Skipped: ...`.
+
+If `manage.function` is omitted, all functions are managed as before. An empty `manage.function:` section manages all functions but disables drop for all of them by default.
 
 ### Managing Privileges
 

--- a/cmd/psqldef/tests_manage_function.yml
+++ b/cmd/psqldef/tests_manage_function.yml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=../../testutil/testcase.schema.json
+# Tests for manage.function (see object-management.md): which functions are
+# managed, and whether DROP FUNCTION is allowed per rule.
+
+ManageFunctionCreatesMatched:
+  manage:
+    function:
+      - target: app_.*
+  current: ""
+  desired: |
+    CREATE FUNCTION app_touch() RETURNS integer AS $$ BEGIN RETURN 1; END; $$ LANGUAGE plpgsql;
+  up: |
+    CREATE FUNCTION app_touch() RETURNS integer AS $$ BEGIN RETURN 1; END; $$ LANGUAGE plpgsql;
+  down: |
+    -- Skipped: DROP FUNCTION "public"."app_touch";
+
+ManageFunctionUnmatchedFunctionUntouched:
+  # external_fn matches no rule: it is absent from the desired schema yet must
+  # not be dropped, and it is excluded from the diff entirely.
+  manage:
+    function:
+      - target: app_.*
+  current: |
+    CREATE FUNCTION app_touch() RETURNS integer AS $$ BEGIN RETURN 1; END; $$ LANGUAGE plpgsql;
+    CREATE FUNCTION external_fn() RETURNS integer AS $$ BEGIN RETURN 2; END; $$ LANGUAGE plpgsql;
+  desired: |
+    CREATE FUNCTION app_touch() RETURNS integer AS $$ BEGIN RETURN 1; END; $$ LANGUAGE plpgsql;
+
+ManageFunctionObsoleteDropForbidden:
+  # A managed function absent from desired is a drop candidate; with drop:false
+  # (default) the DROP is skipped rather than executed, so the reverse migration
+  # produces nothing (the function was never removed).
+  manage:
+    function:
+      - target: app_.*
+  current: |
+    CREATE FUNCTION app_touch() RETURNS integer AS $$ BEGIN RETURN 1; END; $$ LANGUAGE plpgsql;
+    CREATE FUNCTION app_stale() RETURNS integer AS $$ BEGIN RETURN 9; END; $$ LANGUAGE plpgsql;
+  desired: |
+    CREATE FUNCTION app_touch() RETURNS integer AS $$ BEGIN RETURN 1; END; $$ LANGUAGE plpgsql;
+  up: |
+    -- Skipped: DROP FUNCTION "public"."app_stale";
+  down: ""
+
+ManageFunctionObsoleteDropAllowed:
+  # With drop:true the DROP executes even though enable_drop is false.
+  manage:
+    function:
+      - target: app_.*
+        drop: true
+  current: |
+    CREATE FUNCTION app_touch() RETURNS integer AS $$ BEGIN RETURN 1; END; $$ LANGUAGE plpgsql;
+    CREATE FUNCTION app_stale() RETURNS integer AS $$ BEGIN RETURN 9; END; $$ LANGUAGE plpgsql;
+  desired: |
+    CREATE FUNCTION app_touch() RETURNS integer AS $$ BEGIN RETURN 1; END; $$ LANGUAGE plpgsql;
+  up: |
+    DROP FUNCTION "public"."app_stale";
+  down: |
+    CREATE FUNCTION app_stale() RETURNS integer AS $$ BEGIN RETURN 9; END; $$ LANGUAGE plpgsql;
+
+ManageFunctionOtherSchemaUntouched:
+  # manage.function is scoped to the default schema: a same-named function in
+  # another schema (s2.app_stale) matches no rule and must not be dropped, even
+  # with drop:true.
+  manage:
+    function:
+      - target: app_.*
+        drop: true
+  current: |
+    CREATE SCHEMA s2;
+    CREATE FUNCTION app_touch() RETURNS integer AS $$ BEGIN RETURN 1; END; $$ LANGUAGE plpgsql;
+    CREATE FUNCTION s2.app_stale() RETURNS integer AS $$ BEGIN RETURN 9; END; $$ LANGUAGE plpgsql;
+  desired: |
+    CREATE SCHEMA s2;
+    CREATE FUNCTION app_touch() RETURNS integer AS $$ BEGIN RETURN 1; END; $$ LANGUAGE plpgsql;

--- a/database/database.go
+++ b/database/database.go
@@ -67,6 +67,7 @@ type GeneratorConfig struct {
 
 	ManageExtensions *[]ManageObjectRule
 	ManagePrivileges *[]ManageObjectRule // manage.privilege rules: which grantees' privileges are managed and whether REVOKE is allowed
+	ManageFunctions  *[]ManageObjectRule // manage.function rules: which functions are managed and whether DROP is allowed
 
 	// MySQL-specific: value of lower_case_table_names server variable.
 	// 0 = case-sensitive (Linux default), 1 or 2 = case-insensitive (Windows/macOS).
@@ -368,6 +369,9 @@ func MergeGeneratorConfig(base, override GeneratorConfig) GeneratorConfig {
 	if override.ManageExtensions != nil {
 		result.ManageExtensions = override.ManageExtensions
 	}
+	if override.ManageFunctions != nil {
+		result.ManageFunctions = override.ManageFunctions
+	}
 	if override.ManagePrivileges != nil {
 		result.ManagePrivileges = override.ManagePrivileges
 	}
@@ -414,6 +418,7 @@ func parseGeneratorConfigFromBytes(buf []byte, defaults GeneratorConfig) Generat
 	}
 
 	manageExtensions := parseManageRules(config.Manage, "extension")
+	manageFunctions := parseManageRules(config.Manage, "function")
 	managePrivileges := parseManageRules(config.Manage, "privilege")
 
 	var targetTables []string
@@ -467,6 +472,7 @@ func parseGeneratorConfigFromBytes(buf []byte, defaults GeneratorConfig) Generat
 		BulkAlter:               config.BulkAlter,
 		LegacyIgnoreQuotes:      legacyIgnoreQuotes,
 		ManageExtensions:        manageExtensions,
+		ManageFunctions:         manageFunctions,
 		ManagePrivileges:        managePrivileges,
 	}
 }
@@ -492,6 +498,7 @@ func CompileManageTarget(target string) (*regexp.Regexp, error) {
 // recognized keys are parsed permissively and ignored with a warning.
 var manageImplementedKeys = map[string]bool{
 	"extension": true,
+	"function":  true,
 	"privilege": true,
 }
 

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -113,3 +113,31 @@ func TestMatchManageObjectRule(t *testing.T) {
 	_, ok = MatchManageObjectRule(rules[:2], "unrelated")
 	assert.False(t, ok)
 }
+
+func TestParseGeneratorConfigManageFunction(t *testing.T) {
+	// No manage: section → nil (feature off).
+	config := ParseGeneratorConfigString("", GeneratorConfig{})
+	assert.Nil(t, config.ManageFunctions)
+
+	// Rules are parsed with target and drop; drop defaults to false.
+	config = ParseGeneratorConfigString("manage: {function: [{target: 'app_.*'}, {target: 'tmp_.*', drop: true}]}", GeneratorConfig{})
+	if assert.NotNil(t, config.ManageFunctions) {
+		rules := *config.ManageFunctions
+		assert.Equal(t, 2, len(rules))
+		assert.Equal(t, "app_.*", rules[0].Target)
+		assert.False(t, rules[0].Drop)
+		assert.Equal(t, "tmp_.*", rules[1].Target)
+		assert.True(t, rules[1].Drop)
+	}
+
+	// An empty function section manages all functions with drop disabled.
+	config = ParseGeneratorConfigString("manage: {function: []}", GeneratorConfig{})
+	if assert.NotNil(t, config.ManageFunctions) {
+		assert.Equal(t, 0, len(*config.ManageFunctions))
+	}
+
+	// manage.function and manage.privilege coexist independently.
+	config = ParseGeneratorConfigString("manage: {function: [{target: f}], privilege: [{target: p}]}", GeneratorConfig{})
+	assert.NotNil(t, config.ManageFunctions)
+	assert.NotNil(t, config.ManagePrivileges)
+}

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -118,6 +118,7 @@ func GenerateIdempotentDDLs(mode GeneratorMode, sqlParser database.Parser, desir
 	desiredDDLs = FilterViews(desiredDDLs, config)
 	desiredDDLs = FilterPrivileges(desiredDDLs, config)
 	desiredDDLs = FilterExtensions(desiredDDLs, config)
+	desiredDDLs = FilterFunctions(desiredDDLs, config, defaultSchema)
 
 	desiredDDLs = SortTablesByDependencies(desiredDDLs, defaultSchema, mode, config.LegacyIgnoreQuotes, config.MysqlLowerCaseTableNames)
 
@@ -129,6 +130,7 @@ func GenerateIdempotentDDLs(mode GeneratorMode, sqlParser database.Parser, desir
 	currentDDLs = FilterViews(currentDDLs, config)
 	currentDDLs = FilterPrivileges(currentDDLs, config)
 	currentDDLs = FilterExtensions(currentDDLs, config)
+	currentDDLs = FilterFunctions(currentDDLs, config, defaultSchema)
 
 	currentDDLs = SortTablesByDependencies(currentDDLs, defaultSchema, mode, config.LegacyIgnoreQuotes, config.MysqlLowerCaseTableNames)
 
@@ -682,7 +684,8 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 		if g.findFunctionByName(g.desiredFunctions, currentFunction.name) != nil {
 			continue
 		}
-		ddls = append(ddls, fmt.Sprintf("DROP FUNCTION %s", g.escapeQualifiedName(currentFunction.name)))
+		dropDDL := fmt.Sprintf("DROP FUNCTION %s", g.escapeQualifiedName(currentFunction.name))
+		ddls = append(ddls, gateFunctionDropDDL(g.config, currentFunction.name.Name.Name, dropDDL))
 	}
 
 	// Clean up obsoleted types
@@ -791,10 +794,10 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 	}
 
 	// Comment out DROP/REVOKE statements when enable_drop is false. With
-	// manage.privilege, REVOKE gating is already decided per grantee at
-	// emission time, so REVOKE lines are left alone here.
+	// manage.privilege / manage.function, per-object gating is already decided
+	// at emission time, so those statements are left alone here.
 	if !g.config.EnableDrop {
-		ddls = commentOutDropStatements(ddls, g.config.ManagePrivileges != nil)
+		ddls = commentOutDropStatements(ddls, g.config)
 	}
 
 	return ddls, nil
@@ -804,10 +807,21 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 // This makes the output testable and visible in --dry-run output.
 // Every line is commented out so that a multi-line statement can never leak
 // executable SQL after the first line.
-func commentOutDropStatements(ddls []string, preserveRevokes bool) []string {
+//
+// manage.privilege (REVOKE) and manage.function (DROP FUNCTION) decide per
+// object whether the destructive statement is allowed at emission time —
+// forbidden ones already carry the "-- Skipped: " prefix — so those statement
+// kinds are preserved here rather than being re-gated by the global enable_drop.
+func commentOutDropStatements(ddls []string, config database.GeneratorConfig) []string {
+	preserveRevokes := config.ManagePrivileges != nil
+	preserveFunctionDrops := config.ManageFunctions != nil
 	result := make([]string, len(ddls))
 	for i, ddl := range ddls {
 		if preserveRevokes && strings.HasPrefix(ddl, "REVOKE ") {
+			result[i] = ddl
+			continue
+		}
+		if preserveFunctionDrops && strings.HasPrefix(ddl, "DROP FUNCTION ") {
 			result[i] = ddl
 			continue
 		}
@@ -2515,7 +2529,8 @@ func (g *Generator) generateDDLsForCreateFunction(desired *Function) ([]string, 
 		if desired.orReplace {
 			ddls = append(ddls, desired.statement)
 		} else {
-			ddls = append(ddls, "DROP FUNCTION "+g.escapeQualifiedName(currentFunction.name))
+			dropDDL := "DROP FUNCTION " + g.escapeQualifiedName(currentFunction.name)
+			ddls = append(ddls, gateFunctionDropDDL(g.config, currentFunction.name.Name.Name, dropDDL))
 			ddls = append(ddls, desired.statement)
 		}
 	}
@@ -6463,6 +6478,56 @@ func matchManageObjectRule(rules []database.ManageObjectRule, name string) (data
 	return database.MatchManageObjectRule(rules, name)
 }
 
+// FilterFunctions drops CREATE/COMMENT FUNCTION DDLs whose function is not
+// managed by manage.function, so unmanaged functions are excluded from the diff
+// on both the desired and current sides (allow-list model). When manage.function
+// is unset, all functions are managed (unchanged behavior).
+//
+// A rule's target matches against the function name only; manage.function is
+// scoped to the default schema (matching the manage: RFC, where a rule with no
+// schema field defaults to the default schema). Functions in other schemas are
+// left untouched. Schema-qualified rules are not implemented yet.
+func FilterFunctions(ddls []DDL, config database.GeneratorConfig, defaultSchema string) []DDL {
+	if config.ManageFunctions == nil {
+		return ddls
+	}
+
+	filtered := []DDL{}
+	for _, ddl := range ddls {
+		switch stmt := ddl.(type) {
+		case *Function:
+			if !isManagedFunction(config, defaultSchema, stmt.name.Schema.Name, stmt.name.Name.Name) {
+				slog.Debug("function is not managed by any manage.function rule; excluding it", "schema", stmt.name.Schema.Name, "function", stmt.name.Name.Name)
+				continue
+			}
+		case *Comment:
+			if strings.EqualFold(stmt.comment.ObjectType, "FUNCTION") && len(stmt.comment.Object) > 0 {
+				schema := ""
+				if len(stmt.comment.Object) >= 2 {
+					schema = stmt.comment.Object[len(stmt.comment.Object)-2].Name
+				}
+				name := stmt.comment.Object[len(stmt.comment.Object)-1].Name
+				if !isManagedFunction(config, defaultSchema, schema, name) {
+					continue
+				}
+			}
+		}
+		filtered = append(filtered, ddl)
+	}
+	return filtered
+}
+
+// isManagedFunction reports whether a function is managed by manage.function: it
+// must live in the default schema (an empty schema means the default) and its
+// name must match a rule.
+func isManagedFunction(config database.GeneratorConfig, defaultSchema, schema, name string) bool {
+	if schema != "" && schema != defaultSchema {
+		return false
+	}
+	_, matched := matchManageObjectRule(*config.ManageFunctions, name)
+	return matched
+}
+
 // isManagedGrantee reports whether privileges for grantee are managed: by
 // manage.privilege rules when present, else by the legacy managed_roles list.
 func isManagedGrantee(config database.GeneratorConfig, grantee string) bool {
@@ -6487,6 +6552,22 @@ func granteeRevokeAllowed(config database.GeneratorConfig, grantee string) bool 
 // global enable_drop pass handles it).
 func gateRevokeDDL(config database.GeneratorConfig, grantee, ddl string) string {
 	if config.ManagePrivileges != nil && !granteeRevokeAllowed(config, grantee) {
+		return "-- Skipped: " + ddl
+	}
+	return ddl
+}
+
+// gateFunctionDropDDL wraps a DROP FUNCTION statement in a skip comment when
+// manage.function forbids dropping funcName (the matched rule's drop is false,
+// or no rule matches). When manage.function is set the per-rule decision is
+// authoritative — the global enable_drop pass then preserves the remaining bare
+// DROP FUNCTION lines. In legacy mode the DDL is returned unchanged.
+func gateFunctionDropDDL(config database.GeneratorConfig, funcName, ddl string) string {
+	if config.ManageFunctions == nil {
+		return ddl
+	}
+	rule, matched := matchManageObjectRule(*config.ManageFunctions, funcName)
+	if !matched || !rule.Drop {
 		return "-- Skipped: " + ddl
 	}
 	return ddl

--- a/schema/generator_test.go
+++ b/schema/generator_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sqldef/sqldef/v3/database"
 	"github.com/sqldef/sqldef/v3/parser"
 	"github.com/stretchr/testify/assert"
 )
@@ -561,26 +562,75 @@ func TestIsDropStatement(t *testing.T) {
 }
 
 func TestCommentOutDropStatements(t *testing.T) {
+	none := database.GeneratorConfig{}
+	withPrivileges := database.GeneratorConfig{ManagePrivileges: &[]database.ManageObjectRule{}}
+	withFunctions := database.GeneratorConfig{ManageFunctions: &[]database.ManageObjectRule{}}
+
 	// Single-line drops keep the existing format.
 	assert.Equal(t,
 		[]string{`-- Skipped: DROP TABLE "public"."users"`},
-		commentOutDropStatements([]string{`DROP TABLE "public"."users"`}, false),
+		commentOutDropStatements([]string{`DROP TABLE "public"."users"`}, none),
 	)
 	// Non-drop statements pass through unchanged.
 	assert.Equal(t,
 		[]string{"CREATE TABLE users (id bigint)"},
-		commentOutDropStatements([]string{"CREATE TABLE users (id bigint)"}, false),
+		commentOutDropStatements([]string{"CREATE TABLE users (id bigint)"}, none),
 	)
-	// preserveRevokes keeps REVOKE statements executable (used when a
-	// manage.privilege rule allows dropping privileges for a role).
+	// manage.privilege keeps REVOKE statements executable (revoke gating is
+	// already decided per grantee at emission time).
 	assert.Equal(t,
 		[]string{`REVOKE SELECT ON TABLE users FROM app_user`},
-		commentOutDropStatements([]string{`REVOKE SELECT ON TABLE users FROM app_user`}, true),
+		commentOutDropStatements([]string{`REVOKE SELECT ON TABLE users FROM app_user`}, withPrivileges),
+	)
+	// manage.function keeps DROP FUNCTION executable (drop gating is already
+	// decided per function; a forbidden one already carries "-- Skipped: ").
+	assert.Equal(t,
+		[]string{`DROP FUNCTION "public"."managed_fn"`},
+		commentOutDropStatements([]string{`DROP FUNCTION "public"."managed_fn"`}, withFunctions),
+	)
+	// Without manage.function, DROP FUNCTION is still gated by enable_drop.
+	assert.Equal(t,
+		[]string{`-- Skipped: DROP FUNCTION "public"."f"`},
+		commentOutDropStatements([]string{`DROP FUNCTION "public"."f"`}, none),
 	)
 	// Every line of a multi-line statement is commented out so no executable
 	// SQL can leak after the first line.
 	assert.Equal(t,
 		[]string{"-- Skipped: DROP TABLE users;\n-- DROP TABLE orders;"},
-		commentOutDropStatements([]string{"DROP TABLE users;\nDROP TABLE orders;"}, false),
+		commentOutDropStatements([]string{"DROP TABLE users;\nDROP TABLE orders;"}, none),
 	)
+}
+
+func TestGateFunctionDropDDL(t *testing.T) {
+	drop := `DROP FUNCTION "public"."f"`
+
+	// Legacy mode (manage.function unset): unchanged; the global enable_drop
+	// pass handles it.
+	assert.Equal(t, drop, gateFunctionDropDDL(database.GeneratorConfig{}, "f", drop))
+
+	// Matched rule with drop:true → allowed (bare DDL).
+	allow := database.GeneratorConfig{ManageFunctions: &[]database.ManageObjectRule{{Target: "f", Drop: true}}}
+	assert.Equal(t, drop, gateFunctionDropDDL(allow, "f", drop))
+
+	// Matched rule with drop:false → skipped.
+	forbid := database.GeneratorConfig{ManageFunctions: &[]database.ManageObjectRule{{Target: "f"}}}
+	assert.Equal(t, "-- Skipped: "+drop, gateFunctionDropDDL(forbid, "f", drop))
+
+	// No rule matches → skipped (unmanaged functions are never dropped).
+	other := database.GeneratorConfig{ManageFunctions: &[]database.ManageObjectRule{{Target: "other", Drop: true}}}
+	assert.Equal(t, "-- Skipped: "+drop, gateFunctionDropDDL(other, "f", drop))
+}
+
+func TestIsManagedFunction(t *testing.T) {
+	config := database.GeneratorConfig{ManageFunctions: &[]database.ManageObjectRule{{Target: "app_.*"}}}
+
+	// Default schema (empty or explicit "public") + matching name → managed.
+	assert.True(t, isManagedFunction(config, "public", "", "app_touch"))
+	assert.True(t, isManagedFunction(config, "public", "public", "app_touch"))
+
+	// Matching name but a non-default schema → not managed (scoped to default).
+	assert.False(t, isManagedFunction(config, "public", "s2", "app_touch"))
+
+	// Default schema but no rule matches → not managed.
+	assert.False(t, isManagedFunction(config, "public", "public", "other_fn"))
 }

--- a/sqldef.go
+++ b/sqldef.go
@@ -93,6 +93,7 @@ func Run(generatorMode schema.GeneratorMode, db database.Database, sqlParser dat
 			ddls = schema.FilterViews(ddls, options.Config)
 			ddls = schema.FilterPrivileges(ddls, options.Config)
 			ddls = schema.FilterExtensions(ddls, options.Config)
+			ddls = schema.FilterFunctions(ddls, options.Config, defaultSchema)
 			for i, ddl := range ddls {
 				if i > 0 {
 					fmt.Println()

--- a/testutil/testcase.schema.json
+++ b/testutil/testcase.schema.json
@@ -65,7 +65,7 @@
         },
         "manage": {
           "type": "object",
-          "description": "manage: config block (see object-management.md). Only manage.extension and manage.privilege are implemented.",
+          "description": "manage: config block (see object-management.md). Only manage.extension, manage.function and manage.privilege are implemented.",
           "properties": {
             "extension": {
               "type": "array",
@@ -80,6 +80,25 @@
                   "drop": {
                     "type": "boolean",
                     "description": "Whether DROP EXTENSION is allowed for extensions matched by this rule.",
+                    "default": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "function": {
+              "type": "array",
+              "description": "Rules for which functions to manage. Only functions matching a rule's target are managed; unmatched functions are left untouched. An empty array manages all functions with drop disabled by default.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "target": {
+                    "type": "string",
+                    "description": "Regexp pattern matched against the function name, anchored with ^...$. Empty matches all."
+                  },
+                  "drop": {
+                    "type": "boolean",
+                    "description": "Whether DROP FUNCTION is allowed for functions matched by this rule (independent of enable_drop).",
                     "default": false
                   }
                 },

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -45,6 +45,7 @@ type TestCase struct {
 	} `yaml:"config"`
 	Manage struct {
 		Extension *[]database.ManageObjectRule `yaml:"extension"`
+		Function  *[]database.ManageObjectRule `yaml:"function"`
 		Privilege *[]database.ManageObjectRule `yaml:"privilege"`
 	} `yaml:"manage"`
 }
@@ -184,6 +185,7 @@ func RunTest(t *testing.T, db database.Database, test TestCase, mode schema.Gene
 
 	for name, rules := range map[string]*[]database.ManageObjectRule{
 		"extension": test.Manage.Extension,
+		"function":  test.Manage.Function,
 		"privilege": test.Manage.Privilege,
 	} {
 		if rules == nil {
@@ -202,6 +204,7 @@ func RunTest(t *testing.T, db database.Database, test TestCase, mode schema.Gene
 	config := database.GeneratorConfig{
 		ManagedRoles:            test.ManagedRoles,
 		ManageExtensions:        test.Manage.Extension,
+		ManageFunctions:         test.Manage.Function,
 		ManagePrivileges:        test.Manage.Privilege,
 		EnableDrop:              *test.EnableDrop,
 		CreateIndexConcurrently: test.Config.CreateIndexConcurrently,


### PR DESCRIPTION
## Summary

`manage.function` declares which functions psqldef manages, following the slice pattern of `manage.extension` (#1284) and `manage.privilege` (#1296) from the manage: RFC (#1072):

```yaml
manage:
  function:
    - target: 'app_.*'
    - target: 'tmp_.*'
      drop: true  # allows DROP FUNCTION
```

Functions matching no rule are left completely untouched: their definitions in the desired schema are ignored, and their existing definitions are excluded from the diff and `--export`. This lets a database keep functions maintained by another tool outside sqldef's control — for example AWS DMS's `awsdms_intercept_ddl` event-trigger function, which is present in every DMS-migrated database.

The per-rule `drop` flag gates `DROP FUNCTION` independently of the global `enable_drop` (which the manage: RFC deprecates): a function matched by a `drop: true` rule is dropped even when `enable_drop` is `false`, while otherwise the drop is commented out as `-- Skipped: ...`.

## Changes

- config: parse `manage.function` rules ({target, drop}, first match wins, target anchored regexp), sharing `ManageObjectRule` and the manage: key handling; enable `function` in `manageImplementedKeys`
- filtering: `FilterFunctions` excludes unmanaged functions (and their `COMMENT ON FUNCTION`) from both the desired and current sides
- drop gating: both the obsolete-cleanup drop and the replace-path drop go through `gateFunctionDropDDL`, and `commentOutDropStatements` preserves the authorized bare `DROP FUNCTION` lines
- scope: `manage.function` is scoped to the default schema (a rule with no schema field defaults to it, per the RFC); functions in other schemas are left untouched. Schema-qualified rules are not implemented yet.
- docs (cmd-psqldef.md) and round-trip tests, plus config-parse / gate / schema-scope unit tests

## Verification

- New round-trip tests in `tests_manage_function.yml`: create, unmatched-function-untouched, drop-forbidden, drop-allowed, and other-schema-untouched
- Unit tests for config parsing, `gateFunctionDropDDL`, and `isManagedFunction` (default-schema scoping)
- Full psqldef suites on PostgreSQL 13 & 18 (`PSQLDEF_PARSER=generic`), test-core, mysqldef (8.0), and sqlite3def pass locally; existing behavior unchanged when `manage.function` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)
