### PR TITLE
build: remove the redundant parser-v make target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,14 +44,14 @@ The executable binaries will be placed in the `build/$os-$arch/` directory, wher
 To update the generic SQL parser, edit `parser/parser.y` and regenerate:
 
 ```sh
-make parser    # generate parser/parser.go from parser/parser.y
-make parser-v  # same as above, also writes a conflict report to y.output
+make parser  # regenerate parser/parser.go from parser/parser.y
 ```
 
 Requirements:
 - No reduce/reduce conflicts are allowed
 - Do not introduce new shift/reduce conflicts unless absolutely necessary
-- To resolve conflicts, use `make parser-v` and inspect `y.output`
+- `make parser` prints the conflict summary to stdout (`conflicts: N shift/reduce, M reduce/reduce`)
+- To resolve individual conflicts, inspect `y.output`, which `make parser` also writes (it is gitignored)
 
 Usage notes:
 - `psqldef` uses the **generic parser** by default with fallback to `go-pgquery` (native PostgreSQL parser)

--- a/Makefile
+++ b/Makefile
@@ -82,11 +82,6 @@ parser:
 	gofmt -w ./parser/parser.go
 .PHONY: parser
 
-parser-v:
-	go run golang.org/x/tools/cmd/goyacc@$(GOYACC_VERSION) -v y.output -o parser/parser.go parser/parser.y
-	gofmt -w ./parser/parser.go
-.PHONY: parser-v
-
 test:
 	$(GOTEST) $(GOTESTFLAGS) ./...
 .PHONY: test


### PR DESCRIPTION
## Summary

`AGENTS.md` tells you to run `make parser-v` to inspect grammar conflicts. Following that instruction breaks CI.

goyacc embeds its own command line in the header of the file it generates:

```
// Code generated by goyacc -o parser/parser.go parser/parser.y. DO NOT EDIT.               <- make parser
// Code generated by goyacc -v y.output -o parser/parser.go parser/parser.y. DO NOT EDIT.   <- make parser-v
```

That line is the only difference (12 bytes; the parser tables are identical), but the `integrity` job regenerates `parser.go` with `make parser` and requires a byte-for-byte match, so committing the output of `make parser-v` fails:

```
##[error]parser.go has been modified and doesn't match what would be generated from parser.y
Binary files a/parser/parser.go and b/parser/parser.go differ
```

This happened in #1304.

`parser-v` buys nothing in return. goyacc's `-v` flag already defaults to `y.output`, so `make parser` writes the very same report. Measured on master (b5db441, `GOYACC_VERSION=v0.40.0`):

| | `y.output` | conflict summary | `parser.go` |
|---|---|---|---|
| `make parser` | 2,148,800 bytes / 96,931 lines | `conflicts: 29 shift/reduce, 544 reduce/reduce` (stdout) | accepted by `integrity` |
| `make parser-v` | byte-for-byte identical (verified with `diff`) | identical | rejected by `integrity` |

goyacc has no flag to suppress or pin that header — `-l`, `-o`, `-p` and `-v` are all it has.

## Fix

- Drop the `parser-v` target from the `Makefile`. Anyone who typed `make parser-v` gets the same thing from `make parser`.
- Reword the `AGENTS.md` section so both outputs are described accurately: the conflict summary goes to stdout, and `y.output` (gitignored, ~97k lines) holds the per-conflict detail. The previous wording implied you had to open `y.output` just to see the conflict counts.

Alternatives considered and rejected:

- Make `parser-v` an alias of `parser`, or append `$(MAKE) parser` to it — the trap goes away, but a target that does exactly what `parser` does stays around forever.
- Give `parser-v` `-o /dev/null` so it never touches `parser.go` — that is a genuinely new capability, but you need `make parser` anyway once you have edited `parser.y`.
- Fix only the docs — the trap survives behind a warning note that is easy to skim past.

Deliberately unchanged:

- The `integrity` job. Demanding an exact match is what keeps the generated file reproducible; loosening it would stop catching hand edits.
- `.gitignore` — `y.output` is already ignored.
- The `No reduce/reduce conflicts are allowed` requirement. It no longer matches the actual 544, but reconciling that is a separate discussion from making the documented commands match their behavior.

## Verification

- `git grep parser-v` -> no hits.
- `rm -f y.output && make parser` -> writes `y.output` (96,931 lines) and prints `conflicts: 29 shift/reduce, 544 reduce/reduce`.
- `git diff --name-only parser/parser.go` -> empty, i.e. the same check the `integrity` job runs.
- `make build`, `make format` and `make lint` all pass.
- `make test-all-flavors` was not run: this change touches no Go code, and `parser-v` is referenced by neither the test suite nor any CI workflow.
