### PR TITLE
psqldef: update changed functions with CREATE OR REPLACE instead of DROP + CREATE

### DIFF
--- a/cmd/psqldef/tests_functions.yml
+++ b/cmd/psqldef/tests_functions.yml
@@ -397,3 +397,79 @@ CreateFunctionWithDefaultArgs:
     $$ LANGUAGE plpgsql VOLATILE;
   up: ""
   down: ""
+
+# Changing only the body of an existing function uses CREATE OR REPLACE, so it
+# converges without dropping (and works even with enable_drop: false).
+FunctionBodyChangeUsesCreateOrReplace:
+  legacy_ignore_quotes: false
+  enable_drop: false
+  current: |
+    CREATE FUNCTION add_one(x integer) RETURNS integer AS $$ BEGIN RETURN x + 1; END; $$ LANGUAGE plpgsql;
+  desired: |
+    CREATE FUNCTION add_one(x integer) RETURNS integer AS $$ BEGIN RETURN x + 2; END; $$ LANGUAGE plpgsql;
+  up: |
+    CREATE OR REPLACE FUNCTION add_one(x integer) RETURNS integer AS $$ BEGIN RETURN x + 2; END; $$ LANGUAGE plpgsql;
+  down: |
+    CREATE OR REPLACE FUNCTION add_one(x integer) RETURNS integer AS $$ BEGIN RETURN x + 1; END; $$ LANGUAGE plpgsql;
+
+# Changing the return type cannot go through CREATE OR REPLACE (PostgreSQL
+# rejects it), so the function is dropped and recreated.
+FunctionReturnTypeChangeDropsAndRecreates:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE FUNCTION get_val() RETURNS integer AS $$ BEGIN RETURN 1; END; $$ LANGUAGE plpgsql;
+  desired: |
+    CREATE FUNCTION get_val() RETURNS text AS $$ BEGIN RETURN 'x'; END; $$ LANGUAGE plpgsql;
+  up: |
+    DROP FUNCTION public.get_val();
+    CREATE FUNCTION get_val() RETURNS text AS $$ BEGIN RETURN 'x'; END; $$ LANGUAGE plpgsql;
+  down: |
+    DROP FUNCTION public.get_val();
+    CREATE FUNCTION get_val() RETURNS integer AS $$ BEGIN RETURN 1; END; $$ LANGUAGE plpgsql;
+
+# Changing an argument type cannot go through CREATE OR REPLACE (it would
+# create an overload instead of replacing), so drop and recreate.
+FunctionArgTypeChangeDropsAndRecreates:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE FUNCTION twice(x integer) RETURNS integer AS $$ BEGIN RETURN x * 2; END; $$ LANGUAGE plpgsql;
+  desired: |
+    CREATE FUNCTION twice(x bigint) RETURNS bigint AS $$ BEGIN RETURN x * 2; END; $$ LANGUAGE plpgsql;
+  up: |
+    DROP FUNCTION public.twice(integer);
+    CREATE FUNCTION twice(x bigint) RETURNS bigint AS $$ BEGIN RETURN x * 2; END; $$ LANGUAGE plpgsql;
+  down: |
+    DROP FUNCTION public.twice(bigint);
+    CREATE FUNCTION twice(x integer) RETURNS integer AS $$ BEGIN RETURN x * 2; END; $$ LANGUAGE plpgsql;
+
+# Even when the desired statement already says OR REPLACE, a signature change
+# still needs DROP first; OR REPLACE alone would error (return type) or create
+# an overload (argument types).
+FunctionOrReplaceWithReturnTypeChangeDropsFirst:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE FUNCTION fmt_val() RETURNS integer AS $$ BEGIN RETURN 1; END; $$ LANGUAGE plpgsql;
+  desired: |
+    CREATE OR REPLACE FUNCTION fmt_val() RETURNS text AS $$ BEGIN RETURN 'v'; END; $$ LANGUAGE plpgsql;
+  up: |
+    DROP FUNCTION public.fmt_val();
+    CREATE OR REPLACE FUNCTION fmt_val() RETURNS text AS $$ BEGIN RETURN 'v'; END; $$ LANGUAGE plpgsql;
+  down: |
+    DROP FUNCTION public.fmt_val();
+    CREATE FUNCTION fmt_val() RETURNS integer AS $$ BEGIN RETURN 1; END; $$ LANGUAGE plpgsql;
+
+# RETURNS TABLE(...) loses its column list in parsing, so a change to a
+# table-returning function always drops and recreates (OR REPLACE could not be
+# proven safe, and PostgreSQL rejects it when the columns differ).
+FunctionReturnsTableChangeDropsAndRecreates:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE FUNCTION list_items() RETURNS TABLE(id integer) AS $$ SELECT 1 $$ LANGUAGE sql;
+  desired: |
+    CREATE FUNCTION list_items() RETURNS TABLE(id integer, label text) AS $$ SELECT 1, 'a'::text $$ LANGUAGE sql;
+  up: |
+    DROP FUNCTION public.list_items();
+    CREATE FUNCTION list_items() RETURNS TABLE(id integer, label text) AS $$ SELECT 1, 'a'::text $$ LANGUAGE sql;
+  down: |
+    DROP FUNCTION public.list_items();
+    CREATE FUNCTION list_items() RETURNS TABLE(id integer) AS $$ SELECT 1 $$ LANGUAGE sql;

