### PR TITLE
psqldef: filter object owners by TargetSchema in export

### DIFF
--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -1878,3 +1878,60 @@ func TestPsqldefDomainWithTargetSchema(t *testing.T) {
 		assert.Contains(t, exported, `CREATE DOMAIN "test_schema_b"."status"`)
 	})
 }
+
+// TestPsqldefOwnerWithTargetSchema tests that object-owner export (objectOwners)
+// honors TargetSchema. Without the filter, owners of objects in schemas outside
+// TargetSchema leak into the export and the generator aborts with
+// "ALTER TABLE ... OWNER TO performed before CREATE TABLE" because there is no
+// matching CREATE in the desired DDL (regression from the OWNER management PR).
+func TestPsqldefOwnerWithTargetSchema(t *testing.T) {
+	resetTestDatabase()
+
+	// Two schemas, each with a table. Object-owner export is only active when
+	// privilege/role management is enabled, so a table in a non-target schema
+	// must not produce an ALTER ... OWNER TO once TargetSchema is set.
+	mustPgExec(testDatabaseName, `
+		CREATE SCHEMA test_owner_a;
+		CREATE SCHEMA test_owner_b;
+		CREATE TABLE test_owner_a.widgets (id bigint PRIMARY KEY);
+		CREATE TABLE test_owner_b.gadgets (id bigint PRIMARY KEY);
+	`)
+
+	export := func(t *testing.T, targetSchema []string) string {
+		db, err := connectDatabase(dbConfig{DbName: testDatabaseName})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+
+		db.SetGeneratorConfig(database.GeneratorConfig{
+			TargetSchema:       targetSchema,
+			ManagedRoles:       []string{"postgres"}, // activate object-owner export
+			LegacyIgnoreQuotes: true,
+		})
+
+		exported, err := db.ExportDDLs()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return exported
+	}
+
+	t.Run("filter to test_owner_a only", func(t *testing.T) {
+		exported := export(t, []string{"test_owner_a"})
+		assert.Contains(t, exported, "ALTER TABLE test_owner_a.widgets OWNER TO")
+		assert.NotContains(t, exported, "ALTER TABLE test_owner_b.gadgets OWNER TO")
+	})
+
+	t.Run("filter to test_owner_b only", func(t *testing.T) {
+		exported := export(t, []string{"test_owner_b"})
+		assert.Contains(t, exported, "ALTER TABLE test_owner_b.gadgets OWNER TO")
+		assert.NotContains(t, exported, "ALTER TABLE test_owner_a.widgets OWNER TO")
+	})
+
+	t.Run("filter to both schemas", func(t *testing.T) {
+		exported := export(t, []string{"test_owner_a", "test_owner_b"})
+		assert.Contains(t, exported, "ALTER TABLE test_owner_a.widgets OWNER TO")
+		assert.Contains(t, exported, "ALTER TABLE test_owner_b.gadgets OWNER TO")
+	})
+}

--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -243,6 +243,7 @@ func (d *PostgresDatabase) objectOwners() ([]string, error) {
 
 	const query = `
 		SELECT
+			n.nspname AS schema_name,
 			n.nspname || '.' || c.relname AS obj_name,
 			pg_get_userbyid(c.relowner) AS owner
 		FROM pg_class c
@@ -264,9 +265,17 @@ func (d *PostgresDatabase) objectOwners() ([]string, error) {
 
 	var ddls []string
 	for rows.Next() {
-		var objName, owner string
-		if err := rows.Scan(&objName, &owner); err != nil {
+		var schemaName, objName, owner string
+		if err := rows.Scan(&schemaName, &objName, &owner); err != nil {
 			return nil, fmt.Errorf("failed to scan object owner row: %w", err)
+		}
+		// Apply the same TargetSchema filter as the other export helpers
+		// (tables, sequences, types, domains, ...). Without this, owners of
+		// objects in schemas outside TargetSchema leak into the export and the
+		// generator aborts with "ALTER TABLE ... OWNER TO performed before
+		// CREATE TABLE" because there is no matching CREATE in the desired DDL.
+		if d.config.TargetSchema != nil && !slices.Contains(d.config.TargetSchema, schemaName) {
+			continue
 		}
 		ddls = append(ddls, fmt.Sprintf("ALTER TABLE %s OWNER TO %s;", objName, d.quoteIdentifierIfNeeded(owner)))
 	}


### PR DESCRIPTION
## Problem

`objectOwners()` (added in #1301 for declarative `ALTER TABLE ... OWNER TO` management) is the **only** export helper that lacks the `TargetSchema` filter. Every other helper — `tables`, `partitions`, `sequences`, privileges, `types`, `domains`, functions, triggers — skips rows whose schema is not in `TargetSchema`:

```go
if d.config.TargetSchema != nil && !slices.Contains(d.config.TargetSchema, schema) {
    continue
}
```

Because `objectOwners()` omits this, when `TargetSchema` is set the owners of tables/views/matviews in **schemas outside the target** still leak into the exported DDL. Those objects have no matching `CREATE` in the desired schema, so the generator aborts:

```
ALTER TABLE <schema>.<table> OWNER TO "<role>" performed before CREATE TABLE
```

`objectOwners()` only runs when `manage.privilege` (or the deprecated `managed_roles`) is enabled, so users without privilege management are unaffected. But **for anyone using privilege management on a database that has tables in schemas outside `TargetSchema`** (i.e. `public`, application-specific schemas — the common case), export/dry-run fails and there is no config-level workaround.

## Reproduction

```sql
-- current DB: tables in the target schema AND another schema
CREATE SCHEMA app;   CREATE TABLE app.orders (id bigint PRIMARY KEY);
CREATE SCHEMA other; CREATE TABLE other.legacy (id bigint PRIMARY KEY);
```

```yaml
# config.yml
target_schema: app
manage:
  privilege:
    - target: 'app_user'
      drop: true
```

```sql
-- desired.sql (target schema only)
CREATE TABLE "app"."orders" ("id" bigint NOT NULL, PRIMARY KEY ("id"));
```

```
$ psqldef --config config.yml --dry-run <db> < desired.sql
ALTER TABLE other.legacy OWNER TO "..." performed before CREATE TABLE   # exit 1
```

Setting `target_schema` does not help, because `objectOwners()` ignores it.

## Fix

Select `n.nspname` in the `objectOwners` query and skip rows whose schema is not in `TargetSchema`, mirroring every other export helper.

## Test

Adds `TestPsqldefOwnerWithTargetSchema` (modeled on the existing `TestPsqldefDomainWithTargetSchema`) covering single-target and multi-target filtering. Verified that the test fails without the fix (the out-of-target owner leaks into the export) and passes with it. Full `cmd/psqldef` + `database/postgres` suite green locally on PG18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
