### PR TITLE
parser: simplify string concat CHECK test, keep column-level coverage

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -959,6 +959,21 @@ func TestStringConcatOperator(t *testing.T) {
 			{
 				name: "column-level CHECK with concat and comparison",
 				sql:  "CREATE TABLE t (s text CHECK (s || 'x' <> ''))",
+				// Expected AST: ComparisonExpr{Left: ConcatExpr{s, 'x'}, ...}.
+				// Column-level CHECK stores the expression on ColumnType.Check,
+				// a separate grammar production from table-level TableSpec.Checks.
+				checkShape: func(t *testing.T, stmt Statement) {
+					t.Helper()
+					ddl := stmt.(*DDL)
+					expr := ddl.TableSpec.Columns[0].Type.Check.Where.Expr
+					cmp, ok := expr.(*ComparisonExpr)
+					if !ok {
+						t.Fatalf("expected *ComparisonExpr at top, got %T", expr)
+					}
+					if _, ok := cmp.Left.(*ConcatExpr); !ok {
+						t.Errorf("expected *ConcatExpr on ComparisonExpr.Left, got %T", cmp.Left)
+					}
+				},
 			},
 			{
 				name: "chained concat is left-associative",

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1009,7 +1009,7 @@ func TestStringConcatOperator(t *testing.T) {
 		// Right: IsExpr{s, "is null"}}. The shape assertion locks down both
 		// (a) || binds tighter than comparison, and (b) OR is at the outermost
 		// boolean level — independent of how the emitter formats the text.
-		sql := "CREATE TABLE t (s text CHECK ('a' || 'b' = 'ab' OR s IS NULL))"
+		sql := "CREATE TABLE t (s text, CHECK ('a' || 'b' = 'ab' OR s IS NULL))"
 		stmt, err := ParseDDL(sql, ParserModePostgres)
 		if err != nil {
 			t.Fatalf("ParseDDL failed: %v", err)
@@ -1023,7 +1023,7 @@ func TestStringConcatOperator(t *testing.T) {
 		}
 
 		ddl := stmt.(*DDL)
-		expr := ddl.TableSpec.Columns[0].Type.Check.Where.Expr
+		expr := ddl.TableSpec.Checks[0].Where.Expr
 		or, ok := expr.(*OrExpr)
 		if !ok {
 			t.Fatalf("expected *OrExpr at top, got %T", expr)


### PR DESCRIPTION
## Why

`TestStringConcatOperator`'s sub-test "postgres mode: concat coexists with explicit OR" wrote its CHECK constraint at the **column level** (`s text CHECK (...)`) and reached the AST through `ddl.TableSpec.Columns[0].Type.Check.Where.Expr`.

The **table-level** form (`s text, CHECK (...)`) parses to the same expression and reads through the more natural `ddl.TableSpec.Checks[0].Where.Expr`. It was deliberately avoided when the test was added in #1219, because `TableSpec.Format` silently dropped table-level CHECK constraints on `parser.String(*DDL)` round-trip, which broke the `strings.Contains(got, "||")` / `strings.Contains(got, " or ")` assertions sitting right above the AST access.

#1224 fixed that round-trip bug, so the workaround can go.

## What

1. Switch the sub-test to the table-level CHECK form and assert through `TableSpec.Checks[0].Where.Expr`. The assertion semantics are unchanged — `||` still binds tighter than the comparison, and the explicit `OR` is still at the outermost boolean level. The surrounding text assertions and the `*OrExpr` / `*ComparisonExpr` / `*ConcatExpr` type assertions carry over as-is.

2. Add a `checkShape` assertion to the existing "column-level CHECK with concat and comparison" case. Step 1 removed the only AST-shape assertion on `ColumnType.Check` in the package — a separate grammar production from `TableSpec.Checks`, and one that `schema/parser.go` consumes in production — leaving it covered by text round-trip alone. Text round-trip cannot catch a precedence or associativity regression that still emits re-parsable SQL, so the column-level path now gets its own shape assertion.

No production code is touched.

## Testing

```sh
PSQLDEF_PARSER=generic go test ./parser -run TestStringConcatOperator -v
PSQLDEF_PARSER=generic go test ./parser
```

`make build`, `make test-all-flavors` (MySQL, MariaDB, TiDB, PostgreSQL, pgvector, SQL Server, SQLite3), `make format`, and `make lint` all pass.

## Out of scope

`cmd/psqldef/tests_tables.yml`'s `CreateTableWithStringConcatQuotedColumn` stays in CREATE form: the ALTER ADD CONSTRAINT path independently drops the column-name quote, which is a separate issue.
