### PR TITLE
psqldef: export GRANT privileges for views and materialized views

### DIFF
--- a/cmd/psqldef/tests_manage_privilege.yml
+++ b/cmd/psqldef/tests_manage_privilege.yml
@@ -276,3 +276,77 @@ ManagePrivilegeViewOwner:
   up: |
     ALTER TABLE v_users OWNER TO app_user;
   down: ""
+
+ManagePrivilegeViewGrantIdempotent:
+  # A GRANT on a view must be seen by the export so a declared view grant
+  # converges. Without view privilege export the current schema is not
+  # idempotent (the grant is re-emitted every run).
+  manage:
+    privilege:
+      - target: app_user
+        drop: true
+  current: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    CREATE VIEW v_users AS SELECT id FROM users;
+    GRANT SELECT ON TABLE v_users TO app_user;
+  desired: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    CREATE VIEW v_users AS SELECT id FROM users;
+    GRANT SELECT ON TABLE v_users TO app_user;
+  up: ""
+  down: ""
+
+ManagePrivilegeViewGrantRevoke:
+  # Dropping a declared view grant yields a REVOKE when the rule allows drop.
+  manage:
+    privilege:
+      - target: app_user
+        drop: true
+  current: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    CREATE VIEW v_users AS SELECT id FROM users;
+    GRANT SELECT ON TABLE v_users TO app_user;
+  desired: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    CREATE VIEW v_users AS SELECT id FROM users;
+  up: |
+    REVOKE SELECT ON TABLE "public"."v_users" FROM "app_user";
+  down: |
+    GRANT SELECT ON TABLE "public"."v_users" TO "app_user";
+
+ManagePrivilegeMatViewGrantIdempotent:
+  # information_schema.table_privileges does not expose materialized views, so
+  # view privilege export reads relacl directly. This guards that matview
+  # grants converge too.
+  manage:
+    privilege:
+      - target: app_user
+        drop: true
+  current: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    CREATE MATERIALIZED VIEW mv_users AS SELECT id FROM users;
+    GRANT SELECT ON TABLE mv_users TO app_user;
+  desired: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    CREATE MATERIALIZED VIEW mv_users AS SELECT id FROM users;
+    GRANT SELECT ON TABLE mv_users TO app_user;
+  up: ""
+  down: ""

--- a/cmd/psqldef/tests_manage_privilege.yml
+++ b/cmd/psqldef/tests_manage_privilege.yml
@@ -326,6 +326,30 @@ ManagePrivilegeViewGrantRevoke:
   down: |
     GRANT SELECT ON TABLE "public"."v_users" TO "app_user";
 
+ManagePrivilegeViewColumnGrantIdempotent:
+  # Column-level grants on a view (pg_attribute.attacl) must also be exported
+  # so they converge, including WITH GRANT OPTION.
+  manage:
+    privilege:
+      - target: app_user
+        drop: true
+  current: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    CREATE VIEW v_users AS SELECT id, name FROM users;
+    GRANT SELECT (name) ON TABLE v_users TO app_user WITH GRANT OPTION;
+  desired: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    CREATE VIEW v_users AS SELECT id, name FROM users;
+    GRANT SELECT (name) ON TABLE v_users TO app_user WITH GRANT OPTION;
+  up: ""
+  down: ""
+
 ManagePrivilegeMatViewGrantIdempotent:
   # information_schema.table_privileges does not expose materialized views, so
   # view privilege export reads relacl directly. This guards that matview

--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -216,6 +216,12 @@ func (d *PostgresDatabase) ExportDDLs() (string, error) {
 	}
 	ddls = append(ddls, matViewDDLs...)
 
