### PR TITLE
psqldef: fix same-named foreign keys on different tables being merged in export

### DIFF
--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -739,6 +739,49 @@ func TestPsqldefExport(t *testing.T) {
 	))
 }
 
+func TestPsqldefExportForeignKeysWithSameName(t *testing.T) {
+	resetTestDatabase()
+
+	mustPgExec(testDatabaseName, tu.StripHeredoc(`
+		CREATE TABLE accounts (
+		    tenant_id integer NOT NULL,
+		    id integer NOT NULL,
+		    PRIMARY KEY (tenant_id, id),
+		    UNIQUE (id)
+		);
+		CREATE TABLE payment_accounts (
+		    id integer PRIMARY KEY
+		);
+		CREATE TABLE orders (
+		    tenant_id integer,
+		    account_id integer,
+		    CONSTRAINT shared_fk
+		        FOREIGN KEY (tenant_id, account_id)
+		        REFERENCES accounts (tenant_id, id)
+		        ON UPDATE CASCADE
+		        ON DELETE RESTRICT
+		        DEFERRABLE INITIALLY DEFERRED
+		);
+		CREATE TABLE payments (
+		    account_id integer,
+		    CONSTRAINT shared_fk
+		        FOREIGN KEY (account_id)
+		        REFERENCES payment_accounts (id)
+		        ON UPDATE RESTRICT
+		        ON DELETE SET NULL
+		);`,
+	))
+
+	output := tu.MustExecute(t, "./psqldef", psqldefArgs(testDatabaseName, "--export")...)
+	ordersForeignKey := `ALTER TABLE ONLY "public"."orders" ADD CONSTRAINT "shared_fk" FOREIGN KEY ("tenant_id", "account_id") REFERENCES "public"."accounts" ("tenant_id", "id") ON UPDATE CASCADE ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED;`
+	paymentsForeignKey := `ALTER TABLE ONLY "public"."payments" ADD CONSTRAINT "shared_fk" FOREIGN KEY ("account_id") REFERENCES "public"."payment_accounts" ("id") ON UPDATE RESTRICT ON DELETE SET NULL;`
+
+	assert.Contains(t, output, ordersForeignKey)
+	assert.Contains(t, output, paymentsForeignKey)
+	assert.Equal(t, 2, strings.Count(output, `ADD CONSTRAINT "shared_fk"`))
+	assert.Less(t, strings.Index(output, ordersForeignKey), strings.Index(output, paymentsForeignKey))
+}
+
 func TestPsqldefExportManageExtensions(t *testing.T) {
 	resetTestDatabase()
 

--- a/cmd/psqldef/tests_constraints.yml
+++ b/cmd/psqldef/tests_constraints.yml
@@ -386,6 +386,64 @@ CompositeForeignKeyConstraint:
     ALTER TABLE "public"."t2" ADD CONSTRAINT "fk" FOREIGN KEY ("id1","id2") REFERENCES "public"."t1" ("id1","id2");
   down: |
     ALTER TABLE "public"."t2" DROP CONSTRAINT "fk";
+SeparateTablesWithSameForeignKeyName:
+  current: |
+    CREATE TABLE accounts (
+      tenant_id integer NOT NULL,
+      id integer NOT NULL,
+      PRIMARY KEY (tenant_id, id),
+      UNIQUE (id)
+    );
+    CREATE TABLE payment_accounts (
+      id integer PRIMARY KEY
+    );
+    CREATE TABLE orders (
+      tenant_id integer,
+      account_id integer,
+      CONSTRAINT shared_fk
+        FOREIGN KEY (tenant_id, account_id)
+        REFERENCES accounts (tenant_id, id)
+        ON UPDATE CASCADE
+        ON DELETE RESTRICT
+        DEFERRABLE INITIALLY DEFERRED
+    );
+    CREATE TABLE payments (
+      account_id integer,
+      CONSTRAINT shared_fk
+        FOREIGN KEY (account_id)
+        REFERENCES payment_accounts (id)
+        ON UPDATE RESTRICT
+        ON DELETE SET NULL
+    );
+  desired: |
+    CREATE TABLE accounts (
+      tenant_id integer NOT NULL,
+      id integer NOT NULL,
+      PRIMARY KEY (tenant_id, id),
+      UNIQUE (id)
+    );
+    CREATE TABLE payment_accounts (
+      id integer PRIMARY KEY
+    );
+    CREATE TABLE orders (
+      tenant_id integer,
+      account_id integer,
+      CONSTRAINT shared_fk
+        FOREIGN KEY (tenant_id, account_id)
+        REFERENCES accounts (tenant_id, id)
+        ON UPDATE CASCADE
+        ON DELETE RESTRICT
+        DEFERRABLE INITIALLY DEFERRED
+    );
+    CREATE TABLE payments (
+      account_id integer,
+      CONSTRAINT shared_fk
+        FOREIGN KEY (account_id)
+        REFERENCES payment_accounts (id)
+        ON UPDATE RESTRICT
+        ON DELETE SET NULL
+    );
+  legacy_ignore_quotes: false
 AddForeignKeyWithAlter:
   current: |
     CREATE TABLE users (id BIGINT PRIMARY KEY);

--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -1667,6 +1667,9 @@ func (d *PostgresDatabase) getForeignDefsForTables(tableNames []string) (map[str
 		c.foreignColumns = append(c.foreignColumns, foreignColumnName)
 		constraints[key] = c
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	var keys []identifier
 	for key := range constraints {

--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -1673,16 +1673,12 @@ func (d *PostgresDatabase) getForeignDefsForTables(tableNames []string) (map[str
 		keys = append(keys, key)
 	}
 	slices.SortFunc(keys, func(a, b identifier) int {
-		if c := cmp.Compare(a.constraintSchema, b.constraintSchema); c != 0 {
-			return c
-		}
-		if c := cmp.Compare(a.tableSchema, b.tableSchema); c != 0 {
-			return c
-		}
-		if c := cmp.Compare(a.tableName, b.tableName); c != 0 {
-			return c
-		}
-		return cmp.Compare(a.constraintName, b.constraintName)
+		return cmp.Or(
+			cmp.Compare(a.constraintSchema, b.constraintSchema),
+			cmp.Compare(a.tableSchema, b.tableSchema),
+			cmp.Compare(a.tableName, b.tableName),
+			cmp.Compare(a.constraintName, b.constraintName),
+		)
 	})
 
 	result := make(map[string][]string, len(tableNames))

--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -1619,7 +1619,7 @@ func (d *PostgresDatabase) getForeignDefsForTables(tableNames []string) (map[str
 		ON  a2.attrelid = c.confrelid
 		AND a2.attnum   = k.key2
 	WHERE c.contype = 'f' AND n1.nspname || '.' || r1.relname = ANY($1::text[])
-	ORDER BY constraint_schema, constraint_name, k.ordinality
+	ORDER BY constraint_schema, table_schema, table_name, constraint_name, k.ordinality
 	`, periodCol)
 
 	rows, err := d.db.Query(query, pq.Array(tableNames))
@@ -1629,7 +1629,10 @@ func (d *PostgresDatabase) getForeignDefsForTables(tableNames []string) (map[str
 	defer rows.Close()
 
 	type identifier struct {
-		schema, name string
+		constraintSchema string
+		tableSchema      string
+		tableName        string
+		constraintName   string
 	}
 	type constraint struct {
 		tableSchema, constraintName, tableName, foreignTableSchema, foreignTableName, foreignUpdateRule, foreignDeleteRule string
@@ -1646,7 +1649,12 @@ func (d *PostgresDatabase) getForeignDefsForTables(tableNames []string) (map[str
 		if err != nil {
 			return nil, err
 		}
-		key := identifier{constraintSchema, constraintName}
+		key := identifier{
+			constraintSchema: constraintSchema,
+			tableSchema:      tableSchema,
+			tableName:        tableName,
+			constraintName:   constraintName,
+		}
 		if _, exist := constraints[key]; !exist {
 			constraints[key] = constraint{
 				tableSchema, constraintName, tableName, foreignTableSchema, foreignTableName, foreignUpdateRule, foreignDeleteRule,
@@ -1665,10 +1673,16 @@ func (d *PostgresDatabase) getForeignDefsForTables(tableNames []string) (map[str
 		keys = append(keys, key)
 	}
 	slices.SortFunc(keys, func(a, b identifier) int {
-		if c := cmp.Compare(a.schema, b.schema); c != 0 {
+		if c := cmp.Compare(a.constraintSchema, b.constraintSchema); c != 0 {
 			return c
 		}
-		return cmp.Compare(a.name, b.name)
+		if c := cmp.Compare(a.tableSchema, b.tableSchema); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.tableName, b.tableName); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.constraintName, b.constraintName)
 	})
 
 	result := make(map[string][]string, len(tableNames))


### PR DESCRIPTION
## What

Include the source table in the identity used to group foreign key rows in `getForeignDefsForTables` (`database/postgres/database.go`):

- Extend the aggregation key from `(constraint_schema, constraint_name)` to `(constraint_schema, table_schema, table_name, constraint_name)`.
- Add `table_schema, table_name` to the query's `ORDER BY` so composite FK columns never interleave across tables.
- Sort the aggregated keys by the same four fields, keeping the export order deterministic instead of depending on map iteration order.

With this, each foreign key is exported as its own `ALTER TABLE ... ADD CONSTRAINT`, carrying its own columns, referenced table, `ON UPDATE` / `ON DELETE` actions, deferrability, and period.

## Motivation

PostgreSQL scopes constraint names per table (`pg_constraint.conname` is not unique within a database), so two tables in the same schema can both have a foreign key named `shared_fk`. The exporter fetches foreign keys for all tables in one batch query and groups the rows only by constraint schema and name, so such constraints collide: their columns are concatenated into one bogus FK on whichever table came first, and the other table's FK disappears from `--export` entirely.

```sql
-- actual --export output for two distinct FKs both named "shared_fk"
ALTER TABLE ONLY "public"."orders" ADD CONSTRAINT "shared_fk"
    FOREIGN KEY ("tenant_id", "account_id", "account_id")
    REFERENCES "public"."accounts" ("tenant_id", "id", "id") ...;
-- payments.shared_fk is missing
```

Because the exported "current" schema is wrong, re-applying an unchanged desired schema generates a spurious diff, and the apply fails:

```text
pq: constraint "shared_fk" for relation "payments" already exists (42710)
ROLLBACK;
```

## Test

- `cmd/psqldef/tests_constraints.yml` — `SeparateTablesWithSameForeignKeyName`: idempotency test (`current` = `desired`) with two same-named FKs on different tables. The two FKs deliberately differ in every dimension the merge could mix up: composite vs. single-column, referenced table, `ON UPDATE` / `ON DELETE` actions, and deferrability. Uses `legacy_ignore_quotes: false`.
- `cmd/psqldef/psqldef_test.go` — `TestPsqldefExportForeignKeysWithSameName`: asserts `--export` emits exactly two independent `ADD CONSTRAINT "shared_fk"` statements with unmixed definitions, in a deterministic order.
- Full `go test ./database/postgres ./cmd/psqldef` passes on PostgreSQL 14 with `PSQLDEF_PARSER=generic`.
