### PR TITLE
psqldef: compare EXTRACT and date_part according to the PostgreSQL server version

### DIFF
--- a/cmd/psqldef/tests_views.yml
+++ b/cmd/psqldef/tests_views.yml
@@ -493,6 +493,87 @@ ViewWithGroupByAndHaving:
     CREATE VIEW tag_counts AS
     SELECT tag, COUNT(*) AS count
     FROM taggings GROUP BY tag HAVING COUNT(*) > 1;
+ExtractAndDatePartEquivalentBeforePostgres14:
+  max_version: "13"
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TABLE events (
+      created_at timestamp
+    );
+    CREATE VIEW event_years AS
+      SELECT
+        EXTRACT(year FROM created_at) AS event_year,
+        EXTRACT(month FROM created_at) AS event_month
+      FROM events;
+  desired: |
+    CREATE TABLE events (
+      created_at timestamp
+    );
+    CREATE VIEW event_years AS
+      SELECT
+        date_part('year', created_at) AS event_year,
+        pg_catalog.date_part('month', created_at) AS event_month
+      FROM events;
+  up: ""
+  down: ""
+ExtractAndDatePartEquivalentInWindowAndWithinGroupBeforePostgres14:
+  max_version: "13"
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TABLE events (
+      created_at timestamp
+    );
+    CREATE VIEW event_windows AS
+      SELECT row_number() OVER (
+        PARTITION BY EXTRACT(month FROM created_at)
+        ORDER BY EXTRACT(year FROM created_at)
+      ) AS row_num
+      FROM events;
+    CREATE VIEW event_percentiles AS
+      SELECT percentile_cont(0.5) WITHIN GROUP (
+        ORDER BY EXTRACT(epoch FROM created_at)
+      ) AS median_epoch
+      FROM events;
+  desired: |
+    CREATE TABLE events (
+      created_at timestamp
+    );
+    CREATE VIEW event_windows AS
+      SELECT row_number() OVER (
+        PARTITION BY date_part('month', created_at)
+        ORDER BY date_part('year', created_at)
+      ) AS row_num
+      FROM events;
+    CREATE VIEW event_percentiles AS
+      SELECT percentile_cont(0.5) WITHIN GROUP (
+        ORDER BY date_part('epoch', created_at)
+      ) AS median_epoch
+      FROM events;
+  up: ""
+  down: ""
+ExtractAndDatePartDifferFromPostgres14:
+  min_version: "14"
+  legacy_ignore_quotes: false
+  current: |
+    CREATE TABLE events (
+      created_at timestamp
+    );
+    CREATE VIEW event_years AS
+      SELECT EXTRACT(year FROM created_at) AS event_year
+      FROM events;
+  desired: |
+    CREATE TABLE events (
+      created_at timestamp
+    );
+    CREATE VIEW event_years AS
+      SELECT date_part('year', created_at) AS event_year
+      FROM events;
+  up: |
+    DROP VIEW public.event_years;
+    CREATE VIEW public.event_years AS select date_part('year', created_at) as event_year from events;
+  down: |
+    DROP VIEW public.event_years;
+    CREATE VIEW public.event_years AS select EXTRACT(year FROM created_at) as event_year from events;
 ExtractInMaterializedView:
   desired: |
     CREATE TABLE events (

--- a/database/database.go
+++ b/database/database.go
@@ -82,6 +82,11 @@ type GeneratorConfig struct {
 	// Every copy of the config shares one map that ExportDDLs() refills, so read it only after
 	// exporting: the schema being applied may install an extension that registers operator classes.
 	PostgresDefaultOperatorClasses map[string]bool
+
+	// PostgreSQL-specific: whether EXTRACT and date_part return the same type and can be
+	// compared as equivalent expressions. This is true before PostgreSQL 14.
+	// False in offline mode and when the server version cannot be determined.
+	PostgresExtractDatePartEquivalent bool
 }
 
 type ManageObjectRule struct {

--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -56,10 +56,26 @@ func (d *PostgresDatabase) SetGeneratorConfig(config database.GeneratorConfig) {
 		d.defaultOpclasses = map[string]bool{}
 	}
 	config.PostgresDefaultOperatorClasses = d.defaultOpclasses
+	config.PostgresExtractDatePartEquivalent = false
+	var serverVersionNum int
+	if err := d.db.QueryRow("SHOW server_version_num").Scan(&serverVersionNum); err != nil {
+		slog.Debug("Failed to get PostgreSQL server_version_num", "error", err)
+	} else {
+		config.PostgresExtractDatePartEquivalent = extractDatePartEquivalent(serverVersionNum)
+		slog.Debug(
+			"Determined PostgreSQL EXTRACT/date_part comparison capability",
+			"server_version_num", serverVersionNum,
+			"equivalent", config.PostgresExtractDatePartEquivalent,
+		)
+	}
 	d.generatorConfig = config
 	// Sync TargetSchema to d.config for backward compatibility
 	// (other methods read from d.config.TargetSchema)
 	d.config.TargetSchema = config.TargetSchema
+}
+
+func extractDatePartEquivalent(serverVersionNum int) bool {
+	return serverVersionNum < 140000
 }
 
 // refreshDefaultOperatorClasses reloads the default operator class of every access method, keyed by
@@ -530,8 +546,6 @@ func (d *PostgresDatabase) views() ([]string, error) {
 		if d.config.TargetSchema != nil && !slices.Contains(d.config.TargetSchema, schema) {
 			continue
 		}
-		// Normalize PostgreSQL-specific syntax for generic parser compatibility
-		definition = normalizeDatePartToExtract(definition)
 		ddls = append(
 			ddls, fmt.Sprintf(
 				"CREATE VIEW %s.%s AS %s;", d.quoteIdentifierIfNeeded(schema), d.quoteIdentifierIfNeeded(name), definition,
@@ -601,8 +615,6 @@ func (d *PostgresDatabase) materializedViews() ([]string, error) {
 		definition = strings.ReplaceAll(definition, "\n", " ")
 		definition = suffixSemicolon.ReplaceAllString(definition, "")
 		definition = spaces.ReplaceAllString(definition, " ")
-		// Normalize PostgreSQL-specific syntax for generic parser compatibility
-		definition = normalizeDatePartToExtract(definition)
 		ddls = append(
 			ddls, fmt.Sprintf(
 				"CREATE MATERIALIZED VIEW %s.%s AS %s;", d.quoteIdentifierIfNeeded(schema), d.quoteIdentifierIfNeeded(name), definition,
@@ -1170,33 +1182,6 @@ func (d *PostgresDatabase) getIndexDefs(table string) ([]string, error) {
 		indexes = append(indexes, indexdef)
 	}
 	return indexes, nil
-}
-
-// normalizeDatePartToExtract converts PostgreSQL's date_part() function calls to EXTRACT() expressions
-// PostgreSQL stores EXTRACT(field FROM source) as date_part('field'::text, source) internally.
-// The generic parser handles EXTRACT natively but parses date_part as a generic function call,
-// so we need to convert it back to EXTRACT for idempotent schema comparisons.
-func normalizeDatePartToExtract(sql string) string {
-	// Match date_part('field'::text, ...) or date_part('field', ...)
-	// The field can be: year, month, day, hour, minute, second, epoch, dow, doy, week, quarter, etc.
-	// We need to handle nested function calls and complex expressions as the second argument
-
-	// Use a regex that captures the field name and finds the matching closing parenthesis
-	// Pattern: date_part('field'::text, source) or date_part('field', source)
-	re := regexp.MustCompile(`date_part\('([^']+)'(?:::text)?,\s*([^)]+)\)`)
-
-	// Replace with EXTRACT(field FROM source)
-	sql = re.ReplaceAllStringFunc(sql, func(match string) string {
-		submatches := re.FindStringSubmatch(match)
-		if len(submatches) == 3 {
-			field := submatches[1]
-			source := strings.TrimSpace(submatches[2])
-			return fmt.Sprintf("EXTRACT(%s FROM %s)", field, source)
-		}
-		return match
-	})
-
-	return sql
 }
 
 // normalizePostgresTypeCasts normalizes PostgreSQL's verbose type cast syntax for generic parser compatibility.

--- a/database/postgres/database_test.go
+++ b/database/postgres/database_test.go
@@ -48,6 +48,41 @@ func TestUnixSocketConnection(t *testing.T) {
 	}
 }
 
+func TestSetGeneratorConfigDefaultsExtractDatePartToFalseOnVersionQueryError(t *testing.T) {
+	sock := testutil.StartDummyUnixSocket(t, "postgres-config-test", ".s.PGSQL.5432")
+	defer sock.Close()
+
+	db, err := NewDatabase(database.Config{Socket: sock.Dir, Port: 5432})
+	require.NoError(t, err)
+	defer db.Close()
+
+	db.SetGeneratorConfig(database.GeneratorConfig{PostgresExtractDatePartEquivalent: true})
+	assert.False(t, db.GetGeneratorConfig().PostgresExtractDatePartEquivalent)
+}
+
+func TestExtractDatePartEquivalent(t *testing.T) {
+	assert.True(t, extractDatePartEquivalent(139999))
+	assert.False(t, extractDatePartEquivalent(140000))
+}
+
+func TestExportMaterializedViewPreservesDatePart(t *testing.T) {
+	db := setupTestDatabase(t)
+	defer db.Close()
+
+	_, err := db.DB().Exec(`
+		CREATE TABLE events (created_at timestamp);
+		CREATE MATERIALIZED VIEW event_years AS
+		SELECT date_part('year', created_at) AS event_year FROM events;
+	`)
+	require.NoError(t, err)
+
+	db.SetGeneratorConfig(database.GeneratorConfig{LegacyIgnoreQuotes: false})
+	exported, err := db.ExportDDLs()
+	require.NoError(t, err)
+	assert.Contains(t, exported, "date_part(")
+	assert.NotContains(t, exported, "EXTRACT(")
+}
+
 // TestExtensionOIDCollisionByInjectedDependency verifies that ExportDDLs correctly
 // handles OID collisions between user objects and extension objects.
 //

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -2323,8 +2323,8 @@ func (g *Generator) generateDDLsForCreateView(desiredView *View) ([]string, erro
 		// View found. If it's different, create or replace view.
 		// Use AST-based comparison with table lookup for SELECT * expansion
 		tableLookup := g.createTableLookup()
-		currentNormalizedAST := normalizeViewDefinition(currentView.definition, g.mode, tableLookup)
-		desiredNormalizedAST := normalizeViewDefinition(desiredView.definition, g.mode, tableLookup)
+		currentNormalizedAST := normalizeViewDefinition(currentView.definition, g.mode, tableLookup, g.config.PostgresExtractDatePartEquivalent)
+		desiredNormalizedAST := normalizeViewDefinition(desiredView.definition, g.mode, tableLookup, g.config.PostgresExtractDatePartEquivalent)
 		currentNormalized := strings.ToLower(parser.String(currentNormalizedAST))
 		desiredNormalized := strings.ToLower(parser.String(desiredNormalizedAST))
 

--- a/schema/generator_test.go
+++ b/schema/generator_test.go
@@ -437,6 +437,47 @@ func TestNormalizeViewDefinition(t *testing.T) {
 			input:    `SELECT 1 AS id EXCEPT ((SELECT 2 AS id) UNION SELECT 3 AS id)`,
 			expected: `select 1 as id except (select 2 as id union select 3 as id)`,
 		},
+		{
+			name:                              "PostgreSQL before 14: normalize unqualified date_part to EXTRACT",
+			mode:                              GeneratorModePostgres,
+			input:                             `SELECT date_part('year'::text, created_at) AS event_year FROM events`,
+			postgresExtractDatePartEquivalent: true,
+			expected:                          `select extract(year from created_at) as event_year from events`,
+		},
+		{
+			name:                              "PostgreSQL before 14: normalize pg_catalog.date_part to EXTRACT",
+			mode:                              GeneratorModePostgres,
+			input:                             `SELECT pg_catalog.date_part('year'::text, created_at) AS event_year FROM events`,
+			postgresExtractDatePartEquivalent: true,
+			expected:                          `select extract(year from created_at) as event_year from events`,
+		},
+		{
+			name:                              "PostgreSQL before 14: normalize uppercase unquoted PG_CATALOG.date_part to EXTRACT",
+			mode:                              GeneratorModePostgres,
+			input:                             `SELECT PG_CATALOG.date_part('year'::text, created_at) AS event_year FROM events`,
+			postgresExtractDatePartEquivalent: true,
+			expected:                          `select extract(year from created_at) as event_year from events`,
+		},
+		{
+			name:                              "PostgreSQL before 14: preserve other schema date_part",
+			mode:                              GeneratorModePostgres,
+			input:                             `SELECT app.date_part('year'::text, created_at) AS event_year FROM events`,
+			postgresExtractDatePartEquivalent: true,
+			expected:                          `select app.date_part('year', created_at) as event_year from events`,
+		},
+		{
+			name:     "PostgreSQL 14 and later: preserve date_part",
+			mode:     GeneratorModePostgres,
+			input:    `SELECT date_part('year'::text, created_at) AS event_year FROM events`,
+			expected: `select date_part('year', created_at) as event_year from events`,
+		},
+		{
+			name:                              "PostgreSQL before 14: normalize date_part in window expressions",
+			mode:                              GeneratorModePostgres,
+			input:                             `SELECT sum(amount) OVER (PARTITION BY date_part('month'::text, created_at) ORDER BY date_part('year'::text, created_at)) AS running_total, percentile_cont(0.5) WITHIN GROUP (ORDER BY date_part('epoch'::text, created_at)) AS median FROM events`,
+			postgresExtractDatePartEquivalent: true,
+			expected:                          `select sum(amount) over(partition by extract(month from created_at) order by extract(year from created_at) asc) as running_total, percentile_cont(0.5) within group( order by extract(epoch from created_at) asc) as median from events`,
+		},
 		// MySQL should normalize column qualifiers (MySQL adds database.table.column when storing views)
 		{
 			name:     "MySQL: normalize table qualifiers in SELECT",
@@ -470,6 +511,65 @@ func TestNormalizeViewDefinition(t *testing.T) {
 			actual := strings.ToLower(parser.String(normalized))
 
 			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestIsPostgresCatalogQualifier(t *testing.T) {
+	tests := []struct {
+		name      string
+		qualifier parser.Ident
+		expected  bool
+	}{
+		{name: "unqualified", qualifier: parser.Ident{}, expected: true},
+		{name: "lowercase unquoted", qualifier: parser.NewIdent("pg_catalog", false), expected: true},
+		{name: "uppercase unquoted", qualifier: parser.NewIdent("PG_CATALOG", false), expected: true},
+		{name: "lowercase quoted", qualifier: parser.NewIdent("pg_catalog", true), expected: true},
+		{name: "uppercase quoted", qualifier: parser.NewIdent("PG_CATALOG", true), expected: false},
+		{name: "other schema", qualifier: parser.NewIdent("app", false), expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isPostgresCatalogQualifier(tt.qualifier))
+		})
+	}
+}
+
+func TestGeneratePostgresViewExtractDatePartComparison(t *testing.T) {
+	extract := `CREATE VIEW event_years AS SELECT EXTRACT(year FROM created_at) AS event_year FROM events;`
+	datePart := `CREATE VIEW event_years AS SELECT date_part('year', created_at) AS event_year FROM events;`
+
+	for _, tt := range []struct {
+		name       string
+		equivalent bool
+		expected   []string
+	}{
+		{name: "equivalent before PostgreSQL 14", equivalent: true, expected: []string{}},
+		{
+			name:       "different from PostgreSQL 14",
+			equivalent: false,
+			expected: []string{
+				"DROP VIEW public.event_years",
+				"CREATE VIEW public.event_years AS select date_part('year', created_at) as event_year from events",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ddls, err := GenerateIdempotentDDLs(
+				GeneratorModePostgres,
+				database.NewParser(parser.ParserModePostgres),
+				datePart,
+				extract,
+				database.GeneratorConfig{
+					EnableDrop:                        true,
+					LegacyIgnoreQuotes:                false,
+					PostgresExtractDatePartEquivalent: tt.equivalent,
+				},
+				"public",
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, ddls)
 		})
 	}
 }

--- a/schema/generator_test.go
+++ b/schema/generator_test.go
@@ -364,10 +364,11 @@ func TestSQLiteCheckConstraintModification(t *testing.T) {
 
 func TestNormalizeViewDefinition(t *testing.T) {
 	tests := []struct {
-		name     string
-		mode     GeneratorMode
-		input    string
-		expected string
+		name                              string
+		mode                              GeneratorMode
+		input                             string
+		postgresExtractDatePartEquivalent bool
+		expected                          string
 	}{
 		// PostgreSQL specific tests
 		{
@@ -465,7 +466,7 @@ func TestNormalizeViewDefinition(t *testing.T) {
 			assert.Equal(t, parser.CreateView, ddl.Action)
 			assert.NotNil(t, ddl.View.Definition, "Definition should not be nil")
 
-			normalized := normalizeViewDefinition(ddl.View.Definition, g.mode, nil)
+			normalized := normalizeViewDefinition(ddl.View.Definition, g.mode, nil, tt.postgresExtractDatePartEquivalent)
 			actual := strings.ToLower(parser.String(normalized))
 
 			assert.Equal(t, tt.expected, actual)
@@ -494,7 +495,7 @@ func TestNormalizeViewDefinitionInParenthesizedSetOperationSubquery(t *testing.T
 	tableLookup := func(QualifiedName) *Table { return nil }
 
 	normalize := func(definition parser.SelectStatement) string {
-		normalized := normalizeViewDefinition(definition, GeneratorModePostgres, tableLookup)
+		normalized := normalizeViewDefinition(definition, GeneratorModePostgres, tableLookup, false)
 		return stripTableQualifiers(strings.ToLower(parser.String(normalized)))
 	}
 
@@ -523,7 +524,7 @@ func TestNormalizeViewDefinitionExpandsStarFromTable(t *testing.T) {
 	normalized := normalizeViewDefinition(stmt, GeneratorModePostgres, func(name QualifiedName) *Table {
 		assert.Equal(t, "users", name.Name.Name)
 		return table
-	})
+	}, false)
 
 	assert.Equal(t, "select first, second, 3 as marker from users", parser.String(normalized))
 }
@@ -535,17 +536,19 @@ func TestNormalizeTableExprParentheses(t *testing.T) {
 		}
 	}
 
-	assert.Nil(t, normalizeTableExpr(nil, GeneratorModePostgres, nil))
+	assert.Nil(t, normalizeTableExpr(nil, GeneratorModePostgres, nil, false))
 	assert.Equal(t, tableExpr("a"), normalizeTableExpr(
 		&parser.ParenTableExpr{Exprs: parser.TableExprs{tableExpr("a")}},
 		GeneratorModePostgres,
 		nil,
+		false,
 	))
 
 	normalized := normalizeTableExpr(
 		&parser.ParenTableExpr{Exprs: parser.TableExprs{tableExpr("a"), tableExpr("b")}},
 		GeneratorModeSQLite3,
 		nil,
+		false,
 	)
 	paren, ok := normalized.(*parser.ParenTableExpr)
 	assert.True(t, ok)
@@ -685,7 +688,7 @@ func TestNormalizeViewDefinitionPreservesTableAliasColumns(t *testing.T) {
 		},
 	}
 
-	normalized := normalizeViewDefinition(stmt, GeneratorModePostgres, nil)
+	normalized := normalizeViewDefinition(stmt, GeneratorModePostgres, nil, false)
 
 	assert.Equal(t, "select * from (select 1 as id) as s(a, b)", parser.String(normalized))
 }

--- a/schema/generator_test.go
+++ b/schema/generator_test.go
@@ -478,6 +478,20 @@ func TestNormalizeViewDefinition(t *testing.T) {
 			postgresExtractDatePartEquivalent: true,
 			expected:                          `select sum(amount) over(partition by extract(month from created_at) order by extract(year from created_at) asc) as running_total, percentile_cont(0.5) within group( order by extract(epoch from created_at) asc) as median from events`,
 		},
+		{
+			name:                              "PostgreSQL before 14: normalize date_part in OR and unary expressions",
+			mode:                              GeneratorModePostgres,
+			input:                             `SELECT -date_part('epoch'::text, created_at) AS negative_epoch FROM events WHERE date_part('year'::text, created_at) = 2026 OR date_part('month'::text, created_at) = 8`,
+			postgresExtractDatePartEquivalent: true,
+			expected:                          `select -extract(epoch from created_at) as negative_epoch from events where extract(year from created_at) = 2026 or extract(month from created_at) = 8`,
+		},
+		{
+			name:                              "PostgreSQL before 14: normalize date_part in JOIN OR expressions",
+			mode:                              GeneratorModePostgres,
+			input:                             `SELECT l.id FROM events l JOIN events r ON date_part('year'::text, CURRENT_TIMESTAMP) = 2026 OR date_part('month'::text, CURRENT_TIMESTAMP) = 8`,
+			postgresExtractDatePartEquivalent: true,
+			expected:                          `select id from events as l join events as r on extract(year from current_timestamp) = 2026 or extract(month from current_timestamp) = 8`,
+		},
 		// MySQL should normalize column qualifiers (MySQL adds database.table.column when storing views)
 		{
 			name:     "MySQL: normalize table qualifiers in SELECT",
@@ -532,6 +546,41 @@ func TestIsPostgresCatalogQualifier(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, isPostgresCatalogQualifier(tt.qualifier))
+		})
+	}
+}
+
+func TestExtractFromDatePartCallRejectsInvalidArguments(t *testing.T) {
+	source := &parser.AliasedExpr{
+		Expr: &parser.ColName{Name: parser.NewIdent("created_at", false)},
+	}
+	tests := []struct {
+		name  string
+		exprs parser.SelectExprs
+	}{
+		{
+			name:  "field is not an aliased expression",
+			exprs: parser.SelectExprs{&parser.StarExpr{}, source},
+		},
+		{
+			name: "field is not a string literal",
+			exprs: parser.SelectExprs{
+				&parser.AliasedExpr{Expr: parser.NewIntVal("1")},
+				source,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extract, ok := extractFromDatePartCall(
+				GeneratorModePostgres,
+				parser.Ident{},
+				"date_part",
+				tt.exprs,
+			)
+			assert.False(t, ok)
+			assert.Nil(t, extract)
 		})
 	}
 }

--- a/schema/normalize.go
+++ b/schema/normalize.go
@@ -526,6 +526,35 @@ func atTimeZoneFromTimezoneCall(mode GeneratorMode, qualifier parser.Ident, func
 	return &parser.AtTimeZoneExpr{Expr: ts.Expr, Zone: zone.Expr}, true
 }
 
+func extractFromDatePartCall(mode GeneratorMode, qualifier parser.Ident, funcName string, exprs parser.SelectExprs) (*parser.ExtractExpr, bool) {
+	if mode != GeneratorModePostgres || funcName != "date_part" || len(exprs) != 2 {
+		return nil, false
+	}
+	if !isPostgresCatalogQualifier(qualifier) {
+		return nil, false
+	}
+	fieldArg, fieldOK := exprs[0].(*parser.AliasedExpr)
+	sourceArg, sourceOK := exprs[1].(*parser.AliasedExpr)
+	if !fieldOK || !sourceOK {
+		return nil, false
+	}
+	field, ok := fieldArg.Expr.(*parser.SQLVal)
+	if !ok || field.Type != parser.StrVal {
+		return nil, false
+	}
+	return &parser.ExtractExpr{Field: strings.ToLower(field.Val), Source: sourceArg.Expr}, true
+}
+
+func isPostgresCatalogQualifier(qualifier parser.Ident) bool {
+	if qualifier.IsEmpty() {
+		return true
+	}
+	if qualifier.Quoted {
+		return qualifier.Name == "pg_catalog"
+	}
+	return strings.EqualFold(qualifier.Name, "pg_catalog")
+}
+
 // stripFuncResultTextCasts removes text/character varying casts applied to
 // function call results, e.g. current_setting(...)::text -> current_setting(...).
 // PostgreSQL drops such casts when they are no-ops while storing policy
@@ -611,8 +640,15 @@ func stripFuncResultTextCasts(expr parser.Expr) parser.Expr {
 // normalizeExpr normalizes an expression.
 // This is similar to normalizeCheckExpr but tailored for other contexts.
 func normalizeExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
+	return normalizeExprWithCapabilities(expr, mode, false)
+}
+
+func normalizeExprWithCapabilities(expr parser.Expr, mode GeneratorMode, postgresExtractDatePartEquivalent bool) parser.Expr {
 	if expr == nil {
 		return nil
+	}
+	recur := func(expr parser.Expr) parser.Expr {
+		return normalizeExprWithCapabilities(expr, mode, postgresExtractDatePartEquivalent)
 	}
 
 	switch e := expr.(type) {
@@ -635,7 +671,7 @@ func normalizeExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 		}
 	case *parser.ArrayConstructor:
 		elements := util.TransformSlice(e.Elements, func(elem parser.Expr) parser.Expr {
-			return normalizeExpr(elem, mode)
+			return recur(elem)
 		})
 		return &parser.ArrayConstructor{Elements: elements}
 	case *parser.FuncExpr:
@@ -664,7 +700,7 @@ func normalizeExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 						// Expand ARRAY elements into separate normalized arguments
 						for _, elem := range arrayConstr.Elements {
 							normalizedExprs = append(normalizedExprs, &parser.AliasedExpr{
-								Expr: normalizeExpr(elem, mode),
+								Expr: recur(elem),
 							})
 						}
 						continue
@@ -673,11 +709,16 @@ func normalizeExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 			}
 
 			// Not an ARRAY, normalize normally
-			normalized := normalizeSelectExpr(arg, mode)
+			normalized := normalizeSelectExprWithCapabilities(arg, mode, postgresExtractDatePartEquivalent)
 			normalizedExprs = append(normalizedExprs, normalized)
 		}
 		if atz, ok := atTimeZoneFromTimezoneCall(mode, e.Qualifier, funcName, normalizedExprs); ok {
 			return atz
+		}
+		if postgresExtractDatePartEquivalent {
+			if extract, ok := extractFromDatePartCall(mode, e.Qualifier, funcName, normalizedExprs); ok {
+				return extract
+			}
 		}
 		// Normalize function name to lowercase for PostgreSQL (PostgreSQL stores functions in lowercase)
 		// For MySQL, preserve the original case as MySQL preserves case for function names
@@ -686,14 +727,20 @@ func normalizeExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 			normalizedName = parser.NewIdent(funcName, e.Name.Quoted)
 		}
 		return &parser.FuncExpr{
-			Qualifier: e.Qualifier,
-			Name:      normalizedName,
-			Distinct:  e.Distinct,
-			Exprs:     normalizedExprs,
-			Over:      e.Over,
+			Qualifier:   e.Qualifier,
+			Name:        normalizedName,
+			Distinct:    e.Distinct,
+			Exprs:       normalizedExprs,
+			WithinGroup: normalizeOrderBy(e.WithinGroup, mode, postgresExtractDatePartEquivalent),
+			Over:        normalizeOver(e.Over, mode, postgresExtractDatePartEquivalent),
+		}
+	case *parser.ExtractExpr:
+		return &parser.ExtractExpr{
+			Field:  strings.ToLower(e.Field),
+			Source: recur(e.Source),
 		}
 	case *parser.CastExpr:
-		normalizedExpr := normalizeExpr(e.Expr, mode)
+		normalizedExpr := recur(e.Expr)
 		// For PostgreSQL, unwrap unnecessary parentheses around simple expressions in casts
 		// PostgreSQL adds parentheses like (amount)::numeric, but we want to normalize to amount::numeric
 		if mode == GeneratorModePostgres {
@@ -819,7 +866,7 @@ func normalizeExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 			Type: normalizedType,
 		}
 	case *parser.ParenExpr:
-		normalizedInner := normalizeExpr(e.Expr, mode)
+		normalizedInner := recur(e.Expr)
 		// For PostgreSQL and MySQL, unwrap parentheses around most expressions to normalize
 		// Both databases add parentheses around many expressions, but we want a canonical form
 		// We always unwrap ParenExpr during normalization to get a canonical form
@@ -840,30 +887,32 @@ func normalizeExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 			Expr: normalizedInner,
 		}
 	case *parser.ComparisonExpr:
-		return normalizeComparisonExpr(e, mode, normalizeExpr, true)
+		return normalizeComparisonExpr(e, mode, func(expr parser.Expr, _ GeneratorMode) parser.Expr {
+			return recur(expr)
+		}, true)
 	case *parser.AndExpr:
 		return &parser.AndExpr{
-			Left:  normalizeExpr(e.Left, mode),
-			Right: normalizeExpr(e.Right, mode),
+			Left:  recur(e.Left),
+			Right: recur(e.Right),
 		}
 	case *parser.OrExpr:
 		return &parser.OrExpr{
-			Left:  normalizeExpr(e.Left, mode),
-			Right: normalizeExpr(e.Right, mode),
+			Left:  recur(e.Left),
+			Right: recur(e.Right),
 		}
 	case *parser.ConcatExpr:
 		return &parser.ConcatExpr{
-			Left:  normalizeExpr(e.Left, mode),
-			Right: normalizeExpr(e.Right, mode),
+			Left:  recur(e.Left),
+			Right: recur(e.Right),
 		}
 	case *parser.BinaryExpr:
 		return &parser.BinaryExpr{
 			Operator: e.Operator,
-			Left:     normalizeExpr(e.Left, mode),
-			Right:    normalizeExpr(e.Right, mode),
+			Left:     recur(e.Left),
+			Right:    recur(e.Right),
 		}
 	case *parser.UnaryExpr:
-		normalized := normalizeExpr(e.Expr, mode)
+		normalized := recur(e.Expr)
 
 		// Collapse UnaryExpr with minus/plus on numeric literals to SQLVal
 		// This ensures "-20" and "- 20" (unary minus on 20) are treated the same
@@ -904,7 +953,7 @@ func normalizeExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 	case *parser.IsExpr:
 		return &parser.IsExpr{
 			Operator: e.Operator,
-			Expr:     normalizeExpr(e.Expr, mode),
+			Expr:     recur(e.Expr),
 		}
 	case *parser.Subquery:
 		// Recurse into subquery SELECT so that nested FROM clauses receive the
@@ -913,43 +962,43 @@ func normalizeExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 		// everywhere including subquery FROM clauses, but user-written DDL
 		// rarely does, causing spurious view re-creations on every diff).
 		return &parser.Subquery{
-			Select: normalizeViewDefinition(e.Select, mode, nil),
+			Select: normalizeViewDefinition(e.Select, mode, nil, postgresExtractDatePartEquivalent),
 		}
 	case *parser.ConvertExpr:
 		// Normalize CAST(expr AS type) to expr::type (CastExpr) for consistency
 		// PostgreSQL represents both forms identically in its internal representation
 		if mode == GeneratorModePostgres && e.Action == parser.CastStr {
-			return normalizeExpr(&parser.CastExpr{
+			return recur(&parser.CastExpr{
 				Expr: e.Expr,
 				Type: e.Type,
-			}, mode)
+			})
 		}
 		return &parser.ConvertExpr{
 			Action: e.Action,
-			Expr:   normalizeExpr(e.Expr, mode),
+			Expr:   recur(e.Expr),
 			Type:   e.Type,
 			Style:  e.Style,
 		}
 	case *parser.CollateExpr:
 		return &parser.CollateExpr{
-			Expr:    normalizeExpr(e.Expr, mode),
+			Expr:    recur(e.Expr),
 			Charset: strings.ToLower(e.Charset),
 		}
 	case *parser.AtTimeZoneExpr:
 		// Recurse so the ::text cast PostgreSQL adds to the zone is stripped.
 		return &parser.AtTimeZoneExpr{
-			Expr: normalizeExpr(e.Expr, mode),
-			Zone: normalizeExpr(e.Zone, mode),
+			Expr: recur(e.Expr),
+			Zone: recur(e.Zone),
 		}
 	case *parser.CaseExpr:
 		normalizedWhens := make([]*parser.When, len(e.Whens))
 		for i, when := range e.Whens {
 			normalizedWhens[i] = &parser.When{
-				Cond: normalizeExpr(when.Cond, mode),
-				Val:  normalizeExpr(when.Val, mode),
+				Cond: recur(when.Cond),
+				Val:  recur(when.Val),
 			}
 		}
-		normalizedElse := normalizeExpr(e.Else, mode)
+		normalizedElse := recur(e.Else)
 		// PostgreSQL adds ELSE NULL to CASE expressions, normalize it away
 		if _, ok := normalizedElse.(*parser.NullVal); ok {
 			normalizedElse = nil
@@ -961,7 +1010,7 @@ func normalizeExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 			}
 		}
 		return &parser.CaseExpr{
-			Expr:  normalizeExpr(e.Expr, mode),
+			Expr:  recur(e.Expr),
 			Whens: normalizedWhens,
 			Else:  normalizedElse,
 		}
