### PR TITLE
psqldef: diff split desired GRANTs for the same object/grantee once

### DIFF
--- a/cmd/psqldef/tests_manage_privilege.yml
+++ b/cmd/psqldef/tests_manage_privilege.yml
@@ -195,6 +195,57 @@ ManagePrivilegeIdempotent:
   up: ""
   down: ""
 
+ManagePrivilegeSplitGrantStatementsRevokeOnce:
+  # Privileges for the same (table, grantee) split across several desired GRANT
+  # statements must be diffed as one unit: the REVOKE is emitted once, not once
+  # per source statement.
+  manage:
+    privilege:
+      - target: app_user
+        drop: true
+  current: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE users TO app_user;
+  desired: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    GRANT SELECT ON TABLE users TO app_user;
+    GRANT INSERT ON TABLE users TO app_user;
+  up: |
+    REVOKE DELETE, UPDATE ON TABLE "public"."users" FROM "app_user";
+  down: |
+    GRANT UPDATE, DELETE ON TABLE "public"."users" TO "app_user";
+
+ManagePrivilegeSplitGrantStatementsGrantOnce:
+  # The GRANT side must also be diffed as one unit: a privilege missing from the
+  # current schema is granted once even when the desired GRANTs are split.
+  manage:
+    privilege:
+      - target: app_user
+        drop: true
+  current: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    GRANT SELECT ON TABLE users TO app_user;
+  desired: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    GRANT SELECT ON TABLE users TO app_user;
+    GRANT INSERT ON TABLE users TO app_user;
+  up: |
+    GRANT INSERT ON TABLE "public"."users" TO "app_user";
+  down: |
+    REVOKE INSERT ON TABLE "public"."users" FROM "app_user";
+
 ManagePrivilegeOwnerConverge:
   # 宣言された owner が current と違えば ALTER OWNER が出る
   manage:

--- a/cmd/psqldef/tests_manage_privilege.yml
+++ b/cmd/psqldef/tests_manage_privilege.yml
@@ -246,6 +246,33 @@ ManagePrivilegeSplitGrantStatementsGrantOnce:
   down: |
     REVOKE INSERT ON TABLE "public"."users" FROM "app_user";
 