+	viewPrivilegeDDLs, err := d.viewPrivileges()
+	if err != nil {
+		return "", err
+	}
+	ddls = append(ddls, viewPrivilegeDDLs...)
+
 	seqPrivilegeDDLs, err := d.sequencePrivileges()
 	if err != nil {
 		return "", err
@@ -367,6 +373,147 @@ func (d *PostgresDatabase) sequencePrivileges() ([]string, error) {
 	}
 
 	return ddls, rows.Err()
+}
+
+// viewPrivileges exports GRANT ... ON TABLE statements for views and
+// materialized views. Table/column privileges for ordinary tables are attached
+// to the table DDL via getPrivilegeDefsForTables (keyed off tableNames(), which
+// is relkind in ('r','p')), but views and matviews are dumped through a
+// separate path (views()/materializedViews()) that carries no privileges. As a
+// result view/matview grants were never exported, so a declared view GRANT was
+// re-emitted on every run and never converged. Like sequencePrivileges and
+// objectOwners, this emits standalone GRANTs and only runs when privilege
+// management is configured. Extension-owned objects are excluded.
+func (d *PostgresDatabase) viewPrivileges() ([]string, error) {
+	if d.generatorConfig.ManagePrivileges == nil && len(d.generatorConfig.ManagedRoles) == 0 {
+		return nil, nil
+	}
+
+	var ddls []string
+
+	// Table-level privileges on views/matviews (pg_class.relacl). information_schema
+	// .table_privileges (used for ordinary tables) does not expose materialized
+	// views, so read relacl directly to cover both 'v' and 'm' uniformly.
+	const tableLevelQuery = `
+		SELECT
+			n.nspname AS schema_name,
+			n.nspname || '.' || c.relname AS obj_name,
+			CASE WHEN acl.grantee = 0 THEN 'PUBLIC' ELSE pg_get_userbyid(acl.grantee) END AS grantee,
+			acl.is_grantable,
+			string_agg(acl.privilege_type, ', ' ORDER BY acl.privilege_type) AS privileges
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		CROSS JOIN LATERAL aclexplode(c.relacl) AS acl
+		WHERE c.relkind IN ('v', 'm')
+		AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+		AND acl.grantee <> c.relowner
+		AND ($1::text[] IS NULL OR (CASE WHEN acl.grantee = 0 THEN 'PUBLIC' ELSE pg_get_userbyid(acl.grantee) END) = ANY($1::text[]))
+		AND NOT EXISTS (
+			SELECT 1 FROM pg_depend dep
+			WHERE dep.classid = 'pg_class'::regclass AND dep.objid = c.oid AND dep.deptype = 'e'
+		)
+		GROUP BY n.nspname, c.relname, acl.grantee, acl.is_grantable
+		ORDER BY obj_name, grantee, acl.is_grantable
+	`
+
+	rows, err := d.db.Query(tableLevelQuery, d.managedGranteeArgs())
+	if err != nil {
+		return nil, fmt.Errorf("failed to query view privileges: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var schemaName, objName, grantee, privileges string
+		var isGrantable bool
+		if err := rows.Scan(&schemaName, &objName, &grantee, &isGrantable, &privileges); err != nil {
+			return nil, fmt.Errorf("failed to scan view privilege row: %w", err)
+		}
+		if d.config.TargetSchema != nil && !slices.Contains(d.config.TargetSchema, schemaName) {
+			continue
+		}
+		if !d.isExportedGrantee(grantee) {
+			continue
+		}
+
+		escapedGrantee := grantee
+		if grantee != "PUBLIC" {
+			escapedGrantee = d.quoteIdentifierIfNeeded(grantee)
+		}
+
+		grant := fmt.Sprintf("GRANT %s ON TABLE %s TO %s", privileges, objName, escapedGrantee)
+		if isGrantable {
+			grant += " WITH GRANT OPTION"
+		}
+		ddls = append(ddls, grant+";")
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Column-level privileges on views/matviews (pg_attribute.attacl).
+	const columnLevelQuery = `
+		SELECT
+			n.nspname AS schema_name,
+			n.nspname || '.' || c.relname AS obj_name,
+			CASE WHEN acl.grantee = 0 THEN 'PUBLIC' ELSE pg_get_userbyid(acl.grantee) END AS grantee,
+			acl.is_grantable,
+			acl.privilege_type,
+			string_agg(at.attname, ', ' ORDER BY at.attname) AS columns
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		JOIN pg_attribute at ON at.attrelid = c.oid AND at.attacl IS NOT NULL,
+		LATERAL aclexplode(at.attacl) AS acl
+		WHERE c.relkind IN ('v', 'm')
+		AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+		AND acl.grantee <> c.relowner
+		AND ($1::text[] IS NULL OR (CASE WHEN acl.grantee = 0 THEN 'PUBLIC' ELSE pg_get_userbyid(acl.grantee) END) = ANY($1::text[]))
+		AND NOT EXISTS (
+			SELECT 1 FROM pg_depend dep
+			WHERE dep.classid = 'pg_class'::regclass AND dep.objid = c.oid AND dep.deptype = 'e'
+		)
+		GROUP BY n.nspname, c.relname, acl.grantee, acl.is_grantable, acl.privilege_type
+		ORDER BY obj_name, grantee, acl.privilege_type, acl.is_grantable
+	`
+
+	colRows, err := d.db.Query(columnLevelQuery, d.managedGranteeArgs())
+	if err != nil {
+		return nil, fmt.Errorf("failed to query view column privileges: %w", err)
+	}
+	defer colRows.Close()
+
+	for colRows.Next() {
+		var schemaName, objName, grantee, privilegeType, columns string
+		var isGrantable bool
+		if err := colRows.Scan(&schemaName, &objName, &grantee, &isGrantable, &privilegeType, &columns); err != nil {
+			return nil, fmt.Errorf("failed to scan view column privilege row: %w", err)
+		}
+		if d.config.TargetSchema != nil && !slices.Contains(d.config.TargetSchema, schemaName) {
+			continue
+		}
+		if !d.isExportedGrantee(grantee) {
+			continue
+		}
+
+		escapedGrantee := grantee
+		if grantee != "PUBLIC" {
+			escapedGrantee = d.quoteIdentifierIfNeeded(grantee)
+		}
+
+		colNames := strings.Split(columns, ", ")
+		escapedCols := make([]string, len(colNames))
+		for i, col := range colNames {
+			escapedCols[i] = d.quoteIdentifierIfNeeded(col)
+		}
+
+		grant := fmt.Sprintf("GRANT %s (%s) ON TABLE %s TO %s",
+			privilegeType, strings.Join(escapedCols, ", "), objName, escapedGrantee)
+		if isGrantable {
+			grant += " WITH GRANT OPTION"
+		}
+		ddls = append(ddls, grant+";")
+	}
+
+	return ddls, colRows.Err()
 }
 
 func (d *PostgresDatabase) tableNames() ([]string, error) {


### PR DESCRIPTION
## Problem

Table and column privileges for ordinary tables are attached to the table DDL via `getPrivilegeDefsForTables`, whose object list comes from `tableNames()` (`relkind in ('r','p')`). Views and materialized views are dumped through a separate path (`views()` / `materializedViews()`) that carries no privileges, so **their GRANTs were never exported**.

Under `manage.privilege` (or the deprecated `managed_roles`), this means a declared view/matview GRANT is re-emitted on every run and **never converges** — dry-run never reaches zero diff. `objectOwners()` already covers views/matviews (`relkind in ('r','p','v','m')`), so declarative OWNER management works, while GRANT management silently drops the same objects. No REVOKE is produced, so there is no data loss — but view privileges cannot be managed declaratively.

## Reproduction

```sql
CREATE SCHEMA app AUTHORIZATION app_owner;
CREATE TABLE app.t (id int PRIMARY KEY); ALTER TABLE app.t OWNER TO app_owner;
CREATE VIEW app.v_t AS SELECT id FROM app.t; ALTER VIEW app.v_t OWNER TO app_owner;
GRANT SELECT ON app.v_t TO app_reader;   -- grant on a view
```

```yaml
# config.yml
manage:
  privilege:
    - target: 'app_owner|app_reader'
      drop: true
```

```sql
-- desired.sql declares the same view grant
CREATE TABLE "app"."t" (...);
ALTER TABLE app.t OWNER TO app_owner;
CREATE VIEW "app"."v_t" AS SELECT id FROM app.t;
ALTER TABLE app.v_t OWNER TO app_owner;
GRANT SELECT ON TABLE app.v_t TO app_reader;
```

```
$ psqldef --config config.yml --dry-run <db> < desired.sql
GRANT SELECT ON TABLE "app"."v_t" TO "app_reader";   # re-emitted every run — never converges
```

The export does not see the existing view grant, so the declared grant always looks missing.

## Fix

Add `viewPrivileges()`, which reads `relacl` (table-level) and `attacl` (column-level) for `relkind in ('v','m')` and emits standalone `GRANT ... ON TABLE` statements, mirroring `sequencePrivileges()` and `objectOwners()`. `information_schema.table_privileges` does not expose materialized views, so `relacl` is read directly to cover `'v'` and `'m'` uniformly. The same `TargetSchema` and managed-grantee filters as the other export helpers are applied. Only runs when privilege management is configured, so `--export` output is unchanged for users who do not manage privileges.

## Test

Adds view/matview GRANT cases to `tests_manage_privilege.yml`:
- view GRANT idempotent convergence (guards the bug via the current-schema idempotency check),
- view GRANT drift → `REVOKE` (with `drop: true`),
- matview GRANT idempotent convergence (guards the relacl-for-matview path).

Verified that the new tests fail without the fix (view/matview grants are re-emitted and never converge) and pass with it. Full `cmd/psqldef` + `database/postgres` suite green locally on PG18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