@@ -978,12 +1027,12 @@ func normalizeExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 			switch normalizedType {
 			case "integer", "bigint", "smallint", "decimal", "real", "double precision", "boolean",
 				"money", "smallmoney":
-				return normalizeExpr(&parser.CastExpr{
+				return recur(&parser.CastExpr{
 					Expr: e.Value,
 					Type: &parser.ConvertType{Type: normalizedType},
-				}, mode)
+				})
 			}
-			return normalizeExpr(e.Value, mode)
+			return recur(e.Value)
 		}
 		return expr
 	case *parser.IntervalExpr:
@@ -1012,16 +1061,20 @@ func normalizeExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 }
 
 // normalizeSelectExprs normalizes SELECT expressions for comparison
-func normalizeSelectExprs(exprs parser.SelectExprs, mode GeneratorMode) parser.SelectExprs {
+func normalizeSelectExprs(exprs parser.SelectExprs, mode GeneratorMode, postgresExtractDatePartEquivalent bool) parser.SelectExprs {
 	normalized := make(parser.SelectExprs, len(exprs))
 	for i, expr := range exprs {
-		normalized[i] = normalizeSelectExpr(expr, mode)
+		normalized[i] = normalizeSelectExprWithCapabilities(expr, mode, postgresExtractDatePartEquivalent)
 	}
 	return normalized
 }
 
 // normalizeSelectExpr normalizes a single SELECT expression for views
 func normalizeSelectExpr(expr parser.SelectExpr, mode GeneratorMode) parser.SelectExpr {
+	return normalizeSelectExprWithCapabilities(expr, mode, false)
+}
+
+func normalizeSelectExprWithCapabilities(expr parser.SelectExpr, mode GeneratorMode, postgresExtractDatePartEquivalent bool) parser.SelectExpr {
 	switch e := expr.(type) {
 	case *parser.AliasedExpr:
 		as := e.As
@@ -1040,7 +1093,7 @@ func normalizeSelectExpr(expr parser.SelectExpr, mode GeneratorMode) parser.Sele
 			}
 		}
 		return &parser.AliasedExpr{
-			Expr: normalizeExpr(e.Expr, mode),
+			Expr: normalizeExprWithCapabilities(e.Expr, mode, postgresExtractDatePartEquivalent),
 			As:   as,
 		}
 	case *parser.StarExpr:
@@ -1051,16 +1104,16 @@ func normalizeSelectExpr(expr parser.SelectExpr, mode GeneratorMode) parser.Sele
 }
 
 // normalizeTableExprs normalizes FROM clause table expressions