--- a/cmd/psqldef/tests_functions.yml
+++ b/cmd/psqldef/tests_functions.yml
@@ -473,3 +473,21 @@ FunctionReturnsTableChangeDropsAndRecreates:
   down: |
     DROP FUNCTION public.list_items();
     CREATE FUNCTION list_items() RETURNS TABLE(id integer) AS $$ SELECT 1 $$ LANGUAGE sql;
+
+# Overloaded functions (same name, different argument types) are matched and
+# replaced independently; neither is dropped or lost during dependency sorting.
+OverloadedFunctionsBothReplacedInPlace:
+  legacy_ignore_quotes: false
+  enable_drop: false
+  current: |
+    CREATE FUNCTION ovl(a integer) RETURNS integer AS $$ BEGIN RETURN 1; END; $$ LANGUAGE plpgsql;
+    CREATE FUNCTION ovl(a text) RETURNS text AS $$ BEGIN RETURN 'a'; END; $$ LANGUAGE plpgsql;
+  desired: |
+    CREATE FUNCTION ovl(a integer) RETURNS integer AS $$ BEGIN RETURN 2; END; $$ LANGUAGE plpgsql;
+    CREATE FUNCTION ovl(a text) RETURNS text AS $$ BEGIN RETURN 'b'; END; $$ LANGUAGE plpgsql;
+  up: |
+    CREATE OR REPLACE FUNCTION ovl(a integer) RETURNS integer AS $$ BEGIN RETURN 2; END; $$ LANGUAGE plpgsql;
+    CREATE OR REPLACE FUNCTION ovl(a text) RETURNS text AS $$ BEGIN RETURN 'b'; END; $$ LANGUAGE plpgsql;
+  down: |
+    CREATE OR REPLACE FUNCTION ovl(a integer) RETURNS integer AS $$ BEGIN RETURN 1; END; $$ LANGUAGE plpgsql;
+    CREATE OR REPLACE FUNCTION ovl(a text) RETURNS text AS $$ BEGIN RETURN 'a'; END; $$ LANGUAGE plpgsql;

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -9763,7 +9763,7 @@ yydefault:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line parser/parser.y:3187
 		{
-			yyVAL.str = ""
+			yyVAL.str = "or replace"
 		}
 	case 337:
 		yyDollar = yyS[yypt-3 : yypt+1]

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -3185,7 +3185,7 @@ or_replace_opt:
   }
 | OR REPLACE
   {
-    $$ = ""
+    $$ = "or replace"
   }
 
 drop_statement:

