### PR TITLE
build(deps): group Dependabot updates per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
     cooldown:
       default-days: 7
     labels: []
+    groups:
+      gomod:
+        patterns: ["*"]
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -18,6 +21,9 @@ updates:
     cooldown:
       default-days: 7
     labels: []
+    groups:
+      docker:
+        patterns: ["*"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -25,3 +31,6 @@ updates:
     cooldown:
       default-days: 7
     labels: []
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
Bundle all version updates of each ecosystem (`gomod`, `docker`, `github-actions`) into a single PR instead of one PR per dependency.

With `patterns: ["*"]` and no `update-types` filter, major updates are grouped as well, so Dependabot opens at most 3 PRs per month.

🤖 Generated with [Claude Code](https://claude.com/claude-code)