-func normalizeTableExprs(exprs parser.TableExprs, mode GeneratorMode, tableLookup TableLookupFunc) parser.TableExprs {
+func normalizeTableExprs(exprs parser.TableExprs, mode GeneratorMode, tableLookup TableLookupFunc, postgresExtractDatePartEquivalent bool) parser.TableExprs {
 	normalized := make(parser.TableExprs, len(exprs))
 	for i, expr := range exprs {
-		normalized[i] = normalizeTableExpr(expr, mode, tableLookup)
+		normalized[i] = normalizeTableExpr(expr, mode, tableLookup, postgresExtractDatePartEquivalent)
 	}
 	return normalized
 }
 
 // normalizeTableExpr normalizes a single TableExpr
-func normalizeTableExpr(expr parser.TableExpr, mode GeneratorMode, tableLookup TableLookupFunc) parser.TableExpr {
+func normalizeTableExpr(expr parser.TableExpr, mode GeneratorMode, tableLookup TableLookupFunc, postgresExtractDatePartEquivalent bool) parser.TableExpr {
 	if expr == nil {
 		return nil
 	}
@@ -1080,7 +1133,7 @@ func normalizeTableExpr(expr parser.TableExpr, mode GeneratorMode, tableLookup T
 			}
 		case *parser.Subquery:
 			normalizedExpr = &parser.Subquery{
-				Select: normalizeViewDefinition(tableExpr.Select, mode, tableLookup),
+				Select: normalizeViewDefinition(tableExpr.Select, mode, tableLookup, postgresExtractDatePartEquivalent),
 			}
 		}
 		return &parser.AliasedTableExpr{
@@ -1093,22 +1146,22 @@ func normalizeTableExpr(expr parser.TableExpr, mode GeneratorMode, tableLookup T
 		}
 	case *parser.JoinTableExpr:
 		return &parser.JoinTableExpr{
-			LeftExpr:  normalizeTableExpr(e.LeftExpr, mode, tableLookup),
+			LeftExpr:  normalizeTableExpr(e.LeftExpr, mode, tableLookup, postgresExtractDatePartEquivalent),
 			Join:      e.Join,
-			RightExpr: normalizeTableExpr(e.RightExpr, mode, tableLookup),
-			Condition: normalizeJoinCondition(e.Condition, mode),
+			RightExpr: normalizeTableExpr(e.RightExpr, mode, tableLookup, postgresExtractDatePartEquivalent),
+			Condition: normalizeJoinCondition(e.Condition, mode, postgresExtractDatePartEquivalent),
 		}
 	case *parser.ParenTableExpr:
 		// PostgreSQL and MariaDB add parentheses around JOINs when storing views.
 		// Unwrap these to get a canonical form.
 		if (mode == GeneratorModePostgres || mode == GeneratorModeMysql) && len(e.Exprs) == 1 {
 			// Single expression in parentheses - unwrap it
-			return normalizeTableExpr(e.Exprs[0], mode, tableLookup)
+			return normalizeTableExpr(e.Exprs[0], mode, tableLookup, postgresExtractDatePartEquivalent)
 		}
 		// Multiple expressions - normalize but keep parens
 		normalized := make(parser.TableExprs, len(e.Exprs))
 		for i, expr := range e.Exprs {
-			normalized[i] = normalizeTableExpr(expr, mode, tableLookup)
+			normalized[i] = normalizeTableExpr(expr, mode, tableLookup, postgresExtractDatePartEquivalent)
 		}
 		return &parser.ParenTableExpr{Exprs: normalized}
 	default:
@@ -1117,13 +1170,13 @@ func normalizeTableExpr(expr parser.TableExpr, mode GeneratorMode, tableLookup T
 }
 
 // normalizeJoinCondition normalizes the JOIN ON/USING condition
-func normalizeJoinCondition(cond parser.JoinCondition, mode GeneratorMode) parser.JoinCondition {
+func normalizeJoinCondition(cond parser.JoinCondition, mode GeneratorMode, postgresExtractDatePartEquivalent bool) parser.JoinCondition {
 	if cond.On != nil {
 		// For PostgreSQL and MySQL, preserve table qualifiers in JOIN ON clauses
 		// They're needed for disambiguation (e.g., "u.id = o.user_id")
 		// We only normalize the expression structure (parentheses, etc.), not column qualifiers
 		return parser.JoinCondition{
-			On:    normalizeExprPreservingQualifiers(cond.On, mode),
+			On:    normalizeExprPreservingQualifiersWithCapabilities(cond.On, mode, postgresExtractDatePartEquivalent),
 			Using: cond.Using,
 		}
 	}
@@ -1133,6 +1186,10 @@ func normalizeJoinCondition(cond parser.JoinCondition, mode GeneratorMode) parse
 // normalizeExprPreservingQualifiers is like normalizeExpr but preserves table qualifiers in column references
 // This is used for JOIN ON clauses where qualifiers are semantically important
 func normalizeExprPreservingQualifiers(expr parser.Expr, mode GeneratorMode) parser.Expr {
+	return normalizeExprPreservingQualifiersWithCapabilities(expr, mode, false)
+}
+
+func normalizeExprPreservingQualifiersWithCapabilities(expr parser.Expr, mode GeneratorMode, postgresExtractDatePartEquivalent bool) parser.Expr {
 	if expr == nil {
 		return nil
 	}
@@ -1154,28 +1211,28 @@ func normalizeExprPreservingQualifiers(expr parser.Expr, mode GeneratorMode) par
 		}
 	case *parser.AndExpr:
 		return &parser.AndExpr{
-			Left:  normalizeExprPreservingQualifiers(e.Left, mode),
-			Right: normalizeExprPreservingQualifiers(e.Right, mode),
+			Left:  normalizeExprPreservingQualifiersWithCapabilities(e.Left, mode, postgresExtractDatePartEquivalent),
+			Right: normalizeExprPreservingQualifiersWithCapabilities(e.Right, mode, postgresExtractDatePartEquivalent),
 		}
 	case *parser.OrExpr:
 		return &parser.OrExpr{
-			Left:  normalizeExprPreservingQualifiers(e.Left, mode),
-			Right: normalizeExprPreservingQualifiers(e.Right, mode),
+			Left:  normalizeExprPreservingQualifiersWithCapabilities(e.Left, mode, postgresExtractDatePartEquivalent),
+			Right: normalizeExprPreservingQualifiersWithCapabilities(e.Right, mode, postgresExtractDatePartEquivalent),
 		}
 	case *parser.ConcatExpr:
 		return &parser.ConcatExpr{
-			Left:  normalizeExprPreservingQualifiers(e.Left, mode),
-			Right: normalizeExprPreservingQualifiers(e.Right, mode),
+			Left:  normalizeExprPreservingQualifiersWithCapabilities(e.Left, mode, postgresExtractDatePartEquivalent),
+			Right: normalizeExprPreservingQualifiersWithCapabilities(e.Right, mode, postgresExtractDatePartEquivalent),
 		}
 	case *parser.ComparisonExpr:
 		return &parser.ComparisonExpr{
 			Operator: normalizeOperator(e.Operator, mode),
-			Left:     normalizeExprPreservingQualifiers(e.Left, mode),
-			Right:    normalizeExprPreservingQualifiers(e.Right, mode),
-			Escape:   normalizeExprPreservingQualifiers(e.Escape, mode),
+			Left:     normalizeExprPreservingQualifiersWithCapabilities(e.Left, mode, postgresExtractDatePartEquivalent),
+			Right:    normalizeExprPreservingQualifiersWithCapabilities(e.Right, mode, postgresExtractDatePartEquivalent),
+			Escape:   normalizeExprPreservingQualifiersWithCapabilities(e.Escape, mode, postgresExtractDatePartEquivalent),
 		}
 	case *parser.ParenExpr:
-		normalizedInner := normalizeExprPreservingQualifiers(e.Expr, mode)
+		normalizedInner := normalizeExprPreservingQualifiersWithCapabilities(e.Expr, mode, postgresExtractDatePartEquivalent)
 		// For PostgreSQL and MySQL, unwrap unnecessary parentheses
 		if mode == GeneratorModePostgres || mode == GeneratorModeMysql {
 			return normalizedInner
@@ -1183,44 +1240,60 @@ func normalizeExprPreservingQualifiers(expr parser.Expr, mode GeneratorMode) par
 		return &parser.ParenExpr{Expr: normalizedInner}
 	default:
 		// For other expressions, use the regular normalizeExpr
-		return normalizeExpr(expr, mode)
+		return normalizeExprWithCapabilities(expr, mode, postgresExtractDatePartEquivalent)
 	}
 }
 
 // normalizeWhere normalizes WHERE clause
-func normalizeWhere(where *parser.Where, mode GeneratorMode) *parser.Where {
+func normalizeWhere(where *parser.Where, mode GeneratorMode, postgresExtractDatePartEquivalent bool) *parser.Where {
 	if where == nil {
 		return nil
 	}
 	return &parser.Where{
 		Type: where.Type,
-		Expr: normalizeExpr(where.Expr, mode),
+		Expr: normalizeExprWithCapabilities(where.Expr, mode, postgresExtractDatePartEquivalent),
 	}
 }
 
 // normalizeGroupBy normalizes GROUP BY clause
-func normalizeGroupBy(groupBy parser.GroupBy, mode GeneratorMode) parser.GroupBy {
+func normalizeGroupBy(groupBy parser.GroupBy, mode GeneratorMode, postgresExtractDatePartEquivalent bool) parser.GroupBy {
 	normalized := make(parser.GroupBy, len(groupBy))
 	for i, expr := range groupBy {
-		normalized[i] = normalizeExpr(expr, mode)
+		normalized[i] = normalizeExprWithCapabilities(expr, mode, postgresExtractDatePartEquivalent)
 	}
 	return normalized
 }
 
 // normalizeOrderBy normalizes ORDER BY clause
-func normalizeOrderBy(orderBy parser.OrderBy, mode GeneratorMode) parser.OrderBy {
+func normalizeOrderBy(orderBy parser.OrderBy, mode GeneratorMode, postgresExtractDatePartEquivalent bool) parser.OrderBy {
 	normalized := make(parser.OrderBy, len(orderBy))
 	for i, order := range orderBy {
 		normalized[i] = &parser.Order{
-			Expr:      normalizeExpr(order.Expr, mode),
+			Expr:      normalizeExprWithCapabilities(order.Expr, mode, postgresExtractDatePartEquivalent),
 			Direction: order.Direction,
 		}
 	}
 	return normalized
 }
 
+func normalizeOver(over *parser.OverExpr, mode GeneratorMode, postgresExtractDatePartEquivalent bool) *parser.OverExpr {
+	if over == nil {
+		return nil
+	}
+	partitionBy := make(parser.PartitionBy, len(over.PartitionBy))
+	for i, partition := range over.PartitionBy {
+		partitionBy[i] = &parser.Partition{
+			Expr: normalizeExprWithCapabilities(partition.Expr, mode, postgresExtractDatePartEquivalent),
+		}
+	}
+	return &parser.OverExpr{
+		PartitionBy: partitionBy,
+		OrderBy:     normalizeOrderBy(over.OrderBy, mode, postgresExtractDatePartEquivalent),
+	}
+}
+
 // normalizeWith normalizes a WITH clause (Common Table Expressions) for comparison.
-func normalizeWith(with *parser.With, mode GeneratorMode) *parser.With {
+func normalizeWith(with *parser.With, mode GeneratorMode, postgresExtractDatePartEquivalent bool) *parser.With {
 	if with == nil {
 		return nil
 	}
@@ -1230,7 +1303,7 @@ func normalizeWith(with *parser.With, mode GeneratorMode) *parser.With {
 		normalizedCTEs[i] = &parser.CommonTableExpr{
 			Name:       cte.Name,
 			Columns:    cte.Columns,
-			Definition: normalizeViewDefinition(cte.Definition, mode, nil),
+			Definition: normalizeViewDefinition(cte.Definition, mode, nil, postgresExtractDatePartEquivalent),
 		}
 	}
 
@@ -1248,14 +1321,14 @@ type TableLookupFunc func(name QualifiedName) *Table
 // This function removes database-specific formatting differences that don't affect the logical meaning.
 // If tableLookup is provided, SELECT * expressions are expanded to explicit column names
 // (PostgreSQL expands * when storing view definitions).
-func normalizeViewDefinition(stmt parser.SelectStatement, mode GeneratorMode, tableLookup TableLookupFunc) parser.SelectStatement {
+func normalizeViewDefinition(stmt parser.SelectStatement, mode GeneratorMode, tableLookup TableLookupFunc, postgresExtractDatePartEquivalent bool) parser.SelectStatement {
 	if stmt == nil {
 		return nil
 	}
 
 	switch s := stmt.(type) {
 	case *parser.Select:
-		normalizedFrom := normalizeTableExprs(s.From, mode, tableLookup)
+		normalizedFrom := normalizeTableExprs(s.From, mode, tableLookup, postgresExtractDatePartEquivalent)
 		selectExprs := s.SelectExprs
 		// Expand SELECT * if we have table lookup capability
 		if tableLookup != nil && hasStarExpr(selectExprs) {
@@ -1272,28 +1345,28 @@ func normalizeViewDefinition(stmt parser.SelectStatement, mode GeneratorMode, ta
 			Comments:    nil, // Remove comments for view comparison - they don't affect semantic meaning
 			Distinct:    s.Distinct,
 			Hints:       s.Hints,
-			SelectExprs: normalizeSelectExprs(selectExprs, mode),
+			SelectExprs: normalizeSelectExprs(selectExprs, mode, postgresExtractDatePartEquivalent),
 			From:        normalizedFrom,
-			Where:       normalizeWhere(s.Where, mode),
-			GroupBy:     normalizeGroupBy(s.GroupBy, mode),
-			Having:      normalizeWhere(s.Having, mode),
-			OrderBy:     normalizeOrderBy(s.OrderBy, mode),
+			Where:       normalizeWhere(s.Where, mode, postgresExtractDatePartEquivalent),
+			GroupBy:     normalizeGroupBy(s.GroupBy, mode, postgresExtractDatePartEquivalent),
+			Having:      normalizeWhere(s.Having, mode, postgresExtractDatePartEquivalent),
+			OrderBy:     normalizeOrderBy(s.OrderBy, mode, postgresExtractDatePartEquivalent),
 			Limit:       s.Limit,
 			Lock:        s.Lock,
-			With:        normalizeWith(s.With, mode),
+			With:        normalizeWith(s.With, mode, postgresExtractDatePartEquivalent),
 		}
 	case *parser.Union:
 		return &parser.Union{
 			Type:    s.Type,
-			Left:    normalizeViewDefinition(s.Left, mode, tableLookup),
-			Right:   normalizeViewDefinition(s.Right, mode, tableLookup),
-			OrderBy: normalizeOrderBy(s.OrderBy, mode),
+			Left:    normalizeViewDefinition(s.Left, mode, tableLookup, postgresExtractDatePartEquivalent),
+			Right:   normalizeViewDefinition(s.Right, mode, tableLookup, postgresExtractDatePartEquivalent),
+			OrderBy: normalizeOrderBy(s.OrderBy, mode, postgresExtractDatePartEquivalent),
 			Limit:   s.Limit,
 			Lock:    s.Lock,
-			With:    normalizeWith(s.With, mode),
+			With:    normalizeWith(s.With, mode, postgresExtractDatePartEquivalent),
 		}
 	case *parser.ParenSelect:
-		normalized := normalizeViewDefinition(s.Select, mode, tableLookup)
+		normalized := normalizeViewDefinition(s.Select, mode, tableLookup, postgresExtractDatePartEquivalent)
 		if inner, ok := normalized.(*parser.Select); ok && len(inner.OrderBy) == 0 && inner.Limit == nil && inner.Lock == "" && inner.With == nil {
 			return inner
 		}


### PR DESCRIPTION
## What

psqldef compares `EXTRACT` and `date_part` according to the PostgreSQL server version.

- PostgreSQL 13 and earlier normalize built-in `date_part` calls to `EXTRACT` across the VIEW AST, including window expressions and `WITHIN GROUP`.
- PostgreSQL 14 and later preserve the type-sensitive distinction between `EXTRACT` and `date_part`.
- VIEW and MATERIALIZED VIEW export preserves the definition rendered by PostgreSQL.

## Motivation

On PostgreSQL 13 and earlier, exported VIEW definitions can render `EXTRACT` as `date_part`. Comparing the two forms literally recreates an unchanged VIEW. On PostgreSQL 14 and later, an unconditional conversion in the exporter has the opposite problem: it treats expressions with different return types as equal and can hide a VIEW change.

psqldef derives the comparison rule from `server_version_num` and applies it during AST normalization. PostgreSQL 13 and earlier canonicalize only built-in `date_part` calls, including nested and schema-qualified forms. PostgreSQL 14 and later keep `EXTRACT` and `date_part` distinct. The exporter retains PostgreSQL's rendered definition.

## Test

- `database/postgres/database_test.go`
  - Verify the exact `139999` / `140000` version boundary.
  - Verify conservative comparison when version lookup fails.
  - Verify that MATERIALIZED VIEW export preserves `date_part`.
- `schema/generator_test.go`
  - Verify built-in, case-folded, quoted, and other schema-qualified `date_part` forms.
  - Verify normalization in window expressions and `WITHIN GROUP`.
  - Verify generated VIEW DDL with equivalence enabled and disabled.
- `cmd/psqldef/tests_views.yml`
  - Verify zero VIEW DDL on PostgreSQL 13 and earlier.
  - Verify zero VIEW DDL for window and ordered-set aggregate expressions on PostgreSQL 13 and earlier.
  - Verify bidirectional VIEW recreation on PostgreSQL 14 and later.