+ManagePrivilegeSplitGrantStatementsReorderedGrantees:
+  # Grantee lists written in a different order (TO a, b vs TO b, a) target the
+  # same grantees and must aggregate together, so the diff is emitted once per
+  # grantee rather than once per source statement.
+  manage:
+    privilege:
+      - target: 'app_user|readonly_user'
+        drop: true
+  current: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE users TO app_user, readonly_user;
+  desired: |
+    CREATE TABLE users (
+      id BIGINT PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    GRANT SELECT ON TABLE users TO app_user, readonly_user;
+    GRANT INSERT ON TABLE users TO readonly_user, app_user;
+  up: |
+    REVOKE DELETE, UPDATE ON TABLE "public"."users" FROM "app_user";
+    REVOKE DELETE, UPDATE ON TABLE "public"."users" FROM "readonly_user";
+  down: |
+    GRANT UPDATE, DELETE ON TABLE "public"."users" TO "app_user", "readonly_user";
+
 ManagePrivilegeOwnerConverge:
   # 宣言された owner が current と違えば ALTER OWNER が出る
   manage:

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -235,6 +235,12 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 	// bulkAlter fuses per-table ALTER TABLE actions when --bulk-alter is set (MySQL only).
 	bulkAlter := newAlterBundler(g, g.config.BulkAlter && g.mode == GeneratorModeMysql)
 
+	// Desired GRANTs for the same (object, grantees, grant option) can be split
+	// across several statements; they are merged into one entry in
+	// g.desiredPrivileges. Track which aggregated entry has already produced its
+	// diff so the REVOKE/GRANT is emitted once, not once per source statement.
+	generatedGrantPrivileges := map[*GrantPrivilege]bool{}
+
 	// Incrementally examine desiredDDLs
 	for _, ddl := range desiredDDLs {
 		switch desired := ddl.(type) {
@@ -411,7 +417,19 @@ func (g *Generator) generateDDLs(desiredDDLs []DDL) ([]string, error) {
 			}
 			createSchemaDDLs = append(createSchemaDDLs, schemaDDLs...)
 		case *GrantPrivilege:
-			privilegeDDLs, err := g.generateDDLsForGrantPrivilege(desired)
+			// Diff the merged desired privileges for this (object, grantees,
+			// grant option) once. Using the aggregated entry keeps split GRANT
+			// statements from each re-emitting the same REVOKE/GRANT, while still
+			// covering every privilege they collectively declare.
+			aggregated := g.aggregatedDesiredPrivilege(desired)
+			if aggregated == nil {
+				aggregated = desired
+			}
+			if generatedGrantPrivileges[aggregated] {
+				break
+			}
+			generatedGrantPrivileges[aggregated] = true
+			privilegeDDLs, err := g.generateDDLsForGrantPrivilege(aggregated)
 			if err != nil {
 				return nil, err
 			}
@@ -4386,6 +4404,23 @@ func formatPrivilegesForGrant(privileges []string) string {
 		}
 	}
 	return strings.Join(privileges, ", ")
+}
+
+// aggregatedDesiredPrivilege returns the merged desired GrantPrivilege that a
+// raw desired GRANT statement contributes to. Desired GRANTs for the same
+// object, grantees, grant option, and object type are combined into a single
+// entry in g.desiredPrivileges (see convertDDLsToTablesAndViews), so the diff is
+// generated once against the full privilege set rather than once per statement.
+func (g *Generator) aggregatedDesiredPrivilege(raw *GrantPrivilege) *GrantPrivilege {
+	for _, agg := range g.desiredPrivileges {
+		if g.qualifiedNamesEqual(agg.tableName, raw.tableName) &&
+			agg.withGrantOption == raw.withGrantOption &&
+			agg.objectType == raw.objectType &&
+			slices.Equal(agg.grantees, raw.grantees) {
+			return agg
+		}
+	}
+	return nil
 }
 
 func (g *Generator) generateDDLsForGrantPrivilege(desired *GrantPrivilege) ([]string, error) {

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -4333,31 +4333,22 @@ func aggregateDDLsToSchema(ddls []DDL, mode GeneratorMode, defaultSchema string,
 				if qualifiedNamesEqual(existing.tableName, stmt.tableName, defaultSchema, mode, legacyIgnoreQuotes, mysqlLowerCaseTableNames) &&
 					existing.withGrantOption == stmt.withGrantOption &&
 					existing.objectType == stmt.objectType &&
-					len(existing.grantees) == len(stmt.grantees) {
-					allMatch := true
-					for j, grantee := range existing.grantees {
-						if grantee != stmt.grantees[j] {
-							allMatch = false
-							break
-						}
+					sameGranteeSet(existing.grantees, stmt.grantees) {
+					privMap := make(map[string]bool)
+					for _, priv := range existing.privileges {
+						privMap[priv] = true
 					}
-					if allMatch {
-						privMap := make(map[string]bool)
-						for _, priv := range existing.privileges {
-							privMap[priv] = true
-						}
-						for _, priv := range stmt.privileges {
-							privMap[priv] = true
-						}
-						mergedPrivs := []string{}
-						for priv := range privMap {
-							mergedPrivs = append(mergedPrivs, priv)
-						}
-						slices.Sort(mergedPrivs)
-						aggregated.Privileges[i].privileges = mergedPrivs
-						merged = true
-						break
+					for _, priv := range stmt.privileges {
+						privMap[priv] = true
 					}
+					mergedPrivs := []string{}
+					for priv := range privMap {
+						mergedPrivs = append(mergedPrivs, priv)
+					}
+					slices.Sort(mergedPrivs)
+					aggregated.Privileges[i].privileges = mergedPrivs
+					merged = true
+					break
 				}
 			}
 			if !merged {
@@ -4406,6 +4397,20 @@ func formatPrivilegesForGrant(privileges []string) string {
 	return strings.Join(privileges, ", ")
 }
 
+// sameGranteeSet reports whether two grantee lists contain the same grantees
+// regardless of the order they were written in. GRANT ... TO a, b and
+// GRANT ... TO b, a target the same grantees, so they must aggregate together.
+func sameGranteeSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	as := slices.Clone(a)
+	bs := slices.Clone(b)
+	slices.Sort(as)
+	slices.Sort(bs)
+	return slices.Equal(as, bs)
+}
+
 // aggregatedDesiredPrivilege returns the merged desired GrantPrivilege that a
 // raw desired GRANT statement contributes to. Desired GRANTs for the same
 // object, grantees, grant option, and object type are combined into a single
@@ -4416,7 +4421,7 @@ func (g *Generator) aggregatedDesiredPrivilege(raw *GrantPrivilege) *GrantPrivil
 		if g.qualifiedNamesEqual(agg.tableName, raw.tableName) &&
 			agg.withGrantOption == raw.withGrantOption &&
 			agg.objectType == raw.objectType &&
-			slices.Equal(agg.grantees, raw.grantees) {
+			sameGranteeSet(agg.grantees, raw.grantees) {
 			return agg
 		}
 	}


### PR DESCRIPTION
## Problem

When the privileges for the same `(object, grantee, grant option)` are declared across **several** desired `GRANT` statements, psqldef emits the resulting `REVOKE` (or `GRANT`) **once per source statement** — identical duplicated lines — under `manage.privilege` with `drop: true`.

- psqldef: v3.11.20 (`29164ef`)
- PostgreSQL: 16 (`postgres:16` image)

## Reproduction

```sql
CREATE SCHEMA dip_owner;
CREATE ROLE app_x NOLOGIN;
CREATE TABLE dip_owner.t1 (id int);
GRANT SELECT, INSERT, UPDATE, DELETE ON dip_owner.t1 TO app_x;
```

```yaml
# config.yml
target_schema: dip_owner
manage:
  privilege:
    - target: 'app_x'
      drop: true
```

**One desired statement (correct):**

```sql
GRANT SELECT ON TABLE dip_owner.t1 TO app_x;
```
```
REVOKE DELETE, INSERT, UPDATE ON TABLE "dip_owner"."t1" FROM "app_x";
```

**Split into two desired statements (bug):**

```sql
GRANT SELECT ON TABLE dip_owner.t1 TO app_x;
GRANT INSERT ON TABLE dip_owner.t1 TO app_x;
```
```
REVOKE DELETE, UPDATE ON TABLE "dip_owner"."t1" FROM "app_x";
REVOKE DELETE, UPDATE ON TABLE "dip_owner"."t1" FROM "app_x";   # duplicated
```

The GRANT side duplicates the same way (e.g. current has only `SELECT`, desired declares `SELECT` and `INSERT` as two statements → `GRANT INSERT` is emitted twice).

Splitting grants across statements happens naturally when the desired schema is generated from the catalog: `aclexplode(pg_class.relacl)` yields one row per privilege.

## Why it matters

The DDL is idempotent, so no data-level harm, but:

1. **Plan readability** — reviewers see identical lines repeated.
2. **Row-count safety checks** — a caller that blocks an apply when the number of REVOKEs exceeds a threshold counts one logical revoke as N.
3. **Audit records** carry the duplicates.

## Root cause

Desired GRANTs for the same `(object, grantees, grant option, object type)` are already merged into a single entry in `g.desiredPrivileges` (`convertDDLsToTablesAndViews`), and `generateDDLsForGrantPrivilege` already cross-references that aggregated set to compute the correct REVOKE/GRANT. But the generation loop iterates the **raw** desired DDLs and calls `generateDDLsForGrantPrivilege` once per raw `GrantPrivilege`, so the same diff is produced repeatedly.

## Fix

Route each raw desired `GrantPrivilege` to its aggregated entry and generate the diff **once per aggregated entry** (tracked by identity). This diffs the full privilege set as one unit, so a split declaration produces a single `REVOKE`/`GRANT`. Simply skipping duplicate statements would be wrong — it would drop privileges that only a later statement declares — which is why the aggregated (merged) entry is used.

## Tests

Adds `tests_manage_privilege.yml` cases for split-statement `REVOKE` and `GRANT`. Verified they fail without the fix (duplicated lines) and pass with it. Full `parser`, `schema`, `database/postgres`, and `cmd/psqldef` (`PG_FLAVOR=pgvector`) suites pass locally on PG18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
