### PR TITLE
psqldef: apply `--skip-extension` to all schema inputs

### DIFF
--- a/cmd-psqldef.md
+++ b/cmd-psqldef.md
@@ -546,6 +546,8 @@ $ psqldef -U postgres dbname --apply \
 
 By default, psqldef manages every extension in the database (equivalent to `--skip-extension` being off). Some managed PostgreSQL services (e.g. AlloyDB) auto-install extensions such as `google_columnar_engine` that should never be diffed or dropped, while `--skip-extension` would also stop managing extensions you do want tracked, like `vector` or `pg_trgm`.
 
+`--skip-extension` excludes all extensions from both the current and desired schemas. It applies consistently to live database comparisons, offline comparisons using a current SQL file, and `--export`. The flag takes precedence over `manage.extension`, so no extension is created, dropped, or exported when both are specified. To manage only selected extensions, omit `--skip-extension` and use `manage.extension`.
+
 `manage.extension` restricts management to extensions matching a rule, leaving everything else untouched:
 
 ```yaml

--- a/cmd/psqldef/psqldef.go
+++ b/cmd/psqldef/psqldef.go
@@ -91,6 +91,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 
 	// merge --config and --config-inline in order
 	config := database.MergeGeneratorConfigs(configs)
+	config.SkipExtension = opts.SkipExtension
 
 	if opts.EnableDrop {
 		config.EnableDrop = true

--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -981,16 +981,57 @@ func TestPsqldefSkipView(t *testing.T) {
 }
 
 func TestPsqldefSkipExtension(t *testing.T) {
-	resetTestDatabase()
+	const createExtension = "CREATE EXTENSION pgcrypto;\n"
 
-	createExtension := "CREATE EXTENSION pgcrypto;\n"
+	t.Run("live current", func(t *testing.T) {
+		resetTestDatabase()
+		mustPgExec(testDatabaseName, createExtension)
+		tu.WriteFile("schema.sql", "")
 
-	mustPgExec(testDatabaseName, createExtension)
+		output := tu.MustExecute(t, "./psqldef", psqldefArgs(testDatabaseName, "--skip-extension", "-f", "schema.sql")...)
+		assert.Equal(t, nothingModified, output)
+	})
 
-	tu.WriteFile("schema.sql", "")
+	t.Run("desired", func(t *testing.T) {
+		resetTestDatabase()
+		tu.WriteFile("schema.sql", createExtension)
 
-	output := tu.MustExecute(t, "./psqldef", psqldefArgs(testDatabaseName, "--skip-extension", "-f", "schema.sql")...)
-	assert.Equal(t, nothingModified, output)
+		output := tu.MustExecute(t, "./psqldef", psqldefArgs(testDatabaseName, "--skip-extension", "-f", "schema.sql")...)
+		assert.Equal(t, nothingModified, output)
+
+		extensions, err := pgQuery(testDatabaseName, "SELECT extname FROM pg_extension WHERE extname = 'pgcrypto'")
+		assert.NoError(t, err)
+		assert.Empty(t, extensions)
+	})
+
+	t.Run("offline current", func(t *testing.T) {
+		tu.WriteFile("current.sql", createExtension)
+		tu.WriteFile("schema.sql", "")
+
+		output := tu.MustExecute(t, "./psqldef", psqldefArgs("current.sql", "--skip-extension", "-f", "schema.sql")...)
+		assert.Equal(t, nothingModified, output)
+	})
+
+	t.Run("export", func(t *testing.T) {
+		resetTestDatabase()
+		mustPgExec(testDatabaseName, createExtension)
+
+		output := tu.MustExecute(t, "./psqldef", psqldefArgs(testDatabaseName, "--skip-extension", "--export")...)
+		assert.Equal(t, "-- No table exists --\n", output)
+	})
+
+	t.Run("takes precedence over manage.extension", func(t *testing.T) {
+		tu.WriteFile("current.sql", createExtension)
+		tu.WriteFile("schema.sql", "CREATE EXTENSION btree_gist;\n")
+
+		output := tu.MustExecute(t, "./psqldef", psqldefArgs(
+			"current.sql",
+			"--skip-extension",
+			"--config-inline", "manage: {extension: [{target: '.*', drop: true}]}",
+			"-f", "schema.sql",
+		)...)
+		assert.Equal(t, nothingModified, output)
+	})
 }
 
 func TestPsqldefSkipPartition(t *testing.T) {
@@ -1610,6 +1651,7 @@ func TestMain(m *testing.M) {
 	cleanupTestRoles()
 	_ = os.Remove("psqldef")
 	_ = os.Remove("schema.sql")
+	_ = os.Remove("current.sql")
 	_ = os.Remove("config.yml")
 	os.Exit(status)
 }

--- a/database/database.go
+++ b/database/database.go
@@ -64,6 +64,7 @@ type GeneratorConfig struct {
 	DisableDdlTransaction   bool     // Do not use a transaction for DDL statements
 	BulkAlter               bool     // Bundle multiple ALTER TABLE actions on the same table into a single statement (MySQL only)
 	LegacyIgnoreQuotes      bool     // true = ignore quotes (legacy), false = preserve quotes
+	SkipExtension           bool
 
 	ManageExtensions *[]ManageObjectRule
 	ManagePrivileges *[]ManageObjectRule // manage.privilege rules: which grantees' privileges are managed and whether REVOKE is allowed

--- a/object-management.md
+++ b/object-management.md
@@ -361,13 +361,13 @@ When a managed object references an object in an unmanaged schema (e.g., a forei
 | `skip_views` | Use allow-list instead |
 | `target_schema` | Use `default_schema` or `schema` field |
 | `--skip-view` | Omit `view` from `manage` |
-| `--skip-extension` | Omit `extension` from `manage` |
+| `--skip-extension` | Use `manage.extension` for selective management; the flag remains an absolute opt-out |
 | `--skip-partition` | Set `partition: false` on table entries |
 | `managed_roles` | `manage.privilege[].target` |
 
 Transition:
 1. Both old and new options work
-2. If `manage:` is specified, deprecated options are ignored
+2. If `manage:` is specified, deprecated options are ignored, except that `--skip-extension` takes precedence over `manage.extension`
 3. Emit deprecation warnings when mixing old and new options
 
 ## Configuration Generation

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -6911,13 +6911,17 @@ func containsRegexpString(strs []string, str string) bool {
 }
 
 func FilterExtensions(ddls []DDL, config database.GeneratorConfig) []DDL {
-	if config.ManageExtensions == nil {
+	if !config.SkipExtension && config.ManageExtensions == nil {
 		return ddls
 	}
 
 	filtered := []DDL{}
 	for _, ddl := range ddls {
 		if stmt, ok := ddl.(*Extension); ok {
+			if config.SkipExtension {
+				slog.Debug("--skip-extension is enabled; excluding extension from management", "extension", stmt.extension.Name.Name)
+				continue
+			}
 			name := stmt.extension.Name.Name
 			if _, matched := matchManageObjectRule(*config.ManageExtensions, name); !matched {
 				slog.Debug("extension matches no manage.extension rule; excluding it from management", "extension", name)

--- a/schema/generator_test.go
+++ b/schema/generator_test.go
@@ -23,6 +23,63 @@ func TestStringConstantContainingSingleQuote(t *testing.T) {
 	assert.Equal(t, StringConstant("'example'"), "'''example'''")
 }
 
+func TestSkipExtension(t *testing.T) {
+	manageAllExtensions := &[]database.ManageObjectRule{{Target: ".*", Drop: true}}
+	tests := []struct {
+		name     string
+		desired  string
+		current  string
+		config   database.GeneratorConfig
+		expected []string
+	}{
+		{
+			name:     "desired extension",
+			desired:  "CREATE EXTENSION pgcrypto;",
+			config:   database.GeneratorConfig{SkipExtension: true},
+			expected: []string{},
+		},
+		{
+			name:     "current extension",
+			current:  "CREATE EXTENSION pgcrypto;",
+			config:   database.GeneratorConfig{SkipExtension: true, EnableDrop: true},
+			expected: []string{},
+		},
+		{
+			name:    "manage.extension match",
+			desired: "CREATE EXTENSION pgcrypto;",
+			config: database.GeneratorConfig{
+				SkipExtension:    true,
+				ManageExtensions: manageAllExtensions,
+			},
+			expected: []string{},
+		},
+		{
+			name:    "non-extension DDL remains",
+			desired: "CREATE EXTENSION pgcrypto; CREATE TABLE users (id bigint);",
+			config:  database.GeneratorConfig{SkipExtension: true},
+			expected: []string{
+				"CREATE TABLE users (id bigint)",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.config.LegacyIgnoreQuotes = false
+			ddls, err := GenerateIdempotentDDLs(
+				GeneratorModePostgres,
+				database.NewParser(parser.ParserModePostgres),
+				tt.desired,
+				tt.current,
+				tt.config,
+				"public",
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, ddls)
+		})
+	}
+}
+
 func TestAreSamePrimaryKeyColumnsMutation(t *testing.T) {
 	// Test that areSamePrimaryKeyColumns doesn't mutate the input indexes
 	g := &Generator{mode: GeneratorModeMysql}


### PR DESCRIPTION
## What

Make `--skip-extension` an absolute opt-out for extensions across every schema source handled by psqldef.

- Add `SkipExtension` to `database.GeneratorConfig` and propagate the CLI flag after merging `--config` and `--config-inline`.
- Update the shared `schema.FilterExtensions` path to remove every extension before evaluating `manage.extension`. Because the generator applies this filter to both desired and current DDLs, the flag now works for live comparisons, offline comparisons using a current SQL file, and file-based export.
- Keep the PostgreSQL exporter's existing early skip, avoiding the extension catalog query for live databases.
- Document the flag's scope and its precedence over `manage.extension`.

When `--skip-extension` and `manage.extension` are both specified, `--skip-extension` wins: psqldef does not create, drop, or export any extension. Without the flag, existing extension management and `manage.extension` behavior remain unchanged.

## Motivation

Previously, `--skip-extension` was passed only to the database exporter. The PostgreSQL live exporter used it to omit extensions from the current schema, but the shared generator never received the flag. Extensions from the desired schema or an offline current SQL file therefore remained in the diff.

This produced inconsistent behavior depending on the schema source:

| Scenario | Before | After |
|---|---|---|
| Extension exists only in the desired schema | Emit `CREATE EXTENSION` | No DDL |
| Extension exists only in an offline current SQL file | Emit `DROP EXTENSION` | No DDL |
| `--skip-extension` is combined with matching `manage.extension` rules | Rules could keep extensions in the diff | No extension is managed |
| Live current schema or live `--export` | Extensions were already skipped by the exporter | Behavior preserved |

Applying the flag in the shared filter gives current and desired schemas the same semantics regardless of whether the current schema comes from a live database or a file.

## Test

- `cmd/psqldef/psqldef_test.go` — expand `TestPsqldefSkipExtension` to cover live current schema, desired schema, offline current SQL, export, and precedence over `manage.extension`.
- `schema/generator_test.go` — add DB-less coverage for desired-only and current-only extensions, `manage.extension` precedence, and preservation of non-extension DDLs.