--- a/schema/ast.go
+++ b/schema/ast.go
@@ -442,6 +442,7 @@ type Function struct {
 // FunctionArg is the schema-level representation of a function argument.
 // Used by dependency analysis to detect Function -> Type/Domain edges.
 type FunctionArg struct {
+	mode string // "", "IN", "OUT", "INOUT", "VARIADIC" ("" means IN)
 	name Ident
 	typ  string
 }

--- a/schema/ddl_ordering.go
+++ b/schema/ddl_ordering.go
@@ -365,9 +365,29 @@ func SortTablesByDependencies(ddls []DDL, defaultSchema string, mode GeneratorMo
 		itemKeys[DDL(v)] = viewKeys[i]
 	}
 
-	sorted := topologicalSort(sortItems, dependencies, func(d DDL) string { return itemKeys[d] })
-	if len(sorted) == 0 {
-		sorted = sortItems
+	// Multiple items can share a dependency key: overloaded PostgreSQL functions
+	// have the same name but different argument types. topologicalSort keys nodes
+	// by id, so passing duplicates would collapse them (one representative wins
+	// and gets replayed, the others dropped). Sort one representative per key,
+	// then expand each back to all its items in their original order.
+	reps := make([]DDL, 0, len(sortItems))
+	groups := make(map[string][]DDL, len(sortItems))
+	for _, item := range sortItems {
+		key := itemKeys[item]
+		if _, seen := groups[key]; !seen {
+			reps = append(reps, item)
+		}
+		groups[key] = append(groups[key], item)
+	}
+
+	sortedReps := topologicalSort(reps, dependencies, func(d DDL) string { return itemKeys[d] })
+	if len(sortedReps) == 0 {
+		sortedReps = reps
+	}
+
+	sorted := make([]DDL, 0, len(sortItems))
+	for _, rep := range sortedReps {
+		sorted = append(sorted, groups[itemKeys[rep]]...)
 	}
 
 	var result []DDL

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -2562,14 +2562,31 @@ func (g *Generator) generateDDLsForCreateTrigger(triggerName QualifiedName, desi
 func (g *Generator) generateDDLsForCreateFunction(desired *Function) ([]string, error) {
 	var ddls []string
 
-	currentFunction := g.findFunctionByName(g.currentFunctions, desired.name)
+	currentFunction, unmatchedOverloads := g.findReplaceTargetFunction(desired)
 	if currentFunction == nil {
 		// Function does not exist, create it
 		ddls = append(ddls, desired.statement)
 	} else if !g.areSameFunctionDefinition(currentFunction, desired) {
-		// Function exists but is different, use CREATE OR REPLACE
-		// Modify the statement to include OR REPLACE if not already present
-		if desired.orReplace {
+		// PostgreSQL can update a function in place with CREATE OR REPLACE, but
+		// only while the signature (argument modes/names/types and return type)
+		// stays the same: changing the return type is an error, and changing
+		// argument types would create an overload instead of replacing. So:
+		// same signature -> CREATE OR REPLACE (no drop, dependent objects
+		// survive); changed signature -> DROP + CREATE, the only way PostgreSQL
+		// allows it. When overloads make the pairing ambiguous, or on other
+		// dialects, the previous behavior is kept.
+		if g.mode == GeneratorModePostgres && !unmatchedOverloads {
+			if replacement, ok := g.functionReplacementDDL(currentFunction, desired); ok {
+				ddls = append(ddls, replacement)
+			} else {
+				// Signature changed: PostgreSQL requires DROP + CREATE. Gate the
+				// DROP through manage.function so a drop:false rule still forbids
+				// it (the global enable_drop pass preserves bare DROP FUNCTION
+				// lines when manage.function is set).
+				ddls = append(ddls, gateFunctionDropDDL(g.config, currentFunction.name.Name.Name, g.dropFunctionDDL(currentFunction)))
+				ddls = append(ddls, desired.statement)
+			}
+		} else if desired.orReplace {
 			ddls = append(ddls, desired.statement)
 		} else {
 			dropDDL := "DROP FUNCTION " + g.escapeQualifiedName(currentFunction.name)
@@ -2593,6 +2610,169 @@ func (g *Generator) findFunctionByName(functions []*Function, name QualifiedName
 		}
 	}
 	return nil
+}
+
+// findReplaceTargetFunction picks the current function that desired should be
+// compared against. With PostgreSQL overloads (same name, different argument
+// types) it prefers the one matching the desired signature; when several
+// same-named functions exist and none matches, unmatchedOverloads is true and
+// the caller keeps the legacy behavior instead of guessing.
+func (g *Generator) findReplaceTargetFunction(desired *Function) (current *Function, unmatchedOverloads bool) {
+	var sameNamed []*Function
+	for _, f := range g.currentFunctions {
+		if qualifiedNamesEqual(f.name, desired.name, g.defaultSchema, g.mode, g.config.LegacyIgnoreQuotes, g.config.MysqlLowerCaseTableNames) {
+			sameNamed = append(sameNamed, f)
+		}
+	}
+	switch len(sameNamed) {
+	case 0:
+		return nil, false
+	case 1:
+		return sameNamed[0], false
+	}
+	for _, f := range sameNamed {
+		if g.areSameFunctionSignature(f, desired) {
+			return f, false
+		}
+	}
+	return sameNamed[0], true
+}
+
+// functionReplacementDDL returns the single in-place replacement statement for
+// a changed PostgreSQL function, or ok=false when the change needs DROP +
+// CREATE (signature changed, or the statement cannot be rewritten).
+func (g *Generator) functionReplacementDDL(current, desired *Function) (string, bool) {
+	if !g.areSameFunctionSignature(current, desired) {
+		return "", false
+	}
+	if desired.orReplace {
+		return desired.statement, true
+	}
+	return insertOrReplaceIntoCreateFunction(desired.statement)
+}
+
+// areSameFunctionSignature reports whether two functions share the identity
+// PostgreSQL requires for CREATE OR REPLACE: the same argument list (modes,
+// names, and types, in order) and the same return type. Types are compared
+// after normalizing common PostgreSQL aliases (int/integer, varchar/character
+// varying, ...) because the current side comes from pg_get_functiondef, which
+// always prints canonical names. Any remaining mismatch is conservative and
+// falls back to DROP + CREATE.
+func (g *Generator) areSameFunctionSignature(a, b *Function) bool {
+	// The grammar collapses RETURNS TABLE(...) to "TABLE", dropping the column
+	// list, so table-returning functions can never be proven replaceable.
+	if strings.EqualFold(a.returnType, "TABLE") || strings.EqualFold(b.returnType, "TABLE") {
+		return false
+	}
+	if normalizePGFunctionType(a.returnType) != normalizePGFunctionType(b.returnType) || len(a.args) != len(b.args) {
+		return false
+	}
+	for i := range a.args {
+		ca, da := a.args[i], b.args[i]
+		if functionArgMode(ca.mode) != functionArgMode(da.mode) {
+			return false
+		}
+		// Argument names fold like identifiers (unquoted ones lower-case).
+		// PostgreSQL allows adding a name to a previously unnamed parameter,
+		// but not renaming an existing one.
+		can, dan := foldedIdentName(ca.name), foldedIdentName(da.name)
+		if can != "" && can != dan {
+			return false
+		}
+		if normalizePGFunctionType(ca.typ) != normalizePGFunctionType(da.typ) {
+			return false
+		}
+	}
+	return true
+}
+
+func functionArgMode(mode string) string {
+	if mode == "" {
+		return "IN"
+	}
+	return strings.ToUpper(mode)
+}
+
+// foldedIdentName returns the identifier name as PostgreSQL resolves it:
+// quoted identifiers keep their exact case, unquoted ones fold to lower case.
+func foldedIdentName(id Ident) string {
+	if id.Quoted {
+		return id.Name
+	}
+	return strings.ToLower(id.Name)
+}
+
+// pgFunctionTypeAliases maps PostgreSQL type spellings to the canonical names
+// pg_get_functiondef prints. Only exact aliases are listed; timestamptz maps to
+// "timestamp with time zone" (the same type), never to plain timestamp.
+var pgFunctionTypeAliases = map[string]string{
+	"int":         "integer",
+	"int4":        "integer",
+	"int2":        "smallint",
+	"int8":        "bigint",
+	"bool":        "boolean",
+	"varchar":     "character varying",
+	"char":        "character",
+	"bpchar":      "character",
+	"float4":      "real",
+	"float8":      "double precision",
+	"decimal":     "numeric",
+	"timestamptz": "timestamp with time zone",
+	"timetz":      "time with time zone",
+}
+
+// normalizePGFunctionType canonicalizes a function argument/return type for
+// comparison: lower-cased, whitespace-collapsed, with common aliases mapped to
+// the names pg_get_functiondef prints. Array suffixes are preserved.
+func normalizePGFunctionType(typ string) string {
+	t := strings.ToLower(strings.TrimSpace(typ))
+	t = strings.Join(strings.Fields(t), " ")
+	suffix := ""
+	for strings.HasSuffix(t, "[]") {
+		t = strings.TrimSpace(strings.TrimSuffix(t, "[]"))
+		suffix += "[]"
+	}
+	if canonical, ok := pgFunctionTypeAliases[t]; ok {
+		t = canonical
+	}
+	return t + suffix
+}
+
+// dropFunctionDDL renders DROP FUNCTION for current. In PostgreSQL the
+// identity argument types are appended when known so the drop stays
+// unambiguous under overloads; OUT parameters are not part of the identity, so
+// the bare form is kept when any non-input argument is present.
+func (g *Generator) dropFunctionDDL(current *Function) string {
+	base := "DROP FUNCTION " + g.escapeQualifiedName(current.name)
+	argTypes := make([]string, 0, len(current.args))
+	for _, arg := range current.args {
+		switch functionArgMode(arg.mode) {
+		case "IN":
+			argTypes = append(argTypes, arg.typ)
+		case "VARIADIC":
+			argTypes = append(argTypes, "VARIADIC "+arg.typ)
+		default: // OUT/INOUT: play safe with the bare form
+			return base
+		}
+	}
+	return base + "(" + strings.Join(argTypes, ", ") + ")"
+}
+
+// insertOrReplaceIntoCreateFunction splices OR REPLACE after the leading
+// CREATE keyword. The decision that the statement lacks OR REPLACE comes from
+// the parser (desired.orReplace); this only performs the insertion. ok is
+// false when the statement doesn't begin with the CREATE keyword (e.g. an
+// attached leading comment); callers then fall back to DROP + CREATE.
+func insertOrReplaceIntoCreateFunction(stmt string) (string, bool) {
+	trimmed := strings.TrimLeft(stmt, " \t\r\n")
+	if len(trimmed) > 6 && strings.EqualFold(trimmed[:6], "CREATE") {
+		switch trimmed[6] {
+		case ' ', '\t', '\r', '\n':
+			lead := stmt[:len(stmt)-len(trimmed)]
+			return lead + trimmed[:6] + " OR REPLACE" + trimmed[6:], true
+		}
+	}
+	return stmt, false
 }
 
 func (g *Generator) areSameFunctionDefinition(a, b *Function) bool {

--- a/schema/generator_test.go
+++ b/schema/generator_test.go
@@ -840,3 +840,94 @@ func TestIsManagedFunction(t *testing.T) {
 	// Default schema but no rule matches → not managed.
 	assert.False(t, isManagedFunction(config, "public", "public", "other_fn"))
 }
+
+func TestInsertOrReplaceIntoCreateFunction(t *testing.T) {
+	// OR REPLACE is spliced after CREATE, preserving the original casing.
+	got, ok := insertOrReplaceIntoCreateFunction("CREATE FUNCTION f() RETURNS integer AS $$ SELECT 1 $$ LANGUAGE sql;")
+	assert.True(t, ok)
+	assert.Equal(t, "CREATE OR REPLACE FUNCTION f() RETURNS integer AS $$ SELECT 1 $$ LANGUAGE sql;", got)
+
+	got, ok = insertOrReplaceIntoCreateFunction("create function f() returns integer as $$ select 1 $$ language sql;")
+	assert.True(t, ok)
+	assert.Equal(t, "create OR REPLACE function f() returns integer as $$ select 1 $$ language sql;", got)
+
+	// A comment between CREATE and FUNCTION stays in place and the result is
+	// still valid SQL.
+	got, ok = insertOrReplaceIntoCreateFunction("CREATE /* c */ FUNCTION f() RETURNS integer AS $$ SELECT 1 $$ LANGUAGE sql;")
+	assert.True(t, ok)
+	assert.Equal(t, "CREATE OR REPLACE /* c */ FUNCTION f() RETURNS integer AS $$ SELECT 1 $$ LANGUAGE sql;", got)
+
+	_, ok = insertOrReplaceIntoCreateFunction("  CREATE FUNCTION f() RETURNS integer AS $$ SELECT 1 $$ LANGUAGE sql;")
+	assert.True(t, ok)
+
+	// A leading comment defeats the splice; callers fall back to DROP+CREATE.
+	_, ok = insertOrReplaceIntoCreateFunction("-- note\nCREATE FUNCTION f() RETURNS integer AS $$ SELECT 1 $$ LANGUAGE sql;")
+	assert.False(t, ok)
+}
+
+func TestAreSameFunctionSignature(t *testing.T) {
+	g := &Generator{mode: GeneratorModePostgres}
+	fn := func(returnType string, args ...FunctionArg) *Function {
+		return &Function{returnType: returnType, args: args}
+	}
+	arg := func(name, typ string) FunctionArg {
+		return FunctionArg{name: parser.NewIdent(name, false), typ: typ}
+	}
+
+	base := fn("integer", arg("x", "integer"), arg("y", "text"))
+	assert.True(t, g.areSameFunctionSignature(base, fn("integer", arg("x", "integer"), arg("y", "text"))))
+
+	// Common type aliases equal their canonical spelling (the current side
+	// always comes from pg_get_functiondef, which prints canonical names).
+	assert.True(t, g.areSameFunctionSignature(base, fn("int", arg("x", "int4"), arg("y", "text"))))
+	assert.True(t, g.areSameFunctionSignature(
+		fn("character varying", arg("v", "character varying")),
+		fn("varchar", arg("v", "varchar"))))
+	assert.True(t, g.areSameFunctionSignature(
+		fn("integer[]", arg("xs", "integer[]")),
+		fn("int[]", arg("xs", "int[]"))))
+
+	// Unquoted argument names fold to lower case; quoted ones keep their case.
+	assert.True(t, g.areSameFunctionSignature(base, fn("integer", arg("X", "integer"), arg("y", "text"))))
+	quoted := fn("integer", FunctionArg{name: parser.NewIdent("X", true), typ: "integer"}, arg("y", "text"))
+	assert.False(t, g.areSameFunctionSignature(quoted, base))
+
+	// Adding a name to an unnamed parameter is allowed; renaming is not.
+	unnamed := fn("integer", arg("", "integer"), arg("y", "text"))
+	assert.True(t, g.areSameFunctionSignature(unnamed, base))
+	assert.False(t, g.areSameFunctionSignature(base, fn("integer", arg("z", "integer"), arg("y", "text"))))
+
+	// Changed return type / arg type / arity are never replaceable.
+	assert.False(t, g.areSameFunctionSignature(base, fn("text", arg("x", "integer"), arg("y", "text"))))
+	assert.False(t, g.areSameFunctionSignature(base, fn("integer", arg("x", "bigint"), arg("y", "text"))))
+	assert.False(t, g.areSameFunctionSignature(base, fn("integer", arg("x", "integer"))))
+
+	// Argument modes are part of the identity ("" means IN).
+	outArg := fn("integer", FunctionArg{mode: "OUT", name: parser.NewIdent("x", false), typ: "integer"}, arg("y", "text"))
+	assert.False(t, g.areSameFunctionSignature(base, outArg))
+	inExplicit := fn("integer", FunctionArg{mode: "IN", name: parser.NewIdent("x", false), typ: "integer"}, arg("y", "text"))
+	assert.True(t, g.areSameFunctionSignature(base, inExplicit))
+
+	// RETURNS TABLE(...) loses its column list in parsing, so it is never
+	// considered replaceable.
+	assert.False(t, g.areSameFunctionSignature(fn("TABLE"), fn("TABLE")))
+}
+
+func TestDropFunctionDDL(t *testing.T) {
+	g := &Generator{mode: GeneratorModePostgres, defaultSchema: "public"}
+	name := database.QualifiedName{Schema: parser.NewIdent("public", false), Name: parser.NewIdent("f", false)}
+
+	// Identity argument types are appended so overloads stay unambiguous.
+	fn := &Function{name: name, args: []FunctionArg{
+		{name: parser.NewIdent("x", false), typ: "integer"},
+		{mode: "VARIADIC", name: parser.NewIdent("rest", false), typ: "text[]"},
+	}}
+	assert.Equal(t, "DROP FUNCTION "+g.escapeQualifiedName(name)+"(integer, VARIADIC text[])", g.dropFunctionDDL(fn))
+
+	// Zero arguments.
+	assert.Equal(t, "DROP FUNCTION "+g.escapeQualifiedName(name)+"()", g.dropFunctionDDL(&Function{name: name}))
+
+	// OUT parameters are not part of the identity: keep the bare form.
+	outFn := &Function{name: name, args: []FunctionArg{{mode: "OUT", name: parser.NewIdent("x", false), typ: "integer"}}}
+	assert.Equal(t, "DROP FUNCTION "+g.escapeQualifiedName(name), g.dropFunctionDDL(outFn))
+}

--- a/schema/parser.go
+++ b/schema/parser.go
@@ -242,6 +242,7 @@ func parseDDL(mode GeneratorMode, ddl string, stmt parser.Statement, defaultSche
 			var args []FunctionArg
 			for _, arg := range stmt.Function.Args {
 				args = append(args, FunctionArg{
+					mode: arg.Mode,
 					name: arg.Name,
 					typ:  arg.Type,
 				})


### PR DESCRIPTION
## Summary

When a function's body (or another non-signature property) changed, `generateDDLsForCreateFunction` emitted `DROP FUNCTION` + `CREATE` even though its own comment said it should "use CREATE OR REPLACE". The destructive drop-and-recreate loses dependent objects (triggers, views, column defaults), GRANTs and COMMENTs; and under `enable_drop: false` the `DROP` is skipped while the plain `CREATE` then fails with `already exists`, so the change never converges.

While fixing this I found and fixed two underlying bugs, so this PR has two commits.

## Commit 1 — update changed functions with CREATE OR REPLACE

For PostgreSQL, a changed function is now updated in place with `CREATE OR REPLACE` when its **signature** is unchanged, and only dropped-and-recreated when the signature changed (which PostgreSQL requires: changing the return type is an error, and changing argument types creates an overload instead of replacing).

- **Root cause of the redundant drop**: the generic grammar's `or_replace_opt` action returned `""` for `OR REPLACE`, so `Function.OrReplace` was never set and the `OR REPLACE` branch was dead code. The grammar now yields a non-empty value, making the flag reliable (no structural change — conflict counts are unchanged).
- **Signature identity** compares argument modes (`IN`/`OUT`/`INOUT`/`VARIADIC`), names (folded like identifiers — unquoted lower-cased, quoted preserved; adding a name to an unnamed parameter is allowed, renaming is not), and types normalized across common aliases (`int`/`integer`, `varchar`/`character varying`, …) since the current side comes from `pg_get_functiondef`.
- `RETURNS TABLE(...)` loses its column list in parsing, so it is always treated as non-replaceable (drop + create).
- **Overloads**: the changed function is paired with the current definition sharing its signature; when the pairing is ambiguous the previous behavior is kept. `DROP FUNCTION` now carries the identity argument types so it stays unambiguous under overloads.
- OR REPLACE is spliced in via a token check on the leading `CREATE` keyword (no regex SQL parsing); the decision that it's missing comes from the parsed `OrReplace` flag.
- Other dialects are unchanged.

## Commit 2 — keep overloaded functions distinct when ordering DDLs

`SortTablesByDependencies` keyed every object by its normalized name, so PostgreSQL functions overloaded on argument types collapsed to one node in `topologicalSort`: one representative was replayed for every slot, silently dropping the other overloads and duplicating one. This corrupted output whenever two same-named functions appeared together (reproducible on the current tree, independent of commit 1). Items sharing a key are now grouped, one representative per key is sorted, then each is expanded back to all its items in original order; single-item keys (the common case) are unaffected.

## Verification

- New unit tests (`areSameFunctionSignature`, `insertOrReplaceIntoCreateFunction`, `dropFunctionDDL`) and round-trip tests (`tests_functions.yml`): body change → CREATE OR REPLACE; return-type / argument-type / OR-REPLACE-with-return-type change → drop + recreate; `RETURNS TABLE` change → drop + recreate; overloaded functions both replaced in place.
- Verified on a live PostgreSQL that a body change preserves a dependent trigger, the function COMMENT, and a GRANT, and applies the new body.
- `test-core`, psqldef on PostgreSQL 13 / 18 / pgvector, mysqldef on MySQL 8.0 / 9 / MariaDB 12 / TiDB, sqlite3def, `go vet`, and `make parser` (deterministic, conflict counts unchanged) all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
