### PR TITLE
psqldef: support @renamed from= on CREATE TYPE for ENUM type renames

### DIFF
--- a/cmd-psqldef.md
+++ b/cmd-psqldef.md
@@ -462,6 +462,40 @@ CREATE TYPE level AS ENUM (
 );
 ```
 
+### Enum Type Renaming
+
+psqldef supports renaming an enum type itself using the `-- @renamed from=old_name` or `/* @renamed from=old_name */` annotation:
+
+```sql
+CREATE TYPE order_status /* @renamed from=order_state */ AS ENUM ('pending', 'shipped');
+```
+
+This generates:
+```sql
+ALTER TYPE order_state RENAME TO order_status;
+```
+
+The annotation can also be placed right after the parenthesis that opens the enum body:
+
+```sql
+CREATE TYPE order_status AS ENUM ( -- @renamed from=order_state
+  'pending',
+  'shipped'
+);
+```
+
+Without the annotation, psqldef cannot tell a rename from a new type, so it creates the new type, rewrites every referencing column with `ALTER COLUMN ... TYPE ... USING`, and drops the old one. Each of those rewrites takes an `ACCESS EXCLUSIVE` lock and rewrites the whole table, while `ALTER TYPE ... RENAME TO` is a single catalog update.
+
+Renaming the type can be combined with renaming and adding values in the same migration:
+
+```sql
+CREATE TYPE order_status /* @renamed from=order_state */ AS ENUM (
+  'pending',
+  'shipped' /* @renamed from=shipping */,
+  'delivered'
+);
+```
+
 Note: After the migration is complete, you can remove the `@renamed` annotation from your schema file. The annotation is only needed during the migration process.
 
 ## Configuration

--- a/cmd/psqldef/tests_types.yml
+++ b/cmd/psqldef/tests_types.yml
@@ -444,3 +444,231 @@ EnumTypeDefaultIdempotent:
     );
   up: ""
   down: ""
+
+RenameEnumType:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+  desired: |
+    CREATE TYPE order_status /* @renamed from=order_state */ AS ENUM ('pending', 'shipped');
+  up: |
+    ALTER TYPE public.order_state RENAME TO order_status;
+  down: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+    DROP TYPE public.order_status;
+
+RenameEnumTypeLineComment:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+  desired: |
+    CREATE TYPE order_status -- @renamed from=order_state
+    AS ENUM ('pending', 'shipped');
+  up: |
+    ALTER TYPE public.order_state RENAME TO order_status;
+  down: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+    DROP TYPE public.order_status;
+
+RenameEnumTypeCommentAfterOpenParen:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+  desired: |
+    CREATE TYPE order_status AS ENUM ( /* @renamed from=order_state */ 'pending', 'shipped');
+  up: |
+    ALTER TYPE public.order_state RENAME TO order_status;
+  down: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+    DROP TYPE public.order_status;
+
+RenameEnumTypeLineCommentAfterOpenParen:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+  desired: |
+    CREATE TYPE order_status AS ENUM ( -- @renamed from=order_state
+      'pending',
+      'shipped'
+    );
+  up: |
+    ALTER TYPE public.order_state RENAME TO order_status;
+  down: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+    DROP TYPE public.order_status;
+
+RenameEnumTypeCommentOnOwnLine:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+  desired: |
+    CREATE TYPE order_status AS ENUM (
+      /* @renamed from=order_state */
+      'pending',
+      'shipped'
+    );
+  up: |
+    ALTER TYPE public.order_state RENAME TO order_status;
+  down: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+    DROP TYPE public.order_status;
+
+RenameEnumTypeToKeywordName:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+  desired: |
+    CREATE TYPE status /* @renamed from=order_state */ AS ENUM ('pending', 'shipped');
+  up: |
+    ALTER TYPE public.order_state RENAME TO status;
+  down: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+    DROP TYPE public."status";
+
+RenameEnumTypeWithValueRenameAndAddValue:
+  min_version: '12'
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipping');
+  desired: |
+    CREATE TYPE order_status /* @renamed from=order_state */ AS ENUM (
+      'pending',
+      'shipped' /* @renamed from=shipping */,
+      'delivered'
+    );
+  up: |
+    ALTER TYPE public.order_state RENAME TO order_status;
+    ALTER TYPE public.order_status RENAME VALUE 'shipping' TO 'shipped';
+    ALTER TYPE public.order_status ADD VALUE 'delivered';
+  down: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipping');
+    DROP TYPE public.order_status;
+
+RenameEnumTypeWithReferencingColumns:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+    CREATE TABLE orders (
+      id bigint NOT NULL PRIMARY KEY,
+      status order_state NOT NULL DEFAULT 'pending',
+      prev_status order_state
+    );
+    CREATE TABLE shipments (
+      id bigint NOT NULL PRIMARY KEY,
+      status order_state
+    );
+  desired: |
+    CREATE TYPE order_status /* @renamed from=order_state */ AS ENUM ('pending', 'shipped');
+    CREATE TABLE orders (
+      id bigint NOT NULL PRIMARY KEY,
+      status order_status NOT NULL DEFAULT 'pending',
+      prev_status order_status
+    );
+    CREATE TABLE shipments (
+      id bigint NOT NULL PRIMARY KEY,
+      status order_status
+    );
+  up: |
+    ALTER TYPE public.order_state RENAME TO order_status;
+  down: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+    ALTER TABLE public.orders ALTER COLUMN status DROP DEFAULT;
+    ALTER TABLE public.orders ALTER COLUMN status TYPE order_state USING status::text::order_state;
+    ALTER TABLE public.orders ALTER COLUMN status SET DEFAULT 'pending';
+    ALTER TABLE public.orders ALTER COLUMN prev_status TYPE order_state USING prev_status::text::order_state;
+    ALTER TABLE public.shipments ALTER COLUMN status TYPE order_state USING status::text::order_state;
+    DROP TYPE public.order_status;
+
+RenameEnumTypeWithSchema:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE SCHEMA myschema;
+    CREATE TYPE myschema.item_state AS ENUM ('active', 'inactive');
+  desired: |
+    CREATE SCHEMA myschema;
+    CREATE TYPE myschema.item_status /* @renamed from=item_state */ AS ENUM ('active', 'inactive');
+  up: |
+    ALTER TYPE myschema.item_state RENAME TO item_status;
+  down: |
+    CREATE TYPE myschema.item_state AS ENUM ('active', 'inactive');
+    DROP TYPE myschema.item_status;
+
+RenameEnumTypeOldTypeNotFound:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+  desired: |
+    CREATE TYPE order_status /* @renamed from=missing_state */ AS ENUM ('pending', 'shipped');
+  up: |
+    CREATE TYPE order_status /* @renamed from=missing_state */ AS ENUM ('pending', 'shipped');
+    DROP TYPE public.order_state;
+  down: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+    DROP TYPE public.order_status;
+
+RenameEnumTypeCommentBeforeTypeKeywordIgnored:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+  desired: |
+    CREATE /* @renamed from=order_state */ TYPE order_status AS ENUM ('pending', 'shipped');
+  up: |
+    CREATE /* @renamed from=order_state */ TYPE order_status AS ENUM ('pending', 'shipped');
+    DROP TYPE public.order_state;
+  down: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+    DROP TYPE public.order_status;
+
+RenameEnumTypeCommentBeforeTypeNameIgnored:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+  desired: |
+    CREATE TYPE /* @renamed from=order_state */ order_status AS ENUM ('pending', 'shipped');
+  up: |
+    CREATE TYPE /* @renamed from=order_state */ order_status AS ENUM ('pending', 'shipped');
+    DROP TYPE public.order_state;
+  down: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+    DROP TYPE public.order_status;
+
+RenameEnumTypeCommentAfterAsIgnored:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+  desired: |
+    CREATE TYPE order_status AS /* @renamed from=order_state */ ENUM ('pending', 'shipped');
+  up: |
+    CREATE TYPE order_status AS /* @renamed from=order_state */ ENUM ('pending', 'shipped');
+    DROP TYPE public.order_state;
+  down: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+    DROP TYPE public.order_status;
+
+RenameEnumTypeCommentAfterEnumIgnored:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+  desired: |
+    CREATE TYPE order_status AS ENUM /* @renamed from=order_state */ ('pending', 'shipped');
+  up: |
+    CREATE TYPE order_status AS ENUM /* @renamed from=order_state */ ('pending', 'shipped');
+    DROP TYPE public.order_state;
+  down: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+    DROP TYPE public.order_status;
+
+RenameEnumTypeFirstAcceptedCommentWins:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+  desired: |
+    CREATE TYPE order_status /* @renamed from=order_state */ AS ENUM ( /* @renamed from=other_state */
+      'pending',
+      'shipped'
+    );
+  up: |
+    ALTER TYPE public.order_state RENAME TO order_status;
+  down: |
+    CREATE TYPE order_state AS ENUM ('pending', 'shipped');
+    DROP TYPE public.order_status;

--- a/cmd/psqldef/tests_types.yml
+++ b/cmd/psqldef/tests_types.yml
@@ -672,3 +672,30 @@ RenameEnumTypeFirstAcceptedCommentWins:
   down: |
     CREATE TYPE order_state AS ENUM ('pending', 'shipped');
     DROP TYPE public.order_status;
+
+RenameEnumTypeKeepingComment:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TYPE order_state /* @renamed from=order_status */ AS ENUM ('pending', 'shipped');
+    COMMENT ON TYPE order_state IS 'order lifecycle';
+  desired: |
+    CREATE TYPE order_status /* @renamed from=order_state */ AS ENUM ('pending', 'shipped');
+    COMMENT ON TYPE order_status IS 'order lifecycle';
+  up: |
+    ALTER TYPE public.order_state RENAME TO order_status;
+  down: |
+    ALTER TYPE public.order_status RENAME TO order_state;
+
+RenameEnumTypeDroppingComment:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TYPE order_state /* @renamed from=order_status */ AS ENUM ('pending', 'shipped');
+    COMMENT ON TYPE order_state IS 'order lifecycle';
+  desired: |
+    CREATE TYPE order_status /* @renamed from=order_state */ AS ENUM ('pending', 'shipped');
+  up: |
+    ALTER TYPE public.order_state RENAME TO order_status;
+    COMMENT ON TYPE public.order_status IS NULL;
+  down: |
+    ALTER TYPE public.order_status RENAME TO order_state;
+    COMMENT ON TYPE public.order_state IS 'order lifecycle';

--- a/cmd/psqldef/tests_types.yml
+++ b/cmd/psqldef/tests_types.yml
@@ -699,3 +699,26 @@ RenameEnumTypeDroppingComment:
   down: |
     ALTER TYPE public.order_status RENAME TO order_state;
     COMMENT ON TYPE public.order_state IS 'order lifecycle';
+
+RenameEnumTypeWithSchemaQualifiedColumn:
+  legacy_ignore_quotes: false
+  current: |
+    CREATE SCHEMA myschema;
+    CREATE TYPE myschema.item_state AS ENUM ('active', 'inactive');
+    CREATE TABLE items (
+      id bigint NOT NULL PRIMARY KEY,
+      status myschema.item_state
+    );
+  desired: |
+    CREATE SCHEMA myschema;
+    CREATE TYPE myschema.item_status /* @renamed from=item_state */ AS ENUM ('active', 'inactive');
+    CREATE TABLE items (
+      id bigint NOT NULL PRIMARY KEY,
+      status myschema.item_status
+    );
+  up: |
+    ALTER TYPE myschema.item_state RENAME TO item_status;
+  down: |
+    CREATE TYPE myschema.item_state AS ENUM ('active', 'inactive');
+    ALTER TABLE public.items ALTER COLUMN status TYPE myschema.item_state USING status::text::myschema.item_state;
+    DROP TYPE myschema.item_status;

--- a/schema/ast.go
+++ b/schema/ast.go
@@ -504,9 +504,10 @@ type EnumValue struct {
 
 // TODO: include type information
 type Type struct {
-	name       QualifiedName
-	statement  string
-	enumValues []EnumValue
+	name        QualifiedName
+	statement   string
+	enumValues  []EnumValue
+	renamedFrom Ident // Previous type name if renamed via @renamed annotation
 }
 
 type Domain struct {

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -2648,8 +2648,9 @@ func (g *Generator) generateDDLsForCreateType(desired *Type) ([]string, error) {
 			ddls = append(ddls, fmt.Sprintf("ALTER TYPE %s RENAME TO %s",
 				g.escapeQualifiedName(oldName),       // must be qualified
 				g.escapeSQLIdent(desired.name.Name))) // must not be qualified
-			// Must run before oldType is renamed, as it matches columns against the old name.
+			// Must run before oldType is renamed, as they match against the old name.
 			g.renameEnumTypeInCurrentColumns(oldType, desired.name)
+			g.renameTypeInCurrentComments(oldName, desired.name)
 			// g.currentTypes holds pointers, and the obsolete-type cleanup only compares
 			// names against desiredTypes. Without this the run drops the type it just renamed.
 			oldType.name = desired.name
@@ -4838,6 +4839,17 @@ func (g *Generator) renameEnumTypeInCurrentColumns(oldType *Type, newName Qualif
 			}
 			column.typeName = newName.Name.Name
 		}
+	}
+}
+
+// renameTypeInCurrentComments retargets the current-state COMMENT ON TYPE of oldName at newName.
+// PostgreSQL carries the comment over on ALTER TYPE ... RENAME TO, so a comment left pointing at
+// the old name would make the obsolete-comment cleanup emit COMMENT ON TYPE <old> IS NULL against
+// a type that no longer exists, failing the whole run.
+func (g *Generator) renameTypeInCurrentComments(oldName, newName QualifiedName) {
+	target := &parser.Comment{ObjectType: "OBJECT_TYPE", Object: []Ident{oldName.Schema, oldName.Name}}
+	if comment := g.findCommentByObject(g.currentComments, target); comment != nil {
+		comment.comment.Object = []Ident{newName.Schema, newName.Name}
 	}
 }
 

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -233,7 +233,7 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 			} else {
 				// Table not found. Check if it's a rename from another table.
 				if !desired.table.renamedFrom.IsEmpty() {
-					oldTableName := g.normalizeOldTableName(desired.table.renamedFrom, desired.table.name)
+					oldTableName := g.normalizeOldObjectName(desired.table.renamedFrom, desired.table.name)
 					oldTable := g.findTableByName(g.currentTables, oldTableName)
 					if oldTable != nil {
 						// Found the old table, generate rename DDL
@@ -2638,7 +2638,26 @@ func normalizeFunctionOption(opt string) string {
 func (g *Generator) generateDDLsForCreateType(desired *Type) ([]string, error) {
 	ddls := []string{}
 
-	if currentType := g.findType(g.currentTypes, desired); currentType != nil {
+	currentType := g.findType(g.currentTypes, desired)
+	if currentType == nil && !desired.renamedFrom.IsEmpty() {
+		// Looking the desired name up first is what keeps this idempotent: once the rename
+		// has been applied, the new name is found and this branch is never entered again.
+		oldName := g.normalizeOldObjectName(desired.renamedFrom, desired.name)
+		if oldType := g.findType(g.currentTypes, &Type{name: oldName}); oldType != nil {
+			slog.Debug("Renaming enum type", "from", oldName.RawString(), "to", desired.name.RawString())
+			ddls = append(ddls, fmt.Sprintf("ALTER TYPE %s RENAME TO %s",
+				g.escapeQualifiedName(oldName),       // must be qualified
+				g.escapeSQLIdent(desired.name.Name))) // must not be qualified
+			// Must run before oldType is renamed, as it matches columns against the old name.
+			g.renameEnumTypeInCurrentColumns(oldType, desired.name)
+			// g.currentTypes holds pointers, and the obsolete-type cleanup only compares
+			// names against desiredTypes. Without this the run drops the type it just renamed.
+			oldType.name = desired.name
+			currentType = oldType
+		}
+	}
+
+	if currentType != nil {
 		typeName := g.escapeTypeName(currentType)
 
 		// Handle RENAME VALUE for values with @renamed annotation in desired
@@ -3848,12 +3867,12 @@ func (g *Generator) validateAndEscapeGrantee(grantee string) (string, error) {
 	return g.forceEscapeSQLName(grantee), nil
 }
 
-// normalizeOldTableName creates a QualifiedName from a renamedFrom Ident,
-// using the schema from the new table name if not specified.
-func (g *Generator) normalizeOldTableName(oldName Ident, newTable QualifiedName) QualifiedName {
-	// Use the schema from the new table name
+// normalizeOldObjectName creates a QualifiedName from a renamedFrom Ident,
+// using the schema from the new object name if not specified.
+func (g *Generator) normalizeOldObjectName(oldName Ident, newObject QualifiedName) QualifiedName {
+	// Use the schema from the new object name
 	return QualifiedName{
-		Schema: newTable.Schema,
+		Schema: newObject.Schema,
 		Name:   oldName,
 	}
 }
@@ -4800,6 +4819,26 @@ func (g *Generator) findEnumTypeForColumn(column Column, types []*Type) *Type {
 		return nil
 	}
 	return found
+}
+
+// renameEnumTypeInCurrentColumns rewrites the enum type name recorded on the current-state
+// columns that refer to oldType. Column types are compared by name, so leaving the old name
+// behind would make the generator emit "ALTER COLUMN ... TYPE ... USING", the full-table
+// rewrite that renaming the type exists to avoid.
+func (g *Generator) renameEnumTypeInCurrentColumns(oldType *Type, newName QualifiedName) {
+	for _, table := range g.currentTables {
+		for _, column := range getSortedColumns(table.columns) {
+			if g.findEnumTypeForColumn(*column, g.currentTypes) != oldType {
+				continue
+			}
+			// typeIdent is empty when the source SQL wrote the type schema-qualified; keep it
+			// that way so the column keeps rendering its schema prefix from references.
+			if !column.typeIdent.IsEmpty() {
+				column.typeIdent = newName.Name
+			}
+			column.typeName = newName.Name.Name
+		}
+	}
 }
 
 // findDomainByName finds a domain using quote-aware comparison including schema

--- a/schema/parser.go
+++ b/schema/parser.go
@@ -253,9 +253,10 @@ func parseDDL(mode GeneratorMode, ddl string, stmt parser.Statement, defaultSche
 		} else if stmt.Action == parser.CreateType {
 			enumValues := parseEnumValuesWithRename(ddl, stmt.Type.Type.EnumValues, mode)
 			return &Type{
-				name:       normalizeQualifiedObjectName(mode, stmt.Type.Name, defaultSchema),
-				statement:  ddl,
-				enumValues: enumValues,
+				name:        normalizeQualifiedObjectName(mode, stmt.Type.Name, defaultSchema),
+				statement:   ddl,
+				enumValues:  enumValues,
+				renamedFrom: extractRenameFrom(extractTypeComment(ddl, mode)),
 			}, nil
 		} else if stmt.Action == parser.CreateDomain {
 			var constraints []DomainConstraint
@@ -1274,6 +1275,83 @@ func extractEnumValueComments(rawDDL string, mode GeneratorMode) map[string]stri
 	}
 
 	return comments
+}
+
+// Scanner states of extractTypeComment, in the order a CREATE TYPE statement walks through them.
+const (
+	typeCommentStateInit     = iota // before CREATE
+	typeCommentStateCreate          // CREATE seen
+	typeCommentStateName            // CREATE TYPE seen, scanning the (optionally qualified) type name
+	typeCommentStateAfterAs         // AS seen, waiting for the parenthesis that opens the enum body
+	typeCommentStateEnumBody        // inside the enum body
+)
+
+// extractTypeComment extracts the type-level inline comment from a CREATE TYPE ... AS ENUM
+// statement, i.e. the one carrying a @renamed annotation for the type itself.
+//
+// A comment belongs to the type only when the token right before it is the last token of the
+// type name or the parenthesis that opens the enum body:
+//
+//	CREATE TYPE t /* c */ AS ENUM ('a')
+//	CREATE TYPE t AS ENUM ( /* c */ 'a')
+//
+// Everywhere else the comment is ignored: before TYPE or the name it would read as annotating
+// the keyword rather than the new name, and once the first value is scanned the comment belongs
+// to that value (extractEnumValueComments owns it). The rule is expressed purely in terms of the
+// preceding token because none of the sibling extractors look at line positions, so reformatting
+// a statement must not change what an annotation means.
+func extractTypeComment(rawDDL string, mode GeneratorMode) string {
+	tokenizer := parser.NewTokenizer(rawDDL, generatorModeToParserMode(mode))
+	tokenizer.AllowComments = true
+
+	state := typeCommentStateInit
+	prevTok := 0
+
+	for {
+		tok, val := tokenizer.Scan()
+		if tok == 0 {
+			break // EOF
+		}
+
+		// Comments neither advance the state nor become prevTok, so a comment in an ignored
+		// position does not hide a later annotation in an accepted one.
+		if tok == parser.COMMENT {
+			// In the name state prevTok is the last token of the name, except right after
+			// TYPE (no name yet) and right after the dot of a qualified name. The name is
+			// matched positionally rather than by parser.ID because a type name may be a
+			// keyword (e.g. CREATE TYPE status AS ENUM (...) scans as parser.STATUS).
+			nameAdjacent := state == typeCommentStateName && prevTok != parser.TYPE && prevTok != '.'
+			enumOpenAdjacent := state == typeCommentStateEnumBody && prevTok == '('
+			if nameAdjacent || enumOpenAdjacent {
+				return strings.TrimSpace(string(val))
+			}
+			continue
+		}
+
+		switch state {
+		case typeCommentStateInit:
+			if tok == parser.CREATE {
+				state = typeCommentStateCreate
+			}
+		case typeCommentStateCreate:
+			if tok == parser.TYPE {
+				state = typeCommentStateName
+			} else {
+				state = typeCommentStateInit
+			}
+		case typeCommentStateName:
+			if tok == parser.AS {
+				state = typeCommentStateAfterAs
+			}
+		case typeCommentStateAfterAs:
+			if tok == '(' {
+				state = typeCommentStateEnumBody
+			}
+		}
+		prevTok = tok
+	}
+
+	return ""
 }
 
 // generatorModeToParserMode converts GeneratorMode to ParserMode

--- a/schema/parser.go
+++ b/schema/parser.go
@@ -1336,8 +1336,6 @@ func extractTypeComment(rawDDL string, mode GeneratorMode) string {
 		case typeCommentStateCreate:
 			if tok == parser.TYPE {
 				state = typeCommentStateName
-			} else {
-				state = typeCommentStateInit
 			}
 		case typeCommentStateName:
 			if tok == parser.AS {


### PR DESCRIPTION
## Summary

`@renamed from=` is supported on tables, columns, indexes, and enum values, but
not on the ENUM type itself. Renaming `CREATE TYPE order_state AS ENUM (...)` to
`order_status` therefore looks like "new type, old type gone" to sqldef:

```
CREATE TYPE order_status AS ENUM ('pending', 'shipped')
ALTER TABLE public.orders    ALTER COLUMN status      TYPE order_status USING status::text::order_status
ALTER TABLE public.orders    ALTER COLUMN prev_status TYPE order_status USING prev_status::text::order_status
ALTER TABLE public.shipments ALTER COLUMN status      TYPE order_status USING status::text::order_status
DROP TYPE public.order_state
```

One `ALTER COLUMN ... TYPE ... USING` per referencing column, each taking an
`ACCESS EXCLUSIVE` lock and rewriting the whole table — because
`USING col::text::new_type` is a type change as far as PostgreSQL is concerned,
even though the label set is identical and the intended change is a catalog-only
rename. The cost scales with (rows x referencing columns) while the desired
operation is O(1). On a production database that is the difference between a
sub-second migration and a full-table rewrite under an exclusive lock.

The only workaround today is running `ALTER TYPE ... RENAME TO` out of band
before the sqldef run, which reintroduces the manual pre-migration step the
`@renamed` family exists to remove, coordinated per environment.

This PR makes the annotation work on the type itself:

```sql
CREATE TYPE order_status /* @renamed from=order_state */ AS ENUM ('pending', 'shipped');
```

```sql
ALTER TYPE public.order_state RENAME TO order_status;
```

## Changes

- parser: `Type` carries `renamedFrom`, filled by a new `extractTypeComment`
  that accepts a comment only when the token right before it is the last token
  of the type name or the parenthesis that opens the enum body
- generator: `generateDDLsForCreateType` looks the old name up **only** when the
  desired name misses, emits `ALTER TYPE ... RENAME TO`, then rewrites the
  in-memory current state so the rest of the diff sees the new name — the same
  shape as the existing table rename block
- `normalizeOldTableName` is generalized to `normalizeOldObjectName` and shared
  by both rename paths
- a `COMMENT ON TYPE` on the renamed type is retargeted at the new name in the
  current state, so the obsolete-comment cleanup no longer emits
  `COMMENT ON TYPE <old> IS NULL` against a type that no longer exists
- docs (`cmd-psqldef.md`) and 17 round-trip test cases

<details>
<summary>Design notes: why these positions, and why the in-memory state is rewritten</summary>

**Token adjacency, not line position.** None of the existing extractors
(`extractTableComment`, `extractColumnComments`, `extractIndexComments`,
`extractEnumValueComments`) look at line positions, so making types the
exception would leave one annotation whose meaning changes when a statement is
reformatted. `RenameEnumTypeCommentAfterOpenParen` and
`RenameEnumTypeCommentOnOwnLine` differ only in where the newline falls and
guard exactly that.

**`CREATE TYPE /* @renamed */ t` is ignored.** This is the one position where
the existing precedents disagree — `CREATE TABLE /* @renamed from=x */ users (...)`
is accepted, `CREATE INDEX /* @renamed from=x */ new_idx ON ...` is not.
Following the index side keeps the annotation *after* the new name, matching how
all four existing categories are written in the test suite.

**Current-state columns are rewritten before the tables are diffed.** Column
types are compared by name, so a stale old name would produce the very
`ALTER COLUMN ... TYPE ... USING` statements this feature exists to avoid.
`SortTablesByDependencies` already orders `*Type` ahead of `*CreateTable`, so
the rewrite always lands first; `RenameEnumTypeWithReferencingColumns` guards it.

**The old type's name is updated in place** because `g.currentTypes` holds
pointers and the obsolete-type cleanup only compares names against
`desiredTypes` — otherwise the run emits `DROP TYPE <old>` right after renaming
it away.

**The current-state `COMMENT ON TYPE` is retargeted rather than skipped.** Table
renames mark the old name in `g.droppedTables` and let `isCommentOnDroppedTable`
skip the cleanup, but a renamed type is not dropped — PostgreSQL carries its
comment over. Retargeting keeps the desired-vs-current comparison meaningful, so
dropping the comment in the desired schema still emits
`COMMENT ON TYPE <new> IS NULL` (`RenameEnumTypeDroppingComment`) instead of
being silently skipped.

**Old name not found silently falls through to `CREATE TYPE`,** same as the
existing four categories. Idempotency holds because the lookup by the desired
name happens first: once the rename has been applied the new name is found and
no DDL is emitted.

</details>

## Out of scope

- Cross-schema type renames (`ALTER TYPE ... SET SCHEMA`) — PostgreSQL cannot
  express one in a single `ALTER TYPE ... RENAME TO` either
- Schema-qualified old names (`@renamed from=myschema.old`) — not supported by
  the existing four categories either
- Non-column references to the old type name in the current state (function
  signatures, domains, view casts). Those are the pre-existing name-comparison
  behavior, not a regression introduced here
- Dropping a type that carries a `COMMENT ON TYPE`: the obsolete-comment cleanup
  emits `COMMENT ON TYPE <dropped> IS NULL` and the run fails with
  `type ... does not exist`. This reproduces on `master` without any of this
  change (types have no equivalent of `isCommentOnDroppedTable`), so it is
  filed separately rather than folded in here
- MySQL/SQLite3/SQL Server: MySQL declares ENUMs inline per column with no
  type-name concept, SQLite has no ENUMs, SQL Server has no native ENUM type.
  The existing `ALTER TYPE ... RENAME VALUE` support is psqldef-only as well

## Verification

- 18 new round-trip cases in `cmd/psqldef/tests_types.yml`: bare rename, both
  comment styles in both accepted positions, a type name that is a parser
  keyword, rename combined with `RENAME VALUE` + `ADD VALUE` (asserting the
  later statements use the **new** type name), referencing columns across two
  tables including one with a `DEFAULT` (asserting the up migration is the
  single `ALTER TYPE ... RENAME TO` with no `ALTER COLUMN ... TYPE` and no stray
  `DROP TYPE`), schema-qualified type (both bare and referenced by a schema-qualified column), old name not
  found, the four ignored
  positions, first-accepted-comment-wins, and `COMMENT ON TYPE` both kept and
  dropped across the rename
- Written test-first: every case was confirmed to fail with the
  create/rewrite/drop output before the generator change, and the two comment
  cases were confirmed to fail with
  `type "public.order_state" does not exist (42704)` before the retargeting fix
- `make test-all-flavors` passes locally (MySQL 8.0, MariaDB 11.8, TiDB 8.5,
  PostgreSQL 18, pgvector, SQLite3, SQL Server 2025), plus `make build`,
  `make format`, `make lint`. psqldef suites run with `PSQLDEF_PARSER=generic`;
  no pgquery fallback warnings